### PR TITLE
Integrate learned disambiguation models

### DIFF
--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -245,4 +245,5 @@ def load_gilda_models():
     with open(get_gilda_models(), 'rb') as fh:
         models_raw = pickle.load(fh)
     models = {k: load_model_info(v['cl']) for k, v in models_raw.items()}
+    models = {k: v for k, v in models.items() if v.stats['f1']['mean'] > 0.7}
     return models

--- a/gilda/resources/__init__.py
+++ b/gilda/resources/__init__.py
@@ -17,21 +17,31 @@ if not os.path.isdir(resource_dir):
         logger.warning('%s already exists' % resource_dir)
 
 
-def download_grounding_terms(path, base_name):
-    logger.info('Downloading grounding terms from S3.')
+def _download_from_s3(path, base_name):
     config = botocore.client.Config(signature_version=botocore.UNSIGNED)
     s3 = boto3.client('s3', config=config)
     tc = boto3.s3.transfer.TransferConfig(use_threads=False)
     full_key = '%s/%s' % (__version__, base_name)
     out_file = os.path.join(path, base_name)
     s3.download_file('gilda', full_key, out_file, Config=tc)
-    logger.info('Saved grounding terms into: %s' % out_file)
+    return out_file
 
 
 def get_grounding_terms():
     base_name = 'grounding_terms.tsv'
     full_path = os.path.join(resource_dir, base_name)
     if not os.path.exists(full_path):
-        download_grounding_terms(resource_dir, base_name)
+        logger.info('Downloading grounding terms from S3.')
+        out_file = _download_from_s3(resource_dir, base_name)
+        logger.info('Saved grounding terms into: %s' % out_file)
     return full_path
 
+
+def get_gilda_models():
+    base_name = 'gilda_models.pkl'
+    full_path = os.path.join(resource_dir, base_name)
+    if not os.path.exists(full_path):
+        logger.info('Downloading disambiguation models from S3.')
+        out_file = _download_from_s3(resource_dir, base_name)
+        logger.info('Saved disambiguation models into: %s' % out_file)
+    return full_path

--- a/models/learn.py
+++ b/models/learn.py
@@ -68,9 +68,10 @@ def get_texts_for_term(key, pmids):
         if txt:
             texts.append(txt)
     print('Loaded %d texts for %s' % (len(texts), str(key)))
-    if texts and len(texts) < 5:
+    if texts and len(texts) <= 5:
         print('Splitting texts for %s' % str(key))
-        texts = split_texts(texts, 5)
+        texts = split_texts(texts, 6)
+        print('Now have %s texts for %s' % (len(texts), str(key)))
     return texts
 
 
@@ -184,12 +185,12 @@ if __name__ == '__main__':
                 print('Model is None, skipping')
             else:
                 models[model['ambig'][0].text] = model
-                if (count + 1) % 100 == 0:
-                    pickle_name = 'gilda_ambiguities_hgnc_mesh_%d.pkl' % pkl_idx
-                    with open(pickle_name, 'wb') as fh:
-                        pickle.dump(models, fh)
-                    pkl_idx += 1
-                    models = {}
+            if (count + 1) % 100 == 0:
+                pickle_name = 'gilda_ambiguities_hgnc_mesh_%d.pkl' % pkl_idx
+                with open(pickle_name, 'wb') as fh:
+                    pickle.dump(models, fh)
+                pkl_idx += 1
+                models = {}
         pool.close()
         pool.join()
 

--- a/models/learn.py
+++ b/models/learn.py
@@ -60,14 +60,14 @@ def get_all_pmids(ambigs):
     return all_pmids
 
 
-def get_texts_for_term(term_key, pmids):
-    labels = []
+def get_texts_for_term(key, pmids):
+    texts = []
     print('Loading %d PMIDs for %s' % (len(pmids), str(key)))
     for pmid in pmids:
         txt = get_text_content(pmid)
         if txt:
             texts.append(txt)
