### PR TITLE
Add cleaner Python API and other changes

### DIFF
--- a/benchmarks/fplx_evaluation.py
+++ b/benchmarks/fplx_evaluation.py
@@ -59,7 +59,8 @@ def process_fxpl_groundings(df):
             'text': row['Text'],
             'entity_type': row['EntityType'],
             'db_refs': {},
-            'correct': bool(int(row['Grounding']))
+            'correct': bool(int(row['Grounding'])),
+            'context': row['Sentence']
             }
         # We then extract the grounding (up to 3) that were considered
         # for the curation
@@ -126,7 +127,8 @@ def make_comparison(groundings):
         old_eval = evaluate_old_grounding(grounding)
         # Send grounding requests
         res = requests.post('%s/ground' % service_url,
-                            json={'text': grounding['text']}).json()
+                            json={'text': grounding['text'],
+                                  'context': grounding['context']}).json()
         if not res:
             comparison['%s_ungrounded' % old_eval].append((idx, grounding, None))
             continue

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,9 +24,9 @@ copyright = '2019, Benjamin M. Gyori'
 author = 'Benjamin M. Gyori'
 
 # The short X.Y version
-version = '0.1'
+version = '0.2'
 # The full version, including alpha/beta/rc tags
-release = '0.1.4'
+release = '0.2.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,7 +10,6 @@ Gilda documentation
    :maxdepth: 3
 
    modules/index
-   rest_api
 
 
 * :ref:`genindex`

--- a/doc/modules/index.rst
+++ b/doc/modules/index.rst
@@ -1,6 +1,13 @@
 Gilda modules reference
 =======================
 
+API
+---
+
+.. automodule:: gilda.api
+    :members:
+    :show-inheritance:
+
 Grounder
 --------
 

--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.4'
+__version__ = '0.2.0'
 import logging
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'

--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -7,3 +7,6 @@ logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'
 
 
 logger = logging.getLogger('gilda')
+
+
+from .api import *

--- a/gilda/api.py
+++ b/gilda/api.py
@@ -3,7 +3,18 @@ __all__ = ['ground', 'get_models']
 from gilda.grounder import Grounder
 from gilda.resources import get_grounding_terms
 
-grounder = Grounder(get_grounding_terms())
+
+class GrounderInstance(object):
+    def __init__(self):
+        self.grounder = None
+
+    def get_grounder(self):
+        if self.grounder is None:
+            self.grounder = Grounder(get_grounding_terms())
+        return self.grounder
+
+
+grounder = GrounderInstance()
 
 
 def ground(text, context=None):
@@ -23,9 +34,11 @@ def ground(text, context=None):
     list[gilda.grounder.ScoredMatch]
         A list of ScoredMatch objects representing the groundings.
     """
-    scored_matches = grounder.ground(text)
+    scored_matches = grounder.get_grounder().ground(text)
     if context:
-        scored_matches = grounder.disambiguate(text, scored_matches, context)
+        scored_matches = grounder.get_grounder().disambiguate(text,
+                                                              scored_matches,
+                                                              context)
     scored_matches = sorted(scored_matches, key=lambda x: x.score,
                             reverse=True)
     return scored_matches
@@ -40,4 +53,4 @@ def get_models():
         The list of entity texts for which a disambiguation model is
         available.
     """
-    return sorted(list(grounder.gilda_disambiguators.keys()))
+    return sorted(list(grounder.get_grounder().gilda_disambiguators.keys()))

--- a/gilda/api.py
+++ b/gilda/api.py
@@ -1,0 +1,42 @@
+__all__ = ['ground', 'get_models']
+
+from gilda.grounder import Grounder
+
+grounder = Grounder(get_grounding_terms())
+
+
+def ground(text, context=None):
+    """Return a list of scored matches for a text to ground.
+
+    Parameters
+    ----------
+    text : str
+        The entity text to be grounded.
+    context : Optional[str]
+        Any additional text that serves as context for disambiguating the
+        given entity text, used if a model exists for disambiguating the
+        given text.
+
+    Returns
+    -------
+    list[gilda.grounder.ScoredMatch]
+        A list of ScoredMatch objects representing the groundings.
+    """
+    scored_matches = grounder.ground(text)
+    if context:
+        scored_matches = grounder.disambiguate(text, scored_matches, context)
+    scored_matches = sorted(scored_matches, key=lambda x: x.score,
+                            reverse=True)
+    return scored_matches
+
+
+def get_models():
+    """Return a list of entity texts for which disambiguation models exist.
+
+    Returns
+    -------
+    list[str]
+        The list of entity texts for which a disambiguation model is
+        available.
+    """
+    return sorted(list(grounder.gilda_disambiguators.keys()))

