### PR TITLE
Reimplement entries loading with csv

### DIFF
--- a/gilda/app/__main__.py
+++ b/gilda/app/__main__.py
@@ -1,0 +1,15 @@
+import argparse
+from . import app
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Run the grounding app.')
+    parser.add_argument('--host', default='0.0.0.0')
+    parser.add_argument('--port', default=8001, type=int)
+    args = parser.parse_args()
+    app.run(host=args.host, port=args.port, threaded=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -1,4 +1,3 @@
-import argparse
 from flask import Flask, abort, Response, request, jsonify
 from gilda.grounder import Grounder
 from gilda.resources import get_grounding_terms
@@ -23,12 +22,3 @@ def ground():
                                reverse=True):
         res.append(scored_match.to_json())
     return jsonify(res)
-
-
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(
-        description='Run the grounding app.')
-    parser.add_argument('--host', default='0.0.0.0')
-    parser.add_argument('--port', default=8001, type=int)
-    args = parser.parse_args()
-    app.run(host=args.host, port=args.port, threaded=False)

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -1,4 +1,4 @@
-import pandas
+import csv
 import logging
 import itertools
 from adeft import available_shortforms as available_adeft_models
@@ -201,18 +201,16 @@ def load_terms_file(terms_file):
         A lookup dictionary whose keys are normalized entity texts, and values
         are lists of Terms with that normalized entity text.
     """
-    df = pandas.read_csv(terms_file, delimiter='\t', na_values=[''],
-                         keep_default_na=False)
-    entries = {}
-    for idx, row in df.iterrows():
-        # Replace pandas nans with Nones
-        row_nones = [r if not pandas.isna(r) else None for r in row]
-        entry = Term(*row_nones)
-        if row[0] in entries:
-            entries[row[0]].append(entry)
-        else:
-            entries[row[0]] = [entry]
-    return entries
+    with open(terms_file, 'r') as fh:
+        entries = {}
+        for row in csv.reader(fh, delimiter='\t'):
+            row_nones = [r if r else None for r in row]
+            entry = Term(*row_nones)
+            if row[0] in entries:
+                entries[row[0]].append(entry)
+            else:
+                entries[row[0]] = [entry]
+        return entries
 
 
 def load_adeft_models():


### PR DESCRIPTION
This PR changes the loading of entries to use csv instead of pandas to eliminate the dependency of the web app on pandas. It also makes loading the terms file (and thereby, starting the web app) around 20x faster.