### PR TITLE
Make instantiation of Grounder more flexible

### DIFF
--- a/gilda/api.py
+++ b/gilda/api.py
@@ -10,7 +10,7 @@ class GrounderInstance(object):
 
     def get_grounder(self):
         if self.grounder is None:
-            self.grounder = Grounder(get_grounding_terms())
+            self.grounder = Grounder()
         return self.grounder
 
     def ground(self, text, context=None):

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -17,17 +17,28 @@ logger = logging.getLogger(__name__)
 
 
 class Grounder(object):
-    """Class to look up and ground query texts in a terms file."""
-    def __init__(self, terms_file=None):
-        if terms_file is None:
-            terms_file = get_grounding_terms()
+    """Class to look up and ground query texts in a terms file.
 
-        if isinstance(terms_file, str):
-            self.entries = load_terms_file(terms_file)
-        elif isinstance(terms_file, dict):
-            self.entries = terms_file
+    Parameters
+    ----------
+    terms : str or dict or None
+        Specifies the grounding terms that should be loaded in the Grounder.
+        If None, the default grounding terms are loaded from the versioned
+        resource folder. If str, it is interpreted as a path to a grounding
+        terms TSV file which is then loaded. If dict, it is assumed to be
+        a grounding terms dict with normalized entity strings as keys
+        and Term objects as values. Default: None
+    """
+    def __init__(self, terms=None):
+        if terms is None:
+            terms = get_grounding_terms()
+
+        if isinstance(terms, str):
+            self.entries = load_terms_file(terms)
+        elif isinstance(terms, dict):
+            self.entries = terms
         else:
-            raise TypeError('terms_file is neither a path nor a normalized'
+            raise TypeError('terms is neither a path nor a normalized'
                             ' entry name to term dictionary')
 
         self.adeft_disambiguators = load_adeft_models()

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -10,7 +10,7 @@ from .term import Term
 from .process import normalize, replace_dashes, replace_greek_uni, \
     replace_greek_latin, depluralize
 from .scorer import generate_match, score
-from .resources import get_gilda_models
+from .resources import get_gilda_models, get_grounding_terms
 
 
 logger = logging.getLogger(__name__)
@@ -18,8 +18,18 @@ logger = logging.getLogger(__name__)
 
 class Grounder(object):
     """Class to look up and ground query texts in a terms file."""
-    def __init__(self, terms_file):
-        self.entries = load_terms_file(terms_file)
+    def __init__(self, terms_file=None):
+        if terms_file is None:
+            terms_file = get_grounding_terms()
+
+        if isinstance(terms_file, str):
+            self.entries = load_terms_file(terms_file)
+        elif isinstance(terms_file, dict):
+            self.entries = terms_file
+        else:
+            raise TypeError('terms_file is neither a path nor a normalized'
+                            ' entry name to term dictionary')
+
         self.adeft_disambiguators = load_adeft_models()
         self.gilda_disambiguators = load_gilda_models()
 

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -1,9 +1,8 @@
 from gilda.grounder import Grounder
-from gilda.resources import get_grounding_terms
 from . import appreq
 
 
-gr = Grounder(get_grounding_terms())
+gr = Grounder()
 
 
 def test_grounder():

--- a/models/find_ambiguities.py
+++ b/models/find_ambiguities.py
@@ -1,8 +1,7 @@
 from gilda.grounder import Grounder
-from gilda.resources import get_grounding_terms
 from indra.databases import mesh_client
 
-gr = Grounder(get_grounding_terms())
+gr = Grounder()
 
 
 def get_ambiguities(skip_assertions=True, skip_names=True):


### PR DESCRIPTION
This PR allows the user to either specify the `terms_file` argument to `Grounder.__init__()` as either a:

- `None` -> look up the default path using `gilda.resources.get_grounding_terms()` as well as ensure the data has been downloaded from Amazon
- `str` -> use the grounding terms file at the given path
- `dict` -> use a pre-made dictionary of normalized names to terms, with the same structure as `gilda.grounder.load_terms_file()` returns

As a consequence, the redundant callings of `Grounder(get_grounding_terms())` have been simplified to just `Grounder()`.