--- a/gilda/api.py
+++ b/gilda/api.py
@@ -1,6 +1,7 @@
 __all__ = ['ground', 'get_models']
 
 from gilda.grounder import Grounder
+from gilda.resources import get_grounding_terms
 
 grounder = Grounder(get_grounding_terms())
 

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -13,7 +13,7 @@ def info():
 
 
 @app.route('/ground', methods=['POST'])
-def ground():
+def ground_endpoint():
     if request.json is None:
         abort(Response('Missing application/json header.', 415))
     # Get input parameters

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -1,10 +1,7 @@
 from flask import Flask, abort, Response, request, jsonify
-from gilda.grounder import Grounder
-from gilda.resources import get_grounding_terms
+from gilda.api import *
 
 app = Flask(__name__)
-
-grounder = Grounder(get_grounding_terms())
 
 
 @app.route('/', methods=['GET'])
@@ -22,17 +19,11 @@ def ground():
     # Get input parameters
     text = request.json.get('text')
     context = request.json.get('context')
-    scored_matches = grounder.ground(text)
-    if context:
-        scored_matches = grounder.disambiguate(text, scored_matches, context)
-    res = []
-    for scored_match in sorted(scored_matches, key=lambda x: x.score,
-                               reverse=True):
-        res.append(scored_match.to_json())
+    scored_matches = ground(text, context)
+    res = [sm.to_json() for sm in scored_matches]
     return jsonify(res)
 
 
 @app.route('/models', methods=['GET', 'POST'])
 def models():
-    models = sorted(list(grounder.gilda_disambiguators.keys()))
-    return jsonify(models)
+    return jsonify(get_models())

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -18,7 +18,7 @@ from .resources import resource_dir
 
 
 indra_module_path = indra.__path__[0]
-resources = os.path.join(indra_module_path, 'resources')
+indra_resources = os.path.join(indra_module_path, 'resources')
 gilda_resources = os.path.join(os.path.dirname(__file__), 'resources')
 
 logger = logging.getLogger('gilda.generate_terms')
@@ -37,7 +37,7 @@ def read_csv(fname, header=False, delimiter='\t'):
 
 
 def generate_hgnc_terms():
-    fname = os.path.join(resources, 'hgnc_entries.tsv')
+    fname = os.path.join(indra_resources, 'hgnc_entries.tsv')
     logger.info('Loading %s' % fname)
     all_term_args = {}
     rows = [r for r in read_csv(fname, header=True, delimiter='\t')]
@@ -92,7 +92,7 @@ def generate_hgnc_terms():
 
 
 def generate_chebi_terms():
-    fname = os.path.join(resources, 'chebi_entries.tsv')
+    fname = os.path.join(indra_resources, 'chebi_entries.tsv')
     logger.info('Loading %s' % fname)
     terms = []
     for row in read_csv(fname, header=True, delimiter='\t'):
@@ -108,7 +108,7 @@ def generate_chebi_terms():
     # at ftp://ftp.ebi.ac.uk/pub/databases/chebi/Flat_file_
     # tab_delimited/names_3star.tsv.gz, it needs to be decompressed
     # into the INDRA resources folder.
-    fname = os.path.join(resources, 'names_3star.tsv')
+    fname = os.path.join(indra_resources, 'names_3star.tsv')
     added = set()
     for row in read_csv(fname, header=True, delimiter='\t'):
         chebi_id = chebi_client.get_primary_id(str(row['COMPOUND_ID']))