-    print('Loaded %d PMIDs for %s' % (len(labels), str(key)))
+    print('Loaded %d texts for %s' % (len(texts), str(key)))
     if len(texts) < 5:
         print('Splitting texts for %s' % str(key))
         texts = split_texts(texts, 5)

--- a/models/learn.py
+++ b/models/learn.py
@@ -60,23 +60,29 @@ def get_all_pmids(ambigs):
     return all_pmids
 
 
+def get_texts_for_term(term_key, pmids):
+    labels = []
+    print('Loading %d PMIDs for %s' % (len(pmids), str(key)))
+    for pmid in pmids:
+        txt = get_text_content(pmid)
+        if txt:
+            texts.append(txt)
+    print('Loaded %d PMIDs for %s' % (len(labels), str(key)))
+    if len(texts) < 5:
+        print('Splitting texts for %s' % str(key))
+        texts = split_texts(texts, 5)
+    return texts
+
+
 def get_papers(ambig_terms, term_pmids=None):
     if not term_pmids:
         term_pmids = get_pmids(ambig_terms)
     texts = []
     labels = []
     for key, pmids in term_pmids.items():
-        print('Loading %d PMIDs for %s' % (len(pmids), str(key)))
-        for pmid in pmids:
-            txt = get_text_content(pmid)
-            if txt:
-                texts.append(txt)
-                labels.append('%s:%s' % key)
-        print('Loaded %d PMIDs for %s' % (len(labels), str(key)))
-        if len(texts) < 5:
-            print('Splitting texts for %s' % str(key))
-            texts = split_texts(texts, 5)
-            labels = [key for _ in texts]
+        texts1 = get_texts_for_term(key, pmids)
+        texts += texts1
+        labels += ['%s:%s' % key for _ in texts1]
     return texts, labels
 
 

--- a/models/learn.py
+++ b/models/learn.py
@@ -68,7 +68,7 @@ def get_texts_for_term(key, pmids):
         if txt:
             texts.append(txt)
     print('Loaded %d texts for %s' % (len(texts), str(key)))
-    if len(texts) < 5:
+    if texts and len(texts) < 5:
         print('Splitting texts for %s' % str(key))
         texts = split_texts(texts, 5)
     return texts

--- a/models/learn.py
+++ b/models/learn.py
@@ -169,6 +169,8 @@ if __name__ == '__main__':
         for count, model in enumerate(pool.imap_unordered(fun,
                                                           all_ambigs_pmids,
                                                           chunksize=10)):
+            models[model['ambig'][0].text] = model
+            print('#### %d ####' % count)
             if (count + 1) % 100 == 0:
                 pickle_name = 'gilda_ambiguities_hgnc_mesh_%d.pkl' % pkl_idx
                 with open(pickle_name, 'wb') as fh:

--- a/models/learn.py
+++ b/models/learn.py
@@ -107,9 +107,13 @@ def learn_model(ambig_terms_pmids, params):
     terms_str = '\n> ' + '\n> '.join(str(t) for t in ambig_terms)
     print('Learning model for: %s\n=======' % terms_str)
     texts, labels = get_papers(ambig_terms, term_pmids)
+    if len(set(labels)) < 2:
+        print('Could not get enough labels for more than one class, skipping.')
+        return None
+
     label_counts = Counter(labels)
     if any([v <= 5 for v in label_counts.values()]):
-        print('Could not get enough labels for at least one entry, skipping')
+        print('Could not get enough labels for at least one entry, skipping.')
         return None
     cl = AdeftClassifier([ambig_terms[0].text], list(set(labels)))
     cl.cv(texts, labels, params, cv=5)

--- a/models/learn.py
+++ b/models/learn.py
@@ -73,7 +73,19 @@ def get_papers(ambig_terms, term_pmids=None):
                 texts.append(txt)
                 labels.append('%s:%s' % key)
         print('Loaded %d PMIDs for %s' % (len(labels), str(key)))
+        if len(texts) < 5:
+            print('Splitting texts for %s' % str(key))
+            texts = split_texts(texts, 5)
+            labels = [key for _ in texts]
     return texts, labels
+
+
+def split_texts(texts, nmin):
+    while len(texts) < nmin:
+        texts = sorted(texts, key=lambda x: len(x), reverse=True)
+        texts = [texts[0][:int(len(texts[0])/2)],
+                 texts[0][int(len(texts[0])/2)+1:]] + texts[1:]
+    return texts
 
 
 def rank_ambiguities(ambigs, str_counts):

--- a/models/learn.py
+++ b/models/learn.py
@@ -1,3 +1,4 @@
+import os
 import json
 import time
 import pickle
@@ -82,8 +83,7 @@ def rank_ambiguities(ambigs, str_counts):
 
 
 def learn_model(ambig_terms_pmids, params):
-    ambig_terms = [a, _ for a, p in ambig_terms_pmids]
-    term_pmids = [_, p for a, p in ambig_terms_pmids]
+    ambig_terms, term_pmids = ambig_terms_pmids
 
     print()
     terms_str = '\n> ' + '\n> '.join(str(t) for t in ambig_terms)

--- a/models/learn.py
+++ b/models/learn.py
@@ -175,14 +175,17 @@ if __name__ == '__main__':
         for count, model in enumerate(pool.imap_unordered(fun,
                                                           all_ambigs_pmids,
                                                           chunksize=10)):
-            models[model['ambig'][0].text] = model
             print('#### %d ####' % count)
-            if (count + 1) % 100 == 0:
-                pickle_name = 'gilda_ambiguities_hgnc_mesh_%d.pkl' % pkl_idx
-                with open(pickle_name, 'wb') as fh:
-                    pickle.dump(models, fh)
-                pkl_idx += 1
-                models = {}
+            if model is None:
+                print('Model is None, skipping')
+            else:
+                models[model['ambig'][0].text] = model
+                if (count + 1) % 100 == 0:
+                    pickle_name = 'gilda_ambiguities_hgnc_mesh_%d.pkl' % pkl_idx
+                    with open(pickle_name, 'wb') as fh:
+                        pickle.dump(models, fh)
+                    pkl_idx += 1
+                    models = {}
         pool.close()
         pool.join()
 

--- a/models/learn.py
+++ b/models/learn.py
@@ -84,7 +84,7 @@ def split_texts(texts, nmin):
     while len(texts) < nmin:
         texts = sorted(texts, key=lambda x: len(x), reverse=True)
         texts = [texts[0][:int(len(texts[0])/2)],
-                 texts[0][int(len(texts[0])/2)+1:]] + texts[1:]
+                 texts[0][int(len(texts[0])/2):]] + texts[1:]
     return texts
 
 

--- a/models/learn.py
+++ b/models/learn.py
@@ -119,7 +119,8 @@ def learn_model(ambig_terms_pmids, params):
     cl = AdeftClassifier([ambig_terms[0].text], list(set(labels)))
     cl.cv(texts, labels, params, cv=5)
     print(cl.stats)
-    return {'cl': cl, 'ambig': ambig_terms}
+    cl_model_info = cl.get_model_info()
+    return {'cl': cl_model_info, 'ambig': ambig_terms}
 
 
 def learn_batch(ambig_terms_batch):

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(name='gilda',
           'Programming Language :: Python :: 3.7'
       ],
       packages=find_packages(),
-      install_requires=['regex', 'adeft', 'boto3', 'flask'],
+      install_requires=['regex', 'adeft>=0.4.0', 'boto3', 'flask'],
       extras_require={'test': ['nose', 'coverage'],
                       'terms': ['indra']},
       keywords=['nlp', 'biology']


### PR DESCRIPTION
This PR updates the script to learn ~1.3k disambiguation models, and integrates the models themselves into the grounding process. With a cutoff to keep only high accuracy models, ~1k are loaded for actual grounding.