### PR TITLE
Improve parsing UniProt resource file

### DIFF
--- a/gilda/api.py
+++ b/gilda/api.py
@@ -27,7 +27,7 @@ class GrounderInstance(object):
     def get_models(self):
         return sorted(list(self.get_grounder().gilda_disambiguators.keys()))
 
-    def get_names(self, db, id, status=None, source=None)
+    def get_names(self, db, id, status=None, source=None):
         names = []
         for entries in self.get_grounder().entries.values():
             for entry in entries:

--- a/gilda/api.py
+++ b/gilda/api.py
@@ -27,6 +27,16 @@ class GrounderInstance(object):
     def get_models(self):
         return sorted(list(self.get_grounder().gilda_disambiguators.keys()))
 
+    def get_names(self, db, id, status=None, source=None)
+        names = []
+        for entries in self.get_grounder().entries.values():
+            for entry in entries:
+                if (entry.db == db) and (entry.id == id) and \
+                        (not status or entry.status == status) and \
+                        (not source or entry.source == source):
+                    names.append(entry.text)
+        return sorted(list(set(names)))
+
 
 grounder = GrounderInstance()
 
@@ -61,3 +71,22 @@ def get_models():
         available.
     """
     return grounder.get_models()
+
+
+def get_names(db, id, status=None, source=None):
+    """Return a list of entity texts corresponding to a given database ID.
+
+    Parameters
+    ----------
+    db : str
+        The database in which the ID is an entry, e.g., HGNC.
+    id : str
+        The ID of an entry in the database.
+    status : Optional[str]
+        If given, only entity texts with the given status e.g., "synonym"
+        are returned.
+    source : Optional[str]
+        If given, only entity texts from the given source e.g., "uniprot"
+        are returned.
+    """
+    return grounder.get_names(db, id, status=status, source=source)

--- a/gilda/api.py
+++ b/gilda/api.py
@@ -1,7 +1,6 @@
-__all__ = ['ground', 'get_models']
+__all__ = ['ground', 'get_models', 'get_names']
 
 from gilda.grounder import Grounder
-from gilda.resources import get_grounding_terms
 
 
 class GrounderInstance(object):

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -277,7 +277,10 @@ def generate_uniprot_terms(download=True):
 
 
 def parse_uniprot_synonyms(synonyms_str):
-    synonyms_str = re.sub(r'\[Includes: ([^]])+\]', '', synonyms_str).strip()
+    synonyms_str = re.sub(r'\[Includes: ([^]])+\]',
+                          '', synonyms_str).strip()
+    synonyms_str = re.sub(r'\[Cleaved into: ([^]])+\]',
+                          '', synonyms_str).strip()
     syns = ['']
     parentheses_depth = 0
     start = True

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -281,28 +281,33 @@ def parse_uniprot_synonyms(synonyms_str):
                           '', synonyms_str).strip()
     synonyms_str = re.sub(r'\[Cleaved into: ([^]])+\]',
                           '', synonyms_str).strip()
-    syns = ['']
-    parentheses_depth = 0
-    start = True
-    for idx, c in enumerate(synonyms_str):
-        if c == '(':
-            if start and synonyms_str[idx-1] == ' ':
-                syns[-1] = syns[-1][:-1]
-                syns.append('')
-                start = False
-            elif parentheses_depth == 0 and synonyms_str[idx-1] == ' ':
-                syns[-1] = syns[-1][:-1]
-                syns.append('')
-            else:
-                syns[-1] += c
-            parentheses_depth += 1
-        elif c == ')':
-            if start or not start and parentheses_depth > 1:
-                syns[-1] += c
-            parentheses_depth -= 1
-        else:
-            syns[-1] += c
-    return syns
+
+    def find_block_from_right(s):
+        parentheses_depth = 0
+        assert s.endswith(')')
+        s = s[:-1]
+        block = ''
+        for c in s[::-1]:
+            if c == ')':
+                parentheses_depth += 1
+            elif c == '(':
+                if parentheses_depth > 0:
+                    parentheses_depth -= 1
+                else:
+                    return block
+            block = c + block
+        return block
+
+    syns = []
+    while True:
+        if not synonyms_str:
+            return syns
+        if not synonyms_str.endswith(')'):
+            return [synonyms_str] + syns
+
+        syn = find_block_from_right(synonyms_str)
+        syns = [syn] + syns
+        synonyms_str = synonyms_str[:-len(syn)-3]
 
 
 def generate_adeft_terms():

--- a/gilda/tests/test_api.py
+++ b/gilda/tests/test_api.py
@@ -13,3 +13,9 @@ def test_get_models():
     models = get_models()
     assert len(models) > 500
     assert 'STK1' in models
+
+
+def test_get_names():
+    names = get_names('HGNC', '6407')
+    assert len(names) > 5, names
+    assert 'K-Ras' in names

--- a/gilda/tests/test_generate_terms.py
+++ b/gilda/tests/test_generate_terms.py
@@ -25,3 +25,9 @@ def test_parse_embedded_parentheses_uniprot_2():
     assert len(syms) == 7, syms
     assert 'Na(+)/H(+) exchange regulatory cofactor NHE-RF1' in syms, syms
 
+
+def test_parse_parentheses_in_name():
+    txt = 'DNA (cytosine-5)-methyltransferase 1 (EC:2.1.1.37)'
+    syms = parse_uniprot_synonyms(txt)
+    assert syms == ['DNA (cytosine-5)-methyltransferase 1', 'EC:2.1.1.37'], \
+        syms

--- a/gilda/tests/test_generate_terms.py
+++ b/gilda/tests/test_generate_terms.py
@@ -26,8 +26,20 @@ def test_parse_embedded_parentheses_uniprot_2():
     assert 'Na(+)/H(+) exchange regulatory cofactor NHE-RF1' in syms, syms
 
 
+def test_parse_embedded_parentheses_uniprot_3():
+    txt = ('Solute carrier family 13 member 3 (Na(+)/dicarboxylate ' \
+           'cotransporter 3, NaDC-3, rNaDC3) (Sodium-dependent high-affinity' \
+           ' dicarboxylate transporter 2)')
+    syms = parse_uniprot_synonyms(txt)
+    assert syms == \
+        ['Solute carrier family 13 member 3',
+         'Na(+)/dicarboxylate cotransporter 3, NaDC-3, rNaDC3',
+         'Sodium-dependent high-affinity dicarboxylate transporter 2']
+
+
 def test_parse_parentheses_in_name():
     txt = 'DNA (cytosine-5)-methyltransferase 1 (EC:2.1.1.37)'
     syms = parse_uniprot_synonyms(txt)
     assert syms == ['DNA (cytosine-5)-methyltransferase 1', 'EC:2.1.1.37'], \
         syms
+


### PR DESCRIPTION
As far as I can tell, fixes #1 . It also adds a new get_names API function to get the names/synonyms for a grounding entry.