### PR TITLE
Improve MeSH integration through mapping and redundancy resolution

### DIFF
--- a/benchmarks/find_ambiguities.py
+++ b/benchmarks/find_ambiguities.py
@@ -12,10 +12,6 @@ from indra.databases import mesh_client
 from indra.literature import pubmed_client
 from indra.literature.adeft_tools import universal_extract_text
 
-grounding_terms_file = os.path.join(os.path.dirname(__file__), os.pardir,
-                                    os.pardir, 'resources',
-                                    'grounding_terms.tsv')
-
 gr = Grounder(get_grounding_terms())
 
 

--- a/benchmarks/fplx_evaluation.py
+++ b/benchmarks/fplx_evaluation.py
@@ -122,18 +122,32 @@ def make_comparison(groundings):
 
     # Now iterate over all the old groundings, get the new one, and build up
     # the values in the comparison matrix
-    for grounding in groundings:
+    for idx, grounding in enumerate(groundings):
         old_eval = evaluate_old_grounding(grounding)
         # Send grounding requests
         res = requests.post('%s/ground' % service_url,
                             json={'text': grounding['text']}).json()
         if not res:
-            comparison['%s_ungrounded' % old_eval].append((grounding, None))
+            comparison['%s_ungrounded' % old_eval].append((idx, grounding, None))
             continue
         term = res[0]['term']
         new_eval = evaluate_new_grounding(grounding, term)
-        comparison['%s_%s' % (old_eval, new_eval)].append((grounding, term))
+        comparison['%s_%s' % (old_eval, new_eval)].append((idx, grounding, term))
     return comparison
+
+
+def get_comparison_delta(groundings, c1, c2):
+    def find_grounding(c, idx):
+        for k, v in c.items():
+            for entry in v:
+                if entry[0] == idx:
+                    return k, entry
+
+    for idx, grounding in enumerate(groundings):
+        c1g = find_grounding(c1, idx)
+        c2g = find_grounding(c2, idx)
+        if c1g[0] != c2g[0]:
+            print(c1g, c2g)
 
 
 # We now calculate various summary statistics and then print them

--- a/benchmarks/fplx_evaluation.py
+++ b/benchmarks/fplx_evaluation.py
@@ -9,8 +9,6 @@ service_url = 'http://localhost:8001'
 url = ('https://raw.githubusercontent.com/sorgerlab/famplex_paper/master/'
        'step4_stmt_entity_stats/test_agents_with_fplx_sample_curated.csv')
 
-df = pandas.read_csv(url)
-
 # Here we do some manual annotation to add expected correct groundings
 # for some entries that were incorrect or ungrounded in the reference.
 # This will allow us to compare more of the groundings to known correct
@@ -49,36 +47,38 @@ incorrect_assertions = {'IGF': {'HGNC': '5464'},
                         'ARs': {'HGNC': '10015'}}
 
 
