### PR TITLE
Add disambiguation meta-information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
 install:
   - pip install .[test]
   - pip install indra
+  - python -m adeft.download
 script:
   - nosetests gilda -v --with-coverage --cover-inclusive --cover-package=gilda
 after_success:

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -22,3 +22,9 @@ def ground():
                                reverse=True):
         res.append(scored_match.to_json())
     return jsonify(res)
+
+
+@app.route('/models', methods=['GET', 'POST'])
+def models():
+    models = sorted(list(grounder.gilda_disambiguators.keys()))
+    return jsonify(models)

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -136,11 +136,19 @@ class Grounder(object):
                     continue
                 db, id = grounding.split(':', maxsplit=1)
                 if match.term.db == db and match.term.id == id:
+                    match.disambiguation = {'type': 'adeft',
+                                            'score': score,
+                                            'match': 'grounded'}
                     match.multiply(score)
+                    match.disambiguation = score
                     has_adeft_grounding = True
                     break
             if not has_adeft_grounding:
+                match.disambiguation = {'type': adeft,
+                                        'score': ungrounded_score,
+                                        'match': 'ungrounded'}
                 match.multiply(ungrounded_score)
+                match.disambiguation = ungrounded_score
         return scored_matches
 
     def disambiguate_gilda(self, raw_str, scored_matches, context):
@@ -150,7 +158,13 @@ class Grounder(object):
         grounding_dict = res[0]
         for match in scored_matches:
             key = '%s:%s' % (match.term.db, match.term.id)
-            score = grounding_dict.get(key, 0.0)
+            score_entry = grounding_dict.get(key, None)
+            score = score_entry if score_entry is not None else 0.0
+            match.disambiguation = {'type': 'gilda',
+                                    'score': score,
+                                    'match': ('grounded'
+                                              if score_entry is not None
+                                              else 'ungrounded')}
             match.multiply(score)
         return scored_matches
 
@@ -182,11 +196,14 @@ class ScoredMatch(object):
         The score associated with the match.
     match : gilda.scorer.Match
         The Match object characterizing the match to the Term.
+    disambiguation : Optional[dict]
+        Meta-information about disambiguation, when available.
     """
-    def __init__(self, term, score, match):
+    def __init__(self, term, score, match, disambiguation=None):
         self.term = term
         self.score = score
         self.match = match
+        self.disambiguation = disambiguation
 
     def __str__(self):
         return 'ScoredMatch(%s,%s,%s)' % (self.term, self.score, self.match)
@@ -195,11 +212,14 @@ class ScoredMatch(object):
         return str(self)
 
     def to_json(self):
-        return {
+        js = {
             'term': self.term.to_json(),
             'score': self.score,
             'match': self.match.to_json()
         }
+        if self.disambiguation is not None:
+            js['disambiguation'] = self.disambiguation
+        return js
 
     def multiply(self, value):
         logger.info('Multiplying the score of "%s" with %.3f'

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -1,4 +1,5 @@
 import csv
+import json
 import pickle
 import logging
 import itertools
@@ -140,15 +141,13 @@ class Grounder(object):
                                             'score': score,
                                             'match': 'grounded'}
                     match.multiply(score)
-                    match.disambiguation = score
                     has_adeft_grounding = True
                     break
             if not has_adeft_grounding:
-                match.disambiguation = {'type': adeft,
+                match.disambiguation = {'type': 'adeft',
                                         'score': ungrounded_score,
                                         'match': 'ungrounded'}
                 match.multiply(ungrounded_score)
-                match.disambiguation = ungrounded_score
         return scored_matches
 
     def disambiguate_gilda(self, raw_str, scored_matches, context):
@@ -206,7 +205,10 @@ class ScoredMatch(object):
         self.disambiguation = disambiguation
 
     def __str__(self):
-        return 'ScoredMatch(%s,%s,%s)' % (self.term, self.score, self.match)
+        disamb_str = '' if self.disambiguation is None else \
+            (',disambiguation=' + json.dumps(self.disambiguation))
+        return 'ScoredMatch(%s,%s,%s%s)' % \
+            (self.term, self.score, self.match, disamb_str)
 
     def __repr__(self):
         return str(self)

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -46,3 +46,16 @@ def test_grounder_depluralize():
     assert len(entries) == 2, entries
     for entry in entries:
         assert entry.norm_text == 'raf'
+
+
+def test_disambiguate_adeft():
+    matches = gr.ground('IR')
+    matches = gr.disambiguate('IR', matches, 'Insulin Receptor (IR)')
+    for match in matches:
+        assert match.disambiguation is not None
+        assert match.disambiguation['type'] == 'adeft'
+        assert match.disambiguation['match'] in ('grounded', 'ungrounded')
+        assert match.disambiguation['score'] is not None
+        if match.term.db == 'HGNC' and match.term.id == '6091':
+            assert match.disambiguation['match'] == 'grounded'
+            assert match.disambiguation['score'] == 1.0

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -59,3 +59,16 @@ def test_disambiguate_adeft():
         if match.term.db == 'HGNC' and match.term.id == '6091':
             assert match.disambiguation['match'] == 'grounded'
             assert match.disambiguation['score'] == 1.0
+
+
+def test_disambiguate_gilda():
+    matches = gr.ground('NDR1')
+    matches = gr.disambiguate('NDR1', matches, 'STK38')
+    for match in matches:
+        assert match.disambiguation['type'] == 'gilda'
+        assert match.disambiguation['match'] == 'grounded'
+        if match.term.db == 'HGNC' and match.term.id == '17847':
+            assert match.disambiguation['score'] > 0.99
+        if match.term.db == 'HGNC' and match.term.id == '7679':
+            assert match.disambiguation['score'] < 0.01
+        print(match)


### PR DESCRIPTION
This PR adds a `disambiguation` attribute to the `ScoredMatch` object (and it's JSON-serialization) to expose the results of Adeft or Gilda disambiguation having been performed.

It also adds a `/models` endpoint to the web service which lists all entity texts for which Gilda disambiguation models are available. Clients can use this to pre-populate a list of texts for which Gilda should be invoked (with text context).