@@ -138,13 +138,13 @@ def generate_chebi_terms():
 
 
 def generate_mesh_terms(ignore_mappings=False):
-    # Load MeSH ID/label mappings from INDRA
+    # Load MeSH ID/label mappings
     mesh_mappings_file = os.path.join(gilda_resources, 'mesh_mappings.tsv')
     mesh_mappings = {}
     for row in read_csv(mesh_mappings_file, delimiter='\t'):
         mesh_mappings[row[1]] = (row[3], row[4])
     # Load MeSH HGNC/FPLX mappings
-    mesh_names_file = os.path.join(resources,
+    mesh_names_file = os.path.join(indra_resources,
                                    'mesh_id_label_mappings.tsv')
     terms = []
     for row in read_csv(mesh_names_file, header=False, delimiter='\t'):
@@ -178,7 +178,7 @@ def generate_mesh_terms(ignore_mappings=False):
 
 def generate_go_terms():
     # TODO: add synonyms for GO terms here
-    fname = os.path.join(resources, 'go_id_label_mappings.tsv')
+    fname = os.path.join(indra_resources, 'go_id_label_mappings.tsv')
     logger.info('Loading %s' % fname)
     terms = []
     for row in read_csv(fname, delimiter='\t'):
@@ -194,7 +194,7 @@ def generate_go_terms():
 
 
 def generate_famplex_terms():
-    fname = os.path.join(resources, 'famplex', 'grounding_map.csv')
+    fname = os.path.join(indra_resources, 'famplex', 'grounding_map.csv')
     logger.info('Loading %s' % fname)
     terms = []
     for row in read_csv(fname, delimiter=','):

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -311,7 +311,7 @@ def generate_adeft_terms():
     for shortform in available_shortforms:
         da = load_disambiguator(shortform)
         for grounding in da.names.keys():
-            if grounding == 'ungrounded':
+            if grounding == 'ungrounded' or ':' not in grounding:
                 continue
             db_ns, db_id = grounding.split(':', maxsplit=1)
             if db_ns == 'HGNC':
@@ -324,6 +324,8 @@ def generate_adeft_terms():
                 standard_name = chebi_client.get_chebi_name_from_id(db_id)
             elif db_ns == 'FPLX':
                 standard_name = db_id
+            elif db_ns == 'UP':
+                standard_name = uniprot_client.get_gene_name(db_id)
             else:
                 logger.warning('Unknown grounding namespace from Adeft: %s' %
                                db_ns)

--- a/gilda/tests/test_api.py
+++ b/gilda/tests/test_api.py
@@ -1,0 +1,15 @@
+from gilda.tests import appreq
+from gilda.api import *
+
+
+def test_api_ground():
+    scores = ground('kras')
+    assert appreq(scores[0].score, 0.9845), scores
+    scores = ground('ROS', 'reactive oxygen')
+    assert scores[0].term.db == 'MESH'
+
+
+def test_get_models():
+    models = get_models()
+    assert len(models) > 500
+    assert 'STK1' in models

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 
 setup(name='gilda',
-      version='0.1.4',
+      version='0.2.0',
       description=('Grounding for biomedical entities with contextual '
                    'disambiguation'),
       long_description=long_description,
       long_description_content_type='text/markdown',
-      url='https://github.com/bgyori/gilda',
+      url='https://github.com/indralab/gilda',
       author='Benjamin M. Gyori, Harvard Medical School',
       author_email='benjamin_gyori@hms.harvard.edu',
       classifiers=[
@@ -26,6 +26,7 @@ setup(name='gilda',
       packages=find_packages(),
       install_requires=['regex', 'adeft>=0.4.0', 'boto3', 'flask'],
       extras_require={'test': ['nose', 'coverage'],
-                      'terms': ['indra']},
+                      'terms': ['indra'],
+                      'benchmarks': ['pandas', 'requests']},
       keywords=['nlp', 'biology']
       )


### PR DESCRIPTION
This PR adds a simpler and cleaner Python API in `api.py` making it easier to use Gilda as an imported module (in case running it as a local or remote web service is not desirable). It also bumps the version and updates the grounding table and model resources.