### PR TITLE
Refactor functionality from the GrounderInstance class into the Grounder class

### DIFF
--- a/gilda/api.py
+++ b/gilda/api.py
@@ -14,17 +14,11 @@ class GrounderInstance(object):
 
     def ground(self, text, context=None):
         _grounder = self.get_grounder()
-        scored_matches = _grounder.ground(text)
-        if context:
-            scored_matches = _grounder.disambiguate(text,
-                                                    scored_matches,
-                                                    context)
-        scored_matches = sorted(scored_matches, key=lambda x: x.score,
-                                reverse=True)
-        return scored_matches
+        return _grounder.ground(text, context=context, sort=True)
 
     def get_models(self):
-        return sorted(list(self.get_grounder().gilda_disambiguators.keys()))
+        _grounder = self.get_grounder()
+        return _grounder.get_models()
 
     def get_names(self, db, id, status=None, source=None):
         names = []

--- a/gilda/api.py
+++ b/gilda/api.py
@@ -19,14 +19,9 @@ class GrounderInstance(object):
         return self.get_grounder().get_models()
 
     def get_names(self, db, id, status=None, source=None):
-        names = []
-        for entries in self.get_grounder().entries.values():
-            for entry in entries:
-                if (entry.db == db) and (entry.id == id) and \
-                        (not status or entry.status == status) and \
-                        (not source or entry.source == source):
-                    names.append(entry.text)
-        return sorted(list(set(names)))
+        return self.get_grounder().get_names(db, id,
+                                             status=status,
+                                             source=source)
 
 
 grounder = GrounderInstance()

--- a/gilda/api.py
+++ b/gilda/api.py
@@ -13,12 +13,10 @@ class GrounderInstance(object):
         return self.grounder
 
     def ground(self, text, context=None):
-        _grounder = self.get_grounder()
-        return _grounder.ground(text, context=context, sort=True)
+        return self.get_grounder().ground(text, context=context, sort=True)
 
     def get_models(self):
-        _grounder = self.get_grounder()
-        return _grounder.get_models()
+        return self.get_grounder().get_models()
 
     def get_names(self, db, id, status=None, source=None):
         names = []

--- a/gilda/api.py
+++ b/gilda/api.py
@@ -13,7 +13,7 @@ class GrounderInstance(object):
         return self.grounder
 
     def ground(self, text, context=None):
-        return self.get_grounder().ground(text, context=context, sort=True)
+        return self.get_grounder().ground(text, context=context)
 
     def get_models(self):
         return self.get_grounder().get_models()

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -230,6 +230,36 @@ class Grounder(object):
         """
         return sorted(list(self.gilda_disambiguators.keys()))
 
+    def get_names(self, db, id, status=None, source=None):
+        """Return a list of entity texts corresponding to a given database ID.
+
+        Parameters
+        ----------
+        db : str
+            The database in which the ID is an entry, e.g., HGNC.
+        id : str
+            The ID of an entry in the database.
+        status : Optional[str]
+            If given, only entity texts with the given status e.g., "synonym"
+            are returned.
+        source : Optional[str]
+            If given, only entity texts from the given source e.g., "uniprot"
+            are returned.
+
+        Returns
+        -------
+        names: list[str]
+            A list of entity texts corresponding to the given database/ID
+        """
+        names = set()
+        for entries in self.entries.values():
+            for entry in entries:
+                if (entry.db == db) and (entry.id == id) and \
+                   (not status or entry.status == status) and \
+                   (not source or entry.source == source):
+                    names.add(entry.text)
+        return sorted(names)
+
 
 class ScoredMatch(object):
     """Class representing a scored match to a grounding term.


### PR DESCRIPTION
The only functionality I can see for the `GrounderInstance` class is to make the instance of the grounder lazy. Therefore, I moved some of the functionality from this class directly into the `Grounder` class, which should make it more reusable.