-groundings = []
-# Iterate over the rows of the curation table and extract groundings
-for _, row in df.iterrows():
-    if pandas.isnull(row['Grounding']):
-        break
-    # Here we get the original entity text, its type, and the
-    # correct/incorrect curation
-    grounding = {
-        'text': row['Text'],
-        'entity_type': row['EntityType'],
-        'db_refs': {},
-        'correct': bool(int(row['Grounding']))
-        }
-    # We then extract the grounding (up to 3) that were considered
-    # for the curation
-    for i in [1, 2, 3]:
-        if not pandas.isnull(row['DB_Ns%d' % i]):
-            grounding['db_refs'][row['DB_Ns%d' % i]] = row['DB_Id%d' % i]
-    # We standardize some of the grounding entries to match up with
-    # Gilda's format
-    for k, v in copy.deepcopy(grounding['db_refs']).items():
-        # Strip off extra GO prefixes
-        if v.startswith('GO:GO'):
-            grounding['db_refs'][k] = v[3:]
-        # Get CHEBI IDs from PUBCHEM
-        if k == 'PUBCHEM':
-            chebi_id = chebi_client.get_chebi_id_from_pubchem(v)
-            if chebi_id:
-                grounding['db_refs']['CHEBI'] = 'CHEBI:%s' % chebi_id
-    groundings.append(grounding)
+def process_fxpl_groundings(df):
+    groundings = []
+    # Iterate over the rows of the curation table and extract groundings
+    for _, row in df.iterrows():
+        if pandas.isnull(row['Grounding']):
+            break
+        # Here we get the original entity text, its type, and the
+        # correct/incorrect curation
+        grounding = {
+            'text': row['Text'],
+            'entity_type': row['EntityType'],
+            'db_refs': {},
+            'correct': bool(int(row['Grounding']))
+            }
+        # We then extract the grounding (up to 3) that were considered
+        # for the curation
+        for i in [1, 2, 3]:
+            if not pandas.isnull(row['DB_Ns%d' % i]):
+                grounding['db_refs'][row['DB_Ns%d' % i]] = row['DB_Id%d' % i]
+        # We standardize some of the grounding entries to match up with
+        # Gilda's format
+        for k, v in copy.deepcopy(grounding['db_refs']).items():
+            # Strip off extra GO prefixes
+            if v.startswith('GO:GO'):
+                grounding['db_refs'][k] = v[3:]
+            # Get CHEBI IDs from PUBCHEM
+            if k == 'PUBCHEM':
+                chebi_id = chebi_client.get_chebi_id_from_pubchem(v)
+                if chebi_id:
+                    grounding['db_refs']['CHEBI'] = 'CHEBI:%s' % chebi_id
+        groundings.append(grounding)
+    return groundings
 
 
 def evaluate_old_grounding(grounding):
@@ -111,66 +111,73 @@ def evaluate_new_grounding(grounding, term):
     return 'unknown'
 
 
-# Generate an initial comparison matrix
-# This dict contains counts of all the possible relationships between
-# the reference grounding and the one produced by Gilda
-comparison = {'%s_%s' % (a, b): 0 for a, b in
-              itertools.product(['ungrounded', 'correct', 'incorrect'],
-                                ['ungrounded', 'unknown', 'correct',
-                                 'incorrect'])}
+def make_comparison(groundings):
+    # Generate an initial comparison matrix
+    # This dict contains counts of all the possible relationships between
+    # the reference grounding and the one produced by Gilda
+    comparison = {'%s_%s' % (a, b): [] for a, b in
+                  itertools.product(['ungrounded', 'correct', 'incorrect'],
+                                    ['ungrounded', 'unknown', 'correct',
+                                     'incorrect'])}
 
-# Now iterate over all the old groundings, get the new one, and build up
-# the values in the comparison matrix
-for grounding in groundings:
-    old_eval = evaluate_old_grounding(grounding)
-    # Send grounding requests
-    res = requests.post('%s/ground' % service_url,
-                        json={'text': grounding['text']}).json()
-    if not res:
-        comparison['%s_ungrounded' % old_eval] += 1
-        continue
-    term = res[0]['term']
-    new_eval = evaluate_new_grounding(grounding, term)
-    comparison['%s_%s' % (old_eval, new_eval)] += 1
+    # Now iterate over all the old groundings, get the new one, and build up
+    # the values in the comparison matrix
+    for grounding in groundings:
+        old_eval = evaluate_old_grounding(grounding)
+        # Send grounding requests
+        res = requests.post('%s/ground' % service_url,
+                            json={'text': grounding['text']}).json()
+        if not res:
+            comparison['%s_ungrounded' % old_eval].append((grounding, None))
+            continue
+        term = res[0]['term']
+        new_eval = evaluate_new_grounding(grounding, term)
+        comparison['%s_%s' % (old_eval, new_eval)].append((grounding, term))
+    return comparison
 
 
 # We now calculate various summary statistics and then print them
 def get_sum_start(d, s):
-    return sum([v for k, v in d.items() if k.startswith(s)])
+    return sum([len(v) for k, v in d.items() if k.startswith(s)])
 
 
 def get_sum_end(d, s):
