### PR TITLE
Add constants for resource file paths

### DIFF
--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -14,12 +14,10 @@ from indra.databases import hgnc_client, uniprot_client, chebi_client, \
     go_client, mesh_client
 from .term import Term
 from .process import normalize
-from .resources import resource_dir
 
 
 indra_module_path = indra.__path__[0]
 indra_resources = os.path.join(indra_module_path, 'resources')
-gilda_resources = os.path.join(os.path.dirname(__file__), 'resources')
 
 logger = logging.getLogger('gilda.generate_terms')
 
@@ -139,7 +137,7 @@ def generate_chebi_terms():
 
 def generate_mesh_terms(ignore_mappings=False):
     # Load MeSH ID/label mappings
-    mesh_mappings_file = os.path.join(gilda_resources, 'mesh_mappings.tsv')
+    from .resources import MESH_MAPPINGS_PATH as mesh_mappings_file
     mesh_mappings = {}
     for row in read_csv(mesh_mappings_file, delimiter='\t'):
         mesh_mappings[row[1]] = (row[3], row[4])
@@ -367,6 +365,6 @@ def get_all_terms():
 
 if __name__ == '__main__':
     terms = get_all_terms()
-    fname = os.path.join(resource_dir, 'grounding_terms.tsv')
+    from .resources import GROUNDING_TERMS_PATH as fname
     logger.info('Dumping into %s' % fname)
     write_unicode_csv(fname, [t.to_list() for t in terms], delimiter='\t')

--- a/gilda/resources/__init__.py
+++ b/gilda/resources/__init__.py
@@ -6,6 +6,9 @@ from gilda import __version__
 
 logger = logging.getLogger(__name__)
 
+HERE = os.path.abspath(os.path.dirname(__file__))
+MESH_MAPPINGS_PATH = os.path.join(HERE, 'mesh_mappings.tsv')
+
 home_dir = os.path.expanduser('~')
 resource_dir = os.path.join(home_dir, '.gilda', __version__)
 
@@ -15,6 +18,9 @@ if not os.path.isdir(resource_dir):
         os.makedirs(resource_dir)
     except Exception:
         logger.warning('%s already exists' % resource_dir)
+
+GROUNDING_TERMS_BASE_NAME = 'grounding_terms.tsv'
+GROUNDING_TERMS_PATH = os.path.join(resource_dir, GROUNDING_TERMS_BASE_NAME)
 
 
 def _download_from_s3(path, base_name):
@@ -28,8 +34,8 @@ def _download_from_s3(path, base_name):
 
 
 def get_grounding_terms():
-    base_name = 'grounding_terms.tsv'
-    full_path = os.path.join(resource_dir, base_name)
+    base_name = GROUNDING_TERMS_BASE_NAME
+    full_path = GROUNDING_TERMS_PATH
     if not os.path.exists(full_path):
         logger.info('Downloading grounding terms from S3.')
         out_file = _download_from_s3(resource_dir, base_name)


### PR DESCRIPTION
This PR saves the paths to the grounding terms file and to the mesh mapping file as constants, such that other scripts can look them up with `gilda.resources.GROUNDING_TERMS_PATH` and `gilda.resources.MESH_MAPPINGS_PATH`, respectively.

This could make it easier for alternative scripts to write and read these files.