-    return sum([v for k, v in d.items() if k.endswith(s)])
+    return sum([len(v) for k, v in d.items() if k.endswith(s)])
 
 
-old_correct = get_sum_start(comparison, 'correct')
-old_incorrect = get_sum_start(comparison, 'incorrect')
-old_ungrounded = get_sum_start(comparison, 'ungrounded')
-correct = get_sum_end(comparison, '_correct')
-incorrect = get_sum_end(comparison, '_incorrect')
-ungrounded = get_sum_end(comparison, '_ungrounded')
-unknown = get_sum_end(comparison, '_unknown')
+def print_statistics(comparison):
+    old_correct = get_sum_start(comparison, 'correct')
+    old_incorrect = get_sum_start(comparison, 'incorrect')
+    old_ungrounded = get_sum_start(comparison, 'ungrounded')
+    correct = get_sum_end(comparison, '_correct')
+    incorrect = get_sum_end(comparison, '_incorrect')
+    ungrounded = get_sum_end(comparison, '_ungrounded')
+    unknown = get_sum_end(comparison, '_unknown')
+
+    assert old_correct + old_incorrect + old_ungrounded == 300
+
+    prec = (correct / (correct + incorrect + unknown),
+            (correct + unknown) / (correct + incorrect + unknown))
+    recall = (correct / (correct + ungrounded),
+              (correct + unknown) / (correct + unknown + ungrounded))
+    fscore = (2 * prec[0] * recall[0] / (prec[0] + recall[0]),
+              2 * prec[1] * recall[1] / (prec[1] + recall[1]))
+
+    old_prec = old_correct / (old_correct + old_incorrect)
+    old_recall = old_correct / (old_correct + old_ungrounded)
+    old_fscore = 2 * old_prec * old_recall / (old_prec + old_recall)
+
+    print('The reference statistics were:')
+    print('- Precision: %.3f\n- Recall: %.3f\n- F-score: %.3f' %
+          (old_prec, old_recall, old_fscore))
+    print('The current statistics with Gilda are between:')
+    print('- Precision: (%.3f, %.3f)\n- Recall: (%.3f, %.3f)'
+          '\n- F-score: (%.3f, %.3f)' %
+          tuple(itertools.chain(prec, recall, fscore)))
 
 
-assert old_correct + old_incorrect + old_ungrounded == 300
-
-
-prec = (correct / (correct + incorrect + unknown),
-        (correct + unknown) / (correct + incorrect + unknown))
-recall = (correct / (correct + ungrounded),
-          (correct + unknown) / (correct + unknown + ungrounded))
-fscore = (2 * prec[0] * recall[0] / (prec[0] + recall[0]),
-          2 * prec[1] * recall[1] / (prec[1] + recall[1]))
-
-
-old_prec = old_correct / (old_correct + old_incorrect)
-old_recall = old_correct / (old_correct + old_ungrounded)
-old_fscore = 2 * old_prec * old_recall / (old_prec + old_recall)
-
-print('The reference statistics were:')
-print('- Precision: %.3f\n- Recall: %.3f\n- F-score: %.3f' %
-      (old_prec, old_recall, old_fscore))
-print('The current statistics with Gilda are between:')
-print('- Precision: (%.3f, %.3f)\n- Recall: (%.3f, %.3f)'
-      '\n- F-score: (%.3f, %.3f)' %
-      tuple(itertools.chain(prec, recall, fscore)))
+if __name__ == '__main__':
+    df = pandas.read_csv(url)
+    groundings = process_fxpl_groundings(df)
+    comparison = make_comparison(groundings)
+    print_statistics(comparison)

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -146,7 +146,7 @@ def generate_mesh_terms():
     terms = []
     for idx, row in df.iterrows():
         db_id = row[0]
-        name = row[1]
+        text_name = row[1]
         mapping = mesh_mappings.get(db_id)
         if mapping:
             db, db_id = mapping
@@ -158,7 +158,9 @@ def generate_mesh_terms():
         else:
             db = 'MESH'
             status = 'name'
-        term = Term(normalize(name), name, db, db_id, name, status, 'mesh')
+            name = text_name
+        term = Term(normalize(text_name), text_name, db, db_id, name, status,
+                    'mesh')
         terms.append(term)
         synonyms = row[2]
         if row[2]:

--- a/scripts/generate_mesh_mappings.py
+++ b/scripts/generate_mesh_mappings.py
@@ -1,3 +1,4 @@
+import os
 from gilda.grounder import Grounder
 from gilda.resources import get_grounding_terms
 from indra.databases import mesh_client, hgnc_client
@@ -6,6 +7,8 @@ gr = Grounder(get_grounding_terms())
 
 mesh_protein = 'D000602'
 mesh_enzyme = 'D045762'
+resources = os.path.join(os.path.dirname(__file__), os.path.pardir,
+                         'gilda', 'resources')
 
 
 def dump_mappings(mappings, fname):
@@ -32,6 +35,7 @@ def get_mesh_mappings(ambigs):
         me = mesh_entries[0]
         if (mesh_client.mesh_isa(me.id, mesh_protein) or
                 mesh_client.mesh_isa(me.id, mesh_enzyme)):
+            print('Considering %s' % me.id)
             if len(fplx_entries) == 1:
                 key = (me.id, 'FPLX', fplx_entries[0].id)
                 predicted_mappings[key] = (me, fplx_entries[0])
@@ -60,4 +64,4 @@ def find_ambiguities(gr):
 if __name__ == '__main__':
     ambigs = find_ambiguities(gr)
     mappings = get_mesh_mappings(ambigs)
-    dump_mappings(mappings, 'mesh_mappings.tsv')
+    dump_mappings(mappings, os.path.join(resources, 'mesh_mappings.tsv'))

--- a/scripts/generate_mesh_mappings.py
+++ b/scripts/generate_mesh_mappings.py
@@ -1,0 +1,52 @@
+from gilda.grounder import Grounder
+from gilda.resources import get_grounding_terms
+from indra.databases import mesh_client
+
+gr = Grounder(get_grounding_terms())
+
+mesh_protein = 'D000602'
+mesh_enzyme = 'D045762'
+
+
+def dump_mappings(mappings, fname):
+    with open(fname, 'w') as fh:
+        for me, he in mappings:
+            fh.write('\t'.join(['MESH', me.id, 'HGNC', he.id]) + '\n')
+
+
+def get_mesh_hgnc_mappings(ambigs):
+    predicted_mappings = []
+    for _, ambig in ambigs.items():
+        hgnc_entries = [a for a in ambig if a.db == 'HGNC']
+        mesh_entries = [a for a in ambig if a.db == 'MESH']
+        if len(hgnc_entries) != 1 or len(mesh_entries) != 1:
+            continue
+        he = hgnc_entries[0]
+        me = mesh_entries[0]
+
+        if mesh_client.mesh_isa(me.id, mesh_protein) or \
+                mesh_client.mesh_isa(me.id, mesh_enzyme):
+            predicted_mappings.append((me, he))
+    return predicted_mappings
+
+
+def find_ambiguities(gr):
+    ambig_entries = {}
+    for terms in gr.entries.values():
+        for term in terms:
+            # We consider it an ambiguity if the same text entry appears
+            # multiple times
+            key = term.text
+            if key in ambig_entries:
+                ambig_entries[key].append(term)
+            else:
+                ambig_entries[key] = [term]
+    # It's only an ambiguity if there are two entries at least
+    ambig_entries = {k: v for k, v in ambig_entries.items() if len(v) >= 2}
+    return ambig_entries
+
+
+if __name__ == '__main__':
+    ambigs = find_ambiguities(gr)
+    mappings = get_mesh_hgnc_mappings(ambigs)
+    dump_mappings(mappings, 'mesh_mappings.tsv')


### PR DESCRIPTION
This PR adds a script that can "predict" MeSH equivalences with FPLX and HGNC by analyzing shared lexicalizations. These entries are then integrated via their FPLX or HGNC IDs, and only if the synonym coming from MeSH is not available from the original source itself. This works reliably for these entities, though it is not clear if the same approach could be applied across MeSH and ChEBI. The PR also refactors the FPLX benchmark script.