### PR TITLE
Extend MeSH mappings

### DIFF
--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -140,7 +140,7 @@ def generate_mesh_terms(ignore_mappings=False):
     from .resources import MESH_MAPPINGS_PATH as mesh_mappings_file
     mesh_mappings = {}
     for row in read_csv(mesh_mappings_file, delimiter='\t'):
-        mesh_mappings[row[1]] = (row[3], row[4])
+        mesh_mappings[row[1]] = row[2:]
     # Load MeSH HGNC/FPLX mappings
     mesh_names_file = os.path.join(indra_resources,
                                    'mesh_id_label_mappings.tsv')
@@ -150,12 +150,8 @@ def generate_mesh_terms(ignore_mappings=False):
         text_name = row[1]
         mapping = mesh_mappings.get(db_id)
         if not ignore_mappings and mapping:
-            db, db_id = mapping
+            db, db_id, name = mapping
             status = 'synonym'
-            if db == 'HGNC':
-                name = hgnc_client.get_hgnc_name(db_id)
-            elif db == 'FPLX':
-                name = db_id
         else:
             db = 'MESH'
             status = 'name'

--- a/gilda/resources/mesh_mappings.tsv
+++ b/gilda/resources/mesh_mappings.tsv
@@ -1,3 +1,4 @@
+MESH	D000001	Calcimycin	CHEBI	CHEBI:3305	Calcimycin
 MESH	D000067596	Interleukin-33	HGNC	16028	IL33
 MESH	D000067616	S100A12 Protein	HGNC	10489	S100A12
 MESH	D000067696	Ataxin-1	HGNC	10548	ATXN1
@@ -5,8 +6,23 @@ MESH	D000067698	Ataxin-2	HGNC	10555	ATXN2
 MESH	D000067699	Ataxin-3	HGNC	7106	ATXN3
 MESH	D000067719	Ataxin-7	HGNC	10560	ATXN7
 MESH	D000067736	Ataxin-10	HGNC	10549	ATXN10
+MESH	D000068180	Aripiprazole	CHEBI	CHEBI:31236	aripiprazole
 MESH	D000068256	Darbepoetin alfa	HGNC	4392	GNAS
+MESH	D000068338	Everolimus	CHEBI	CHEBI:68478	everolimus
+MESH	D000068579	Celecoxib	CHEBI	CHEBI:41423	celecoxib
+MESH	D000068677	Sildenafil Citrate	CHEBI	CHEBI:58987	sildenafil citrate
+MESH	D000068679	Emtricitabine	CHEBI	CHEBI:31536	emtricitabine
+MESH	D000068800	Etanercept	HGNC	11917	TNFRSF1B
+MESH	D000068876	Fingolimod Hydrochloride	CHEBI	CHEBI:63112	fingolimod hydrochloride
+MESH	D000069056	Lurasidone Hydrochloride	CHEBI	CHEBI:70732	lurasidone hydrochloride
+MESH	D000069059	Atorvastatin	CHEBI	CHEBI:39548	atorvastatin
+MESH	D000069349	Linezolid	CHEBI	CHEBI:63607	linezolid
+MESH	D000069445	Atomoxetine Hydrochloride	CHEBI	CHEBI:331697	atomoxetine hydrochloride
+MESH	D000069454	Darunavir	CHEBI	CHEBI:367163	darunavir
+MESH	D000069503	Vilazodone Hydrochloride	CHEBI	CHEBI:70705	vilazodone hydrochloride
+MESH	D000069557	Travoprost	CHEBI	CHEBI:746859	travoprost
 MESH	D000069585	Filgrastim	HGNC	2438	CSF3
+MESH	D000070	Acebutolol	CHEBI	CHEBI:2379	acebutolol
 MESH	D000070778	Perilipin-1	HGNC	9076	PLIN1
 MESH	D000070780	Perilipin-2	HGNC	248	PLIN2
 MESH	D000070796	Perilipin-3	HGNC	16893	PLIN3
@@ -25,8 +41,11 @@ MESH	D000071235	Fibromodulin	HGNC	3774	FMOD
 MESH	D000071256	Uncoupling Protein 1	HGNC	12517	UCP1
 MESH	D000071479	APOBEC-1 Deaminase	HGNC	604	APOBEC1
 MESH	D000071679	Glycogen Synthase Kinase 3 beta	HGNC	4617	GSK3B
+MESH	D000071756	Soluble Guanylyl Cyclase	FPLX	SGC	SGC
 MESH	D000071816	Glycodelin	HGNC	8573	PAEP
 MESH	D000071821	Dystonin	HGNC	1090	DST
+MESH	D000071838	Fibrillin-1	HGNC	3603	FBN1
+MESH	D000071840	Fibrillin-2	HGNC	3604	FBN2
 MESH	D000071841	PAX6 Transcription Factor	HGNC	8620	PAX6
 MESH	D000071858	Epithelial Cell Adhesion Molecule	HGNC	11529	EPCAM
 MESH	D000071916	AC133 Antigen	HGNC	9454	PROM1
@@ -38,6 +57,7 @@ MESH	D000072622	Cyclophilin C	HGNC	9256	PPIC
 MESH	D000072640	Interferon-Induced Helicase, IFIH1	HGNC	18873	IFIH1
 MESH	D000073861	Apelin	HGNC	16665	APLN
 MESH	D000073939	Dysferlin	HGNC	3097	DYSF
+MESH	D000074	Acenocoumarol	CHEBI	CHEBI:53766	acenocoumarol
 MESH	D000074001	Intercellular Adhesion Molecule-3	HGNC	5346	ICAM3
 MESH	D000074010	Bone Marrow Stromal Antigen 2	HGNC	1119	BST2
 MESH	D000074026	Fatty Acid Binding Protein 3	HGNC	3557	FABP3
@@ -66,71 +86,651 @@ MESH	D000076202	c-Mer Tyrosine Kinase	HGNC	7027	MERTK
 MESH	D000076222	Mechanistic Target of Rapamycin Complex 1	FPLX	mTORC1	mTORC1
 MESH	D000076225	Mechanistic Target of Rapamycin Complex 2	FPLX	mTORC2	mTORC2
 MESH	D000076245	Heterogeneous Nuclear Ribonucleoprotein A1	HGNC	5031	HNRNPA1
+MESH	D000077004	Tuberous Sclerosis Complex 1 Protein	HGNC	12362	TSC1
+MESH	D000077005	Tuberous Sclerosis Complex 2 Protein	HGNC	12363	TSC2
+MESH	D000077022	Survivin	HGNC	593	BIRC5
+MESH	D000077143	Docetaxel	CHEBI	CHEBI:4672	docetaxel anhydrous
+MESH	D000077145	Sulfanilamide	CHEBI	CHEBI:45373	sulfanilamide
+MESH	D000077149	Sevoflurane	CHEBI	CHEBI:9130	sevoflurane
+MESH	D000077150	Oxaliplatin	CHEBI	CHEBI:31941	oxaliplatin
+MESH	D000077152	Olanzapine	CHEBI	CHEBI:7735	olanzapine
+MESH	D000077153	Progranulins	HGNC	4601	GRN
+MESH	D000077157	Sorafenib	CHEBI	CHEBI:50924	sorafenib
+MESH	D000077185	Resveratrol	CHEBI	CHEBI:27881	resveratrol
+MESH	D000077190	Interferon alpha-2	HGNC	5423	IFNA2
+MESH	D000077204	Temozolomide	CHEBI	CHEBI:72564	temozolomide
+MESH	D000077205	Pioglitazone	CHEBI	CHEBI:8228	pioglitazone
+MESH	D000077208	Remifentanil	CHEBI	CHEBI:8802	remifentanil
+MESH	D000077210	Sunitinib	CHEBI	CHEBI:38940	sunitinib
+MESH	D000077212	Ropivacaine	CHEBI	CHEBI:8890	(S)-ropivacaine
+MESH	D000077214	Becaplermin	HGNC	8800	PDGFB
+MESH	D000077214	Becaplermin	FPLX	PDGF_BB	PDGF_BB
+MESH	D000077222	Limonene	CHEBI	CHEBI:15384	limonene
+MESH	D000077236	Topiramate	CHEBI	CHEBI:63631	topiramate
+MESH	D000077237	Arsenic Trioxide	CHEBI	CHEBI:30621	diarsenic trioxide
+MESH	D000077261	Carvedilol	CHEBI	CHEBI:3441	carvedilol
+MESH	D000077266	Moxifloxacin	CHEBI	CHEBI:63611	moxifloxacin
+MESH	D000077269	Lenalidomide	CHEBI	CHEBI:63791	lenalidomide
+MESH	D000077271	Imiquimod	CHEBI	CHEBI:36704	imiquimod
+MESH	D000077276	Lycopene	CHEBI	CHEBI:15948	lycopene
+MESH	D000077286	Cetrimonium	CHEBI	CHEBI:39561	cetyltrimethylammonium ion
+MESH	D000077287	Levetiracetam	CHEBI	CHEBI:6437	levetiracetam
+MESH	D000077288	Troglitazone	CHEBI	CHEBI:9753	troglitazone
+MESH	D000077289	Letrozole	CHEBI	CHEBI:6413	letrozole
+MESH	D000077293	Receptor, Transforming Growth Factor-beta Type I	HGNC	11772	TGFBR1
+MESH	D000077294	Receptor, Transforming Growth Factor-beta Type II	HGNC	11773	TGFBR2
+MESH	D000077297	Pregnane X Receptor	HGNC	7968	NR1I2
+MESH	D000077333	Telmisartan	CHEBI	CHEBI:9434	telmisartan
+MESH	D000077335	Desflurane	CHEBI	CHEBI:4445	desflurane
+MESH	D000077339	Leflunomide	CHEBI	CHEBI:6402	leflunomide
+MESH	D000077385	Silybin	CHEBI	CHEBI:9144	silibinin
+MESH	D000077404	Cidofovir	CHEBI	CHEBI:3696	cidofovir anhydrous
+MESH	D000077405	Irbesartan	CHEBI	CHEBI:5959	irbesartan
+MESH	D000077409	Tamsulosin	CHEBI	CHEBI:9398	tamsulosin
+MESH	D000077410	Aluminum Chloride	CHEBI	CHEBI:30114	aluminium trichloride
+MESH	D000077422	Enrofloxacin	CHEBI	CHEBI:35720	enrofloxacin
+MESH	D000077423	Polidocanol	CHEBI	CHEBI:46859	polidocanol
+MESH	D000077430	Nabumetone	CHEBI	CHEBI:7443	nabumetone
+MESH	D000077443	Acamprosate	CHEBI	CHEBI:51041	acamprosate
+MESH	D000077465	Cabergoline	CHEBI	CHEBI:3286	cabergoline
+MESH	D000077484	Vemurafenib	CHEBI	CHEBI:63637	vemurafenib
+MESH	D000077489	Piperazine	CHEBI	CHEBI:28568	piperazine
+MESH	D000077543	Deferiprone	CHEBI	CHEBI:68554	deferiprone
+MESH	D000077545	Eplerenone	CHEBI	CHEBI:31547	eplerenone
+MESH	D000077546	Roscovitine	CHEBI	CHEBI:45307	seliciclib
+MESH	D000077553	Edaravone	CHEBI	CHEBI:31530	edaravone
+MESH	D000077554	Levobupivacaine	CHEBI	CHEBI:6149	levobupivacaine
+MESH	D000077556	Alitretinoin	CHEBI	CHEBI:50648	9-cis-retinoic acid
+MESH	D000077582	Amisulpride	CHEBI	CHEBI:64045	amisulpride
+MESH	D000077583	Quinapril	CHEBI	CHEBI:8713	quinapril
+MESH	D000077590	Mivacurium	CHEBI	CHEBI:6958	Mivacurium
+MESH	D000077591	Eucalyptol	CHEBI	CHEBI:27961	1,8-cineole
+MESH	D000077602	Tolvaptan	CHEBI	CHEBI:32246	Tolvaptan
+MESH	D000077604	Fomepizole	CHEBI	CHEBI:5141	fomepizole
+MESH	D000077613	Etoricoxib	CHEBI	CHEBI:6339	etoricoxib
+MESH	D000077723	Cefepime	CHEBI	CHEBI:478164	cefepime
+MESH	D000077731	Meropenem	CHEBI	CHEBI:43968	meropenem
+MESH	D000077732	Fidaxomicin	CHEBI	CHEBI:68590	fidaxomicin
+MESH	D000077769	Rilmenidine	CHEBI	CHEBI:8862	Rilmenidine
+MESH	D000077771	Methantheline	CHEBI	CHEBI:6817	Methantheline
+MESH	D000077786	Torsemide	CHEBI	CHEBI:9637	torasemide
+MESH	D000077863	Homoharringtonine	CHEBI	CHEBI:71019	omacetaxine mepesuccinate
+MESH	D000077922	Thiamethoxam	CHEBI	CHEBI:39185	thiamethoxam
+MESH	D000078102	Lumefantrine	CHEBI	CHEBI:156095	lumefantrine
+MESH	D000078223	5-Methoxypsoralen	CHEBI	CHEBI:18293	5-methoxypsoralen
+MESH	D000078224	Lenograstim	HGNC	2438	CSF3
+MESH	D000078328	Felbamate	CHEBI	CHEBI:4995	felbamate
+MESH	D000078330	Oxcarbazepine	CHEBI	CHEBI:7824	oxcarbazepine
+MESH	D000078785	Mirtazapine	CHEBI	CHEBI:6950	mirtazapine
+MESH	D000078787	Neuroglobin	HGNC	14077	NGB
+MESH	D000078792	Midkine	HGNC	6972	MDK
+MESH	D000078842	Cytoglobin	HGNC	16505	CYGB
+MESH	D000079	Acetaldehyde	CHEBI	CHEBI:15343	acetaldehyde
+MESH	D000082	Acetaminophen	CHEBI	CHEBI:46195	paracetamol
+MESH	D000086	Acetazolamide	CHEBI	CHEBI:27690	acetazolamide
+MESH	D000093	Acetoin	CHEBI	CHEBI:15688	acetoin
+MESH	D000096	Acetone	CHEBI	CHEBI:15347	acetone
+MESH	D000099	Acetoxyacetylaminofluorene	CHEBI	CHEBI:76331	N-acetoxy-2-acetamidofluorene
 MESH	D000103	Acetyl-CoA Carboxylase	FPLX	ACC	ACC
+MESH	D000109	Acetylcholine	CHEBI	CHEBI:15355	acetylcholine
 MESH	D000110	Acetylcholinesterase	HGNC	108	ACHE
+MESH	D000114	Acetylene	CHEBI	CHEBI:27518	acetylene
 MESH	D000115	Acetylesterase	HGNC	18717	ABHD2
+MESH	D000117	Acetylglucosamine	CHEBI	CHEBI:28009	N-acetyl-beta-D-glucosamine
 MESH	D000121	Acetylserotonin O-Methyltransferase	HGNC	750	ASMT
+MESH	D000157	Aconitine	CHEBI	CHEBI:2430	aconitine
+MESH	D000165	Acridine Orange	CHEBI	CHEBI:87346	acridine orange free base
+MESH	D000165	Acridine Orange	CHEBI	CHEBI:51739	acridine orange
+MESH	D000171	Acrolein	CHEBI	CHEBI:15368	acrolein
+MESH	D000175	Acronine	CHEBI	CHEBI:2437	acronycine
 MESH	D000176	Acrosin	HGNC	126	ACR
+MESH	D000181	Acrylonitrile	CHEBI	CHEBI:28217	acrylonitrile
+MESH	D000225	Adenine	CHEBI	CHEBI:16708	adenine
+MESH	D000241	Adenosine	CHEBI	CHEBI:16335	adenosine
+MESH	D000242	Cyclic AMP	CHEBI	CHEBI:17489	3',5'-cyclic AMP
+MESH	D000245	Adenosine Diphosphate Glucose	CHEBI	CHEBI:15751	ADP alpha-D-glucoside
+MESH	D000246	Adenosine Diphosphate Ribose	CHEBI	CHEBI:16960	ADP-D-ribose
 MESH	D000263	Adenylate Kinase	HGNC	361	AK1
 MESH	D000264	Adenylosuccinate Lyase	HGNC	291	ADSL
+MESH	D000266	Adenylyl Imidodiphosphate	CHEBI	CHEBI:47785	AMP-PNP
 MESH	D000324	Adrenocorticotropic Hormone	HGNC	9201	POMC
+MESH	D000376	Agmatine	CHEBI	CHEBI:17431	agmatine
+MESH	D000404	Ajmaline	CHEBI	CHEBI:28462	ajmaline
+MESH	D000420	Albuterol	CHEBI	CHEBI:2549	albuterol
+MESH	D000431	Ethanol	CHEBI	CHEBI:16236	ethanol
+MESH	D000432	Methanol	CHEBI	CHEBI:17790	methanol
+MESH	D000433	1-Propanol	CHEBI	CHEBI:28831	propan-1-ol
+MESH	D000443	Alcuronium	CHEBI	CHEBI:55313	alcuronium
+MESH	D000448	Aldicarb	CHEBI	CHEBI:2555	aldicarb
+MESH	D000450	Aldosterone	CHEBI	CHEBI:27584	aldosterone
+MESH	D000464	Alginates	CHEBI	CHEBI:17548	alginic acid
+MESH	D000481	Allantoin	CHEBI	CHEBI:15676	allantoin
+MESH	D000487	Allethrin	CHEBI	CHEBI:34572	allethrin
+MESH	D000493	Allopurinol	CHEBI	CHEBI:40279	allopurinol
+MESH	D000500	Allylestrenol	CHEBI	CHEBI:31189	Allylestrenol
+MESH	D000514	alpha 1-Antichymotrypsin	HGNC	16	SERPINA3
+MESH	D000515	alpha 1-Antitrypsin	HGNC	8941	SERPINA1
 MESH	D000519	alpha-Galactosidase	HGNC	4296	GLA
+MESH	D000523	Algestone	CHEBI	CHEBI:763	algestone
+MESH	D000525	Alprazolam	CHEBI	CHEBI:2611	alprazolam
+MESH	D000526	Alprenolol	CHEBI	CHEBI:51211	alprenolol
+MESH	D000527	Alprostadil	CHEBI	CHEBI:15544	prostaglandin E1
+MESH	D000547	Amantadine	CHEBI	CHEBI:2618	amantadine
+MESH	D000576	Americium	CHEBI	CHEBI:33389	americium atom
 MESH	D000582	Amidophosphoribosyltransferase	HGNC	9238	PPAT
-MESH	D000803	Angiotensin I	HGNC	333	AGT
-MESH	D000804	Angiotensin II	HGNC	333	AGT
-MESH	D000805	Angiotensin III	HGNC	333	AGT
-MESH	D000808	Angiotensinogen	HGNC	333	AGT
+MESH	D000583	Amikacin	CHEBI	CHEBI:2637	amikacin
+MESH	D000584	Amiloride	CHEBI	CHEBI:2639	amiloride
+MESH	D000615	Aminoethylphosphonic Acid	CHEBI	CHEBI:15573	(2-aminoethyl)phosphonic acid
+MESH	D000629	Aminopropionitrile	CHEBI	CHEBI:27413	beta-aminopropionitrile
+MESH	D000632	Aminopyrine	CHEBI	CHEBI:160246	aminophenazone
+MESH	D000638	Amiodarone	CHEBI	CHEBI:2663	amiodarone
+MESH	D000639	Amitriptyline	CHEBI	CHEBI:2666	amitriptyline
+MESH	D000640	Amitrole	CHEBI	CHEBI:40036	amitrole
+MESH	D000641	Ammonia	CHEBI	CHEBI:16134	ammonia
+MESH	D000650	Amnion	CHEBI	CHEBI:73806	Ala-Met
+MESH	D000654	Amobarbital	CHEBI	CHEBI:2673	amobarbital
+MESH	D000655	Amodiaquine	CHEBI	CHEBI:2674	amodiaquine
+MESH	D000657	Amoxapine	CHEBI	CHEBI:2675	amoxapine
+MESH	D000658	Amoxicillin	CHEBI	CHEBI:2676	amoxicillin
+MESH	D000661	Amphetamine	CHEBI	CHEBI:2679	amphetamine
+MESH	D000667	Ampicillin	CHEBI	CHEBI:28971	ampicillin
+MESH	D000675	Ampyrone	CHEBI	CHEBI:59026	4-aminoantipyrine
+MESH	D000677	Amsacrine	CHEBI	CHEBI:2687	amsacrine
+MESH	D000687	Amylopectin	CHEBI	CHEBI:28057	amylopectin
+MESH	D000688	Amylose	CHEBI	CHEBI:28102	amylose
+MESH	D000691	Anabasine	CHEBI	CHEBI:74	(S)-anabasine
+MESH	D000735	Androstenedione	CHEBI	CHEBI:16422	androst-4-ene-3,17-dione
+MESH	D000738	Androsterone	CHEBI	CHEBI:16032	androsterone
+MESH	D000781	Anethole Trithione	CHEBI	CHEBI:31221	Anetholtrithion
+MESH	D000841	Anisomycin	CHEBI	CHEBI:338412	(-)-anisomycin
+MESH	D000894	Anti-Inflammatory Agents, Non-Steroidal	CHEBI	CHEBI:35475	non-steroidal anti-inflammatory drug
 MESH	D000979	alpha-2-Antiplasmin	HGNC	9075	SERPINF2
+MESH	D000983	Antipyrine	CHEBI	CHEBI:31225	antipyrine
 MESH	D000990	Antithrombin III	HGNC	775	SERPINC1
+MESH	D001032	Apazone	CHEBI	CHEBI:38010	apazone
 MESH	D001053	Apolipoproteins	FPLX	Apolipoprotein	Apolipoprotein
 MESH	D001054	Apolipoproteins A	FPLX	APOA	APOA
 MESH	D001057	Apolipoproteins E	HGNC	613	APOE
+MESH	D001074	Propoxur	CHEBI	CHEBI:34938	propoxur
+MESH	D001104	Arbutin	CHEBI	CHEBI:18305	hydroquinone O-beta-D-glucopyranoside
 MESH	D001141	Aromatase	HGNC	2594	CYP19A1
+MESH	D001151	Arsenic	CHEBI	CHEBI:27563	arsenic atom
+MESH	D001153	Arsphenamine	CHEBI	CHEBI:9016	arsphenamine
 MESH	D001227	Aspartylglucosylaminase	HGNC	318	AGA
+MESH	D001241	Aspirin	CHEBI	CHEBI:15365	acetylsalicylic acid
+MESH	D001278	Atractyloside	CHEBI	CHEBI:2913	Atractyloside
+MESH	D001279	Atracurium	CHEBI	CHEBI:2914	atracurium
+MESH	D001280	Atrazine	CHEBI	CHEBI:15930	atrazine
+MESH	D001285	Atropine	CHEBI	CHEBI:16684	atropine
+MESH	D001374	Azacitidine	CHEBI	CHEBI:2038	5-azacytidine
+MESH	D001375	Azaguanine	CHEBI	CHEBI:63486	8-azaguanine
+MESH	D001380	Azauridine	CHEBI	CHEBI:35668	6-azauridine
+MESH	D001387	Azinphosmethyl	CHEBI	CHEBI:2953	azinphos-methyl
+MESH	D001455	Bambermycins	CHEBI	CHEBI:28908	bambermycin
+MESH	D001462	Barbital	CHEBI	CHEBI:31252	5,5-diethylbarbituric acid
+MESH	D001507	Beclomethasone	CHEBI	CHEBI:3001	beclomethasone
+MESH	D001539	Bendroflumethiazide	CHEBI	CHEBI:3013	bendroflumethiazide
+MESH	D001542	Benomyl	CHEBI	CHEBI:3015	benomyl
+MESH	D001553	Benzbromarone	CHEBI	CHEBI:3023	benzbromarone
+MESH	D001554	Benzene	CHEBI	CHEBI:16716	benzene
+MESH	D001564	Benzo(a)pyrene	CHEBI	CHEBI:29865	benzo[a]pyrene
+MESH	D001566	Benzocaine	CHEBI	CHEBI:116735	benzocaine
+MESH	D001573	Benzoin	CHEBI	CHEBI:17682	benzoin
+MESH	D001581	Benzothiadiazines	CHEBI	CHEBI:50265	benzothiadiazine
+MESH	D001589	Benzphetamine	CHEBI	CHEBI:3044	benzphetamine
+MESH	D001590	Benztropine	CHEBI	CHEBI:3048	benzatropine
+MESH	D001599	Berberine	CHEBI	CHEBI:16118	berberine
+MESH	D001603	Berkelium	CHEBI	CHEBI:33391	berkelium atom
+MESH	D001608	Beryllium	CHEBI	CHEBI:30501	beryllium atom
+MESH	D001622	Betaine	CHEBI	CHEBI:17750	glycine betaine
+MESH	D001623	Betamethasone	CHEBI	CHEBI:3077	betamethasone
+MESH	D001640	Bicuculline	CHEBI	CHEBI:3092	bicuculline
+MESH	D001663	Bilirubin	CHEBI	CHEBI:16990	bilirubin IXalpha
+MESH	D001664	Biliverdine	CHEBI	CHEBI:17033	biliverdin
+MESH	D001726	Bisacodyl	CHEBI	CHEBI:3125	Bisacodyl
+MESH	D001728	Dicumarol	CHEBI	CHEBI:4513	dicoumarol
+MESH	D001735	Bithionol	CHEBI	CHEBI:3131	bithionol
+MESH	D001737	Biuret	CHEBI	CHEBI:18138	biuret
+MESH	D001895	Boron	CHEBI	CHEBI:27560	boron atom
+MESH	D001960	Bromazepam	CHEBI	CHEBI:31302	Bromazepam
+MESH	D001968	Bromisovalum	CHEBI	CHEBI:31304	bromisoval
+MESH	D001971	Bromocriptine	CHEBI	CHEBI:3181	bromocriptine
+MESH	D001973	Bromodeoxyuridine	CHEBI	CHEBI:472552	5-bromo-2'-deoxyuridine
+MESH	D001974	Bromosuccinimide	CHEBI	CHEBI:53174	N-bromosuccinimide
+MESH	D001977	Brompheniramine	CHEBI	CHEBI:3183	brompheniramine
+MESH	D002026	Buformin	CHEBI	CHEBI:3209	Buformin
+MESH	D002027	Bufotenin	CHEBI	CHEBI:3210	bufotenin
+MESH	D002040	Levobunolol	CHEBI	CHEBI:6438	levobunolol
+MESH	D002045	Bupivacaine	CHEBI	CHEBI:3215	bupivacaine
+MESH	D002047	Buprenorphine	CHEBI	CHEBI:3216	buprenorphine
+MESH	D002049	Burimamide	CHEBI	CHEBI:3221	Burimamide
+MESH	D002065	Buspirone	CHEBI	CHEBI:3223	buspirone
+MESH	D002066	Busulfan	CHEBI	CHEBI:28901	busulfan
+MESH	D002077	Butorphanol	CHEBI	CHEBI:3242	butorphanol
+MESH	D002083	Butylated Hydroxyanisole	CHEBI	CHEBI:76359	butylated hydroxyanisole
+MESH	D002084	Butylated Hydroxytoluene	CHEBI	CHEBI:34247	2,6-di-tert-butyl-4-methylphenol
 MESH	D002091	Butyrylcholinesterase	HGNC	983	BCHE
+MESH	D002103	Cadaverine	CHEBI	CHEBI:18127	cadaverine
+MESH	D002110	Caffeine	CHEBI	CHEBI:27732	caffeine
+MESH	D002112	Calcifediol	CHEBI	CHEBI:17933	calcidiol
+MESH	D002116	Calcitonin	HGNC	1437	CALCA
+MESH	D002117	Calcitriol	CHEBI	CHEBI:17823	calcitriol
+MESH	D002125	Calcium Gluconate	CHEBI	CHEBI:3309	Calcium Gluconate
 MESH	D002147	Calmodulin	FPLX	CALM	CALM
+MESH	D002164	Camphor	CHEBI	CHEBI:36773	camphor
+MESH	D002166	Camptothecin	CHEBI	CHEBI:27656	camptothecin
+MESH	D002174	Candicidin	CHEBI	CHEBI:354984	candicidin
+MESH	D002187	Cannabinol	CHEBI	CHEBI:3360	Cannabinol
+MESH	D002193	Cantharidin	CHEBI	CHEBI:64213	cantharidin
+MESH	D002211	Capsaicin	CHEBI	CHEBI:3374	capsaicin
+MESH	D002225	Carbazilquinone	CHEBI	CHEBI:31356	Carboquone
+MESH	D002235	Carbofuran	CHEBI	CHEBI:34611	carbofuran
+MESH	D002244	Carbon	CHEBI	CHEBI:27594	carbon atom
+MESH	D002251	Carbon Tetrachloride	CHEBI	CHEBI:27385	tetrachloromethane
+MESH	D002258	Carbonyl Cyanide m-Chlorophenyl Hydrazone	CHEBI	CHEBI:3259	CCCP
+MESH	D002259	Carbonyl Cyanide p-Trifluoromethoxyphenylhydrazone	CHEBI	CHEBI:75458	carbonyl cyanide p-trifluoromethoxyphenylhydrazone
+MESH	D002260	Carboprost	CHEBI	CHEBI:3403	carboprost
+MESH	D002261	Carboxin	CHEBI	CHEBI:3405	carboxin
+MESH	D002308	Cardiolipins	CHEBI	CHEBI:28494	cardiolipin
+MESH	D002323	Carfecillin	CHEBI	CHEBI:3414	carfecillin
+MESH	D002328	Carisoprodol	CHEBI	CHEBI:3419	carisoprodol
+MESH	D002329	Carmine	CHEBI	CHEBI:78310	carminic acid
+MESH	D002330	Carmustine	CHEBI	CHEBI:3423	carmustine
+MESH	D002351	Carrageenan	CHEBI	CHEBI:3435	carrageenan
+MESH	D002354	Carteolol	CHEBI	CHEBI:3437	carteolol
+MESH	D002360	Carubicin	CHEBI	CHEBI:31359	carminomycin
 MESH	D002374	Catalase	HGNC	1516	CAT
+MESH	D002392	Catechin	CHEBI	CHEBI:15600	(+)-catechin
 MESH	D002401	Cathepsin B	HGNC	2527	CTSB
 MESH	D002402	Cathepsin D	HGNC	2529	CTSD
+MESH	D002433	Cefaclor	CHEBI	CHEBI:3478	cefaclor
+MESH	D002435	Cefamandole	CHEBI	CHEBI:3480	cefamandole
+MESH	D002437	Cefazolin	CHEBI	CHEBI:474053	cefazolin
+MESH	D002438	Cefoperazone	CHEBI	CHEBI:3493	cefoperazone
+MESH	D002439	Cefotaxime	CHEBI	CHEBI:3498	cefotaxime sodium
+MESH	D002440	Cefoxitin	CHEBI	CHEBI:209807	cefoxitin
+MESH	D002441	Cefsulodin	CHEBI	CHEBI:3507	cefsulodin
+MESH	D002442	Ceftazidime	CHEBI	CHEBI:3509	ceftazidime pentahydrate
+MESH	D002444	Cefuroxime	CHEBI	CHEBI:3515	cefuroxime
+MESH	D002475	Cellobiose	CHEBI	CHEBI:17057	cellobiose
+MESH	D002482	Cellulose	CHEBI	CHEBI:18246	(1->4)-beta-D-glucan
+MESH	D002504	Meclofenoxate	CHEBI	CHEBI:6712	Meclofenoxate
+MESH	D002506	Cephalexin	CHEBI	CHEBI:3534	cephalexin
+MESH	D002506	Cephalexin	CHEBI	CHEBI:3535	cephalexin monohydrate
+MESH	D002507	Cephaloglycin	CHEBI	CHEBI:34613	cefaloglycin
+MESH	D002509	Cephaloridine	CHEBI	CHEBI:3537	cefaloridine
+MESH	D002512	Cephalothin	CHEBI	CHEBI:124991	cefalotin
+MESH	D002515	Cephradine	CHEBI	CHEBI:3547	cephradine
 MESH	D002553	Cerebroside-Sulfatase	HGNC	713	ARSA
+MESH	D002569	Cerulenin	CHEBI	CHEBI:171741	cerulenin
 MESH	D002570	Ceruloplasmin	HGNC	2295	CP
+MESH	D002599	Chalcone	CHEBI	CHEBI:27618	chalcone
+MESH	D002635	Chenodeoxycholic Acid	CHEBI	CHEBI:16755	chenodeoxycholic acid
+MESH	D002686	Chitin	CHEBI	CHEBI:17029	chitin
+MESH	D002698	Chloralose	CHEBI	CHEBI:81902	Chloralose
+MESH	D002699	Chlorambucil	CHEBI	CHEBI:28830	chlorambucil
+MESH	D002701	Chloramphenicol	CHEBI	CHEBI:17698	chloramphenicol
+MESH	D002703	Chloranil	CHEBI	CHEBI:36703	tetrachloro-1,4-benzoquinone
+MESH	D002706	Chlordan	CHEBI	CHEBI:34623	chlordane
+MESH	D002710	Chlorhexidine	CHEBI	CHEBI:3614	chlorhexidine
+MESH	D002725	Chloroform	CHEBI	CHEBI:35255	chloroform
+MESH	D002727	Proguanil	CHEBI	CHEBI:8455	proguanil
+MESH	D002731	4-Chloromercuribenzenesulfonate	CHEBI	CHEBI:33206	p-chloromercuribenzenesulfonic acid
+MESH	D002738	Chloroquine	CHEBI	CHEBI:3638	chloroquine
+MESH	D002740	Chlorothiazide	CHEBI	CHEBI:3640	chlorothiazide
+MESH	D002742	Chlorphenamidine	CHEBI	CHEBI:34629	chlordimeform
+MESH	D002743	Chlorphenesin	CHEBI	CHEBI:3642	chlorphenesin
+MESH	D002744	Chlorpheniramine	CHEBI	CHEBI:52010	chlorphenamine
+MESH	D002745	Chlorphentermine	CHEBI	CHEBI:3646	Chlorphentermine
+MESH	D002746	Chlorpromazine	CHEBI	CHEBI:3647	chlorpromazine
+MESH	D002749	Chlorprothixene	CHEBI	CHEBI:3651	chlorprothixene
+MESH	D002752	Chlorthalidone	CHEBI	CHEBI:3654	chlorthalidone
+MESH	D002753	Chlorzoxazone	CHEBI	CHEBI:3655	chlorzoxazone
+MESH	D002762	Cholecalciferol	CHEBI	CHEBI:28940	calciol
 MESH	D002766	Cholecystokinin	HGNC	1569	CCK
+MESH	D002784	Cholesterol	CHEBI	CHEBI:16113	cholesterol
 MESH	D002786	Cholesterol Side-Chain Cleavage Enzyme	HGNC	2590	CYP11A1
 MESH	D002790	Cholesterol 7-alpha-Hydroxylase	HGNC	2651	CYP7A1
+MESH	D002794	Choline	CHEBI	CHEBI:15354	choline
 MESH	D002802	Cholinesterases	HGNC	983	BCHE
+MESH	D002807	Chondroitin	CHEBI	CHEBI:16137	chondroitin D-glucuronate
 MESH	D002811	Chondroitinsulfatases	HGNC	4122	GALNS
+MESH	D002857	Chromium	CHEBI	CHEBI:28073	chromium atom
+MESH	D002936	Cinnarizine	CHEBI	CHEBI:31403	cinnarizine
+MESH	D002939	Ciprofloxacin	CHEBI	CHEBI:100241	ciprofloxacin
+MESH	D002945	Cisplatin	CHEBI	CHEBI:27899	cisplatin
+MESH	D002974	Clemastine	CHEBI	CHEBI:3738	clemastine
+MESH	D002981	Clindamycin	CHEBI	CHEBI:3745	clindamycin
+MESH	D002994	Clofibrate	CHEBI	CHEBI:3750	clofibrate
+MESH	D002996	Clomiphene	CHEBI	CHEBI:3752	clomiphene
+MESH	D002997	Clomipramine	CHEBI	CHEBI:47780	clomipramine
+MESH	D003022	Clotrimazole	CHEBI	CHEBI:3764	clotrimazole
+MESH	D003023	Cloxacillin	CHEBI	CHEBI:49566	cloxacillin
+MESH	D003024	Clozapine	CHEBI	CHEBI:3766	clozapine
+MESH	D003042	Cocaine	CHEBI	CHEBI:27958	cocaine
+MESH	D003061	Codeine	CHEBI	CHEBI:16714	codeine
+MESH	D003070	Coformycin	CHEBI	CHEBI:16213	coformycin
+MESH	D003078	Colchicine	CHEBI	CHEBI:27882	(S)-colchicine
+MESH	D003084	Colestipol	CHEBI	CHEBI:3814	colestipol
+MESH	D003101	Collodion	CHEBI	CHEBI:53325	nitrocellulose
 MESH	D003175	Complement C2	HGNC	1248	C2
 MESH	D003176	Complement C3	HGNC	1318	C3
 MESH	D003182	Complement C5	HGNC	1331	C5
+MESH	D003224	Congo Red	CHEBI	CHEBI:34653	Congo Red
+MESH	D003300	Copper	CHEBI	CHEBI:28694	copper atom
 MESH	D003304	Coproporphyrinogen Oxidase	HGNC	2321	CPOX
+MESH	D003345	Corticosterone	CHEBI	CHEBI:16827	corticosterone
 MESH	D003346	Corticotropin-Releasing Hormone	HGNC	2355	CRH
+MESH	D003348	Cortisone	CHEBI	CHEBI:16962	cortisone
+MESH	D003350	Cortodoxone	CHEBI	CHEBI:28324	11-deoxycortisol
+MESH	D003372	Coumaphos	CHEBI	CHEBI:3903	coumaphos
+MESH	D003375	Coumestrol	CHEBI	CHEBI:3908	coumestrol
+MESH	D003404	Creatinine	CHEBI	CHEBI:16737	creatinine
+MESH	D003474	Curcumin	CHEBI	CHEBI:3962	curcumin
+MESH	D003484	Cyanamide	CHEBI	CHEBI:16698	cyanamide
+MESH	D003492	Cycasin	CHEBI	CHEBI:17074	cycasin
+MESH	D003493	Cyclacillin	CHEBI	CHEBI:31444	cyclacillin
+MESH	D003494	Cyclamates	CHEBI	CHEBI:82431	Cyclamate
+MESH	D003501	Cyclizine	CHEBI	CHEBI:3994	cyclizine
+MESH	D003504	Ancitabine	CHEBI	CHEBI:74843	ancitabine hydrochloride
+MESH	D003506	Cyclofenil	CHEBI	CHEBI:31446	Cyclofenil
+MESH	D003513	Cycloheximide	CHEBI	CHEBI:27641	cycloheximide
+MESH	D003519	Cyclopentolate	CHEBI	CHEBI:4024	cyclopentolate
+MESH	D003520	Cyclophosphamide	CHEBI	CHEBI:4026	cyclophosphamide hydrate
+MESH	D003529	Cymarine	CHEBI	CHEBI:4037	Cymarin
+MESH	D003533	Cyproheptadine	CHEBI	CHEBI:4046	cyproheptadine
+MESH	D003538	Cystamine	CHEBI	CHEBI:78757	cystamine
+MESH	D003543	Cysteamine	CHEBI	CHEBI:17141	cysteamine
+MESH	D003561	Cytarabine	CHEBI	CHEBI:28680	cytarabine
+MESH	D003562	Cytidine	CHEBI	CHEBI:17562	cytidine
+MESH	D003566	Cytidine Diphosphate Choline	CHEBI	CHEBI:16436	CDP-choline
+MESH	D003571	Cytochalasin B	CHEBI	CHEBI:23527	cytochalasin B
 MESH	D003575	Cytochromes c1	HGNC	2579	CYC1
+MESH	D003596	Cytosine	CHEBI	CHEBI:16040	cytosine
+MESH	D003606	Dacarbazine	CHEBI	CHEBI:4305	dacarbazine
+MESH	D003620	Dantrolene	CHEBI	CHEBI:4317	dantrolene
+MESH	D003622	Dapsone	CHEBI	CHEBI:4325	dapsone
+MESH	D003630	Daunorubicin	CHEBI	CHEBI:41977	daunorubicin
+MESH	D003632	Dichlorodiphenyldichloroethane	CHEBI	CHEBI:27841	DDD
+MESH	D003633	Dichlorodiphenyl Dichloroethylene	CHEBI	CHEBI:16598	DDE
+MESH	D003633	Dichlorodiphenyl Dichloroethylene	CHEBI	CHEBI:27454	1-chloro-2,2-bis(4'-chlorophenyl)ethylene
+MESH	D003634	DDT	CHEBI	CHEBI:16130	DDT
+MESH	D003642	Deanol	CHEBI	CHEBI:271436	N,N-dimethylethanolamine
+MESH	D003647	Debrisoquin	CHEBI	CHEBI:34665	debrisoquin
+MESH	D003671	DEET	CHEBI	CHEBI:7071	N,N-diethyl-m-toluamide
+MESH	D003676	Deferoxamine	CHEBI	CHEBI:4356	desferrioxamine B
+MESH	D003687	Dehydroepiandrosterone	CHEBI	CHEBI:28689	dehydroepiandrosterone
+MESH	D003707	Demeclocycline	CHEBI	CHEBI:4392	demeclocycline
+MESH	D003708	Nordazepam	CHEBI	CHEBI:111762	nordazepam
+MESH	D003841	Deoxycytidine	CHEBI	CHEBI:15698	2'-deoxycytidine
+MESH	D003846	Deoxyepinephrine	CHEBI	CHEBI:18243	dopamine
+MESH	D003847	Deoxyglucose	CHEBI	CHEBI:15866	2-deoxy-D-glucose
+MESH	D003849	Deoxyguanosine	CHEBI	CHEBI:17172	2'-deoxyguanosine
 MESH	D003850	Deoxyribonuclease I	HGNC	2956	DNASE1
+MESH	D003855	Deoxyribose	CHEBI	CHEBI:28816	2-deoxy-D-ribose
+MESH	D003857	Deoxyuridine	CHEBI	CHEBI:16450	2'-deoxyuridine
+MESH	D003871	Dermatan Sulfate	CHEBI	CHEBI:18376	dermatan sulfate
+MESH	D003891	Desipramine	CHEBI	CHEBI:47781	desipramine
 MESH	D003893	Desmin	HGNC	2770	DES
+MESH	D003897	Desmosterol	CHEBI	CHEBI:17737	desmosterol
+MESH	D003900	Desoxycorticosterone	CHEBI	CHEBI:16973	11-deoxycorticosterone
+MESH	D003902	Detergents	CHEBI	CHEBI:27780	detergent
+MESH	D003907	Dexamethasone	CHEBI	CHEBI:41879	dexamethasone
+MESH	D003913	Dextroamphetamine	CHEBI	CHEBI:4469	(S)-amphetamine
+MESH	D003915	Dextromethorphan	CHEBI	CHEBI:4470	dextromethorphan
+MESH	D003931	Diacetyl	CHEBI	CHEBI:16583	butane-2,3-dione
+MESH	D003932	Heroin	CHEBI	CHEBI:27808	heroin
+MESH	D003958	Diamide	CHEBI	CHEBI:48958	1,1'-azobis(N,N-dimethylformamide)
+MESH	D003962	Dianisidine	CHEBI	CHEBI:82321	3,3'-Dimethoxybenzidine
+MESH	D003973	Diatrizoate	CHEBI	CHEBI:53691	amidotrizoic acid
+MESH	D003975	Diazepam	CHEBI	CHEBI:49575	diazepam
+MESH	D003976	Diazinon	CHEBI	CHEBI:34682	diazinon
+MESH	D003981	Diazoxide	CHEBI	CHEBI:4495	diazoxide
+MESH	D003982	Dibekacin	CHEBI	CHEBI:37945	dibekacin
+MESH	D003992	Dibucaine	CHEBI	CHEBI:247956	cinchocaine
+MESH	D004003	Dichlorophen	CHEBI	CHEBI:34689	Dichlorophen
+MESH	D004005	Dichlorphenamide	CHEBI	CHEBI:101085	diclofenamide
+MESH	D004006	Dichlorvos	CHEBI	CHEBI:34690	dichlorvos
+MESH	D004008	Diclofenac	CHEBI	CHEBI:47381	diclofenac
+MESH	D004009	Dicloxacillin	CHEBI	CHEBI:4511	dicloxacillin
+MESH	D004010	Dicofol	CHEBI	CHEBI:34692	dicofol
+MESH	D004024	Dicyclohexylcarbodiimide	CHEBI	CHEBI:53090	1,3-dicyclohexylcarbodiimide
+MESH	D004025	Dicyclomine	CHEBI	CHEBI:4514	dicyclomine
+MESH	D004026	Dieldrin	CHEBI	CHEBI:34696	dieldrin
+MESH	D004028	Dienestrol	CHEBI	CHEBI:4518	dienestrol
+MESH	D004050	Ditiocarb	CHEBI	CHEBI:144353	diethyldithiocarbamic acid
+MESH	D004051	Diethylhexyl Phthalate	CHEBI	CHEBI:17747	bis(2-ethylhexyl) phthalate
+MESH	D004052	Diethylnitrosamine	CHEBI	CHEBI:34873	N-nitrosodiethylamine
+MESH	D004053	Diethylpropion	CHEBI	CHEBI:4530	diethylpropion
+MESH	D004054	Diethylstilbestrol	CHEBI	CHEBI:41922	diethylstilbestrol
+MESH	D004061	Diflunisal	CHEBI	CHEBI:39669	diflunisal
+MESH	D004072	Digitonin	CHEBI	CHEBI:27729	digitonin
+MESH	D004074	Digitoxin	CHEBI	CHEBI:28544	digitoxin
+MESH	D004087	Dihydroergotamine	CHEBI	CHEBI:4562	dihydroergotamine
+MESH	D004090	Dihydromorphine	CHEBI	CHEBI:4575	Dihydromorphine
+MESH	D004091	Hydromorphone	CHEBI	CHEBI:5790	hydromorphone
+MESH	D004097	Dihydrotachysterol	CHEBI	CHEBI:4591	dihydrotachysterol
+MESH	D004098	Dihydroxyacetone	CHEBI	CHEBI:16016	dihydroxyacetone
+MESH	D004113	Succimer	CHEBI	CHEBI:63623	succimer
+MESH	D004116	Dimethisterone	CHEBI	CHEBI:4606	Dimethisterone
+MESH	D004117	Dimethoate	CHEBI	CHEBI:34714	dimethoate
+MESH	D004118	Dimethoxyphenylethylamine	CHEBI	CHEBI:136995	3,4-dimethoxyphenylethylamine
+MESH	D004121	Dimethyl Sulfoxide	CHEBI	CHEBI:28262	dimethyl sulfoxide
+MESH	D004126	Dimethylformamide	CHEBI	CHEBI:17741	N,N-dimethylformamide
+MESH	D004128	Dimethylnitrosamine	CHEBI	CHEBI:35807	N-nitrosodimethylamine
+MESH	D004130	N,N-Dimethyltryptamine	CHEBI	CHEBI:28969	N,N-dimethyltryptamine
+MESH	D004132	Diflubenzuron	CHEBI	CHEBI:34703	diflubenzuron
+MESH	D004137	Dinitrochlorobenzene	CHEBI	CHEBI:34718	1-chloro-2,4-dinitrobenzene
+MESH	D004139	Dinitrofluorobenzene	CHEBI	CHEBI:53049	1-fluoro-2,4-dinitrobenzene
+MESH	D004159	Diphenylamine	CHEBI	CHEBI:4640	diphenylamine
+MESH	D004160	Diphenylcarbazide	CHEBI	CHEBI:4641	Diphenylcarbazide
+MESH	D004161	Diphenylhexatriene	CHEBI	CHEBI:51594	1,6-diphenylhexatriene
+MESH	D004174	Diprenorphine	CHEBI	CHEBI:4650	Diprenorphine
+MESH	D004177	Dipyrone	CHEBI	CHEBI:59033	metamizole sodium
+MESH	D004221	Disulfiram	CHEBI	CHEBI:4659	disulfiram
+MESH	D004226	Dithioerythritol	CHEBI	CHEBI:17456	dithioerythritol
+MESH	D004228	Dithionitrobenzoic Acid	CHEBI	CHEBI:86228	dithionitrobenzoic acid
+MESH	D004229	Dithiothreitol	CHEBI	CHEBI:18320	1,4-dithiothreitol
+MESH	D004237	Diuron	CHEBI	CHEBI:116509	diuron
+MESH	D004246	Dimethylphenylpiperazinium Iodide	CHEBI	CHEBI:4290	1,1-dimethyl-4-phenylpiperazinium iodide
+MESH	D004247	DNA	CHEBI	CHEBI:16991	deoxyribonucleic acid
+MESH	D004280	Dobutamine	CHEBI	CHEBI:4670	dobutamine
+MESH	D004286	Dolichol	CHEBI	CHEBI:16091	dolichol
+MESH	D004298	Dopamine	CHEBI	CHEBI:18243	dopamine
+MESH	D004315	Doxapram	CHEBI	CHEBI:681848	doxapram
+MESH	D004316	Doxepin	CHEBI	CHEBI:4710	doxepin
+MESH	D004317	Doxorubicin	CHEBI	CHEBI:28748	doxorubicin
+MESH	D004318	Doxycycline	CHEBI	CHEBI:50845	doxycycline
+MESH	D004369	Pentetic Acid	CHEBI	CHEBI:35739	pentetic acid
+MESH	D004376	Galactitol	CHEBI	CHEBI:16813	galactitol
+MESH	D004390	Chlorpyrifos	CHEBI	CHEBI:34631	chlorpyrifos
+MESH	D004394	Dydrogesterone	CHEBI	CHEBI:31527	dydrogesterone
+MESH	D004400	Dyphylline	CHEBI	CHEBI:4728	dyphylline
+MESH	D004440	Ecdysone	CHEBI	CHEBI:16688	ecdysone
+MESH	D004441	Ecdysterone	CHEBI	CHEBI:16587	20-hydroxyecdysone
+MESH	D004464	Econazole	CHEBI	CHEBI:4754	econazole
+MESH	D004491	Edrophonium	CHEBI	CHEBI:251408	edrophonium
+MESH	D004533	Egtazic Acid	CHEBI	CHEBI:30740	ethylene glycol bis(2-aminoethyl)tetraacetic acid
 MESH	D004549	Elastin	HGNC	3327	ELN
+MESH	D004562	Electrocardiography	CHEBI	CHEBI:70255	(-)-epicatechin-3-O-gallate
+MESH	D004569	Electroencephalography	CHEBI	CHEBI:73494	Glu-Glu-Gly
+MESH	D004640	Emetine	CHEBI	CHEBI:4781	emetine
+MESH	D004642	Emodin	CHEBI	CHEBI:42223	emodin
+MESH	D004726	Endosulfan	CHEBI	CHEBI:4791	endosulfan
+MESH	D004732	Endrin	CHEBI	CHEBI:81526	Endrin
+MESH	D004737	Enflurane	CHEBI	CHEBI:4792	enflurane
 MESH	D004765	Enteropeptidase	HGNC	9490	TMPRSS15
+MESH	D004801	Eosine Yellowish-(YS)	CHEBI	CHEBI:52053	eosin YS dye
+MESH	D004809	Ephedrine	CHEBI	CHEBI:15407	(-)-ephedrine
+MESH	D004811	Epichlorohydrin	CHEBI	CHEBI:37144	epichlorohydrin
 MESH	D004815	Epidermal Growth Factor	HGNC	3229	EGF
+MESH	D004836	Epimestrol	CHEBI	CHEBI:34738	Epimestrol
+MESH	D004840	Epirizole	CHEBI	CHEBI:31545	Epirizole
+MESH	D004857	Equilin	CHEBI	CHEBI:42309	equilin
+MESH	D004874	Ergonovine	CHEBI	CHEBI:4822	ergometrine
+MESH	D004875	Ergosterol	CHEBI	CHEBI:16933	ergosterol
+MESH	D004896	Erythritol	CHEBI	CHEBI:17113	erythritol
+MESH	D004917	Erythromycin	CHEBI	CHEBI:42355	erythromycin A
 MESH	D004921	Erythropoietin	HGNC	3415	EPO
+MESH	D004923	Erythrosine	CHEBI	CHEBI:61000	erythrosin B
+MESH	D004928	Escin	CHEBI	CHEBI:2500	Aescin
+MESH	D004929	Esculin	CHEBI	CHEBI:4853	esculin
+MESH	D004958	Estradiol	CHEBI	CHEBI:16469	17beta-estradiol
+MESH	D004961	Estramustine	CHEBI	CHEBI:4868	estramustine
+MESH	D004964	Estriol	CHEBI	CHEBI:27974	estriol
+MESH	D004970	Estrone	CHEBI	CHEBI:17263	estrone
+MESH	D004977	Ethambutol	CHEBI	CHEBI:4877	ethambutol
+MESH	D004978	Ethamoxytriphetol	CHEBI	CHEBI:34748	Ethamoxytriphetol
+MESH	D004979	Ethamsylate	CHEBI	CHEBI:31563	Etamsylate
+MESH	D004980	Ethane	CHEBI	CHEBI:6015	isoflurane
+MESH	D004986	Ether	CHEBI	CHEBI:35702	diethyl ether
+MESH	D004999	Amifostine	CHEBI	CHEBI:2636	amifostine
+MESH	D005000	Ethionamide	CHEBI	CHEBI:4885	ethionamide
+MESH	D005013	Ethosuximide	CHEBI	CHEBI:4887	ethosuximide
+MESH	D005015	Ethoxyquin	CHEBI	CHEBI:77323	ethoxyquin
+MESH	D005031	Ethylenethiourea	CHEBI	CHEBI:34750	Ethylenethiourea
+MESH	D005033	Ethylmaleimide	CHEBI	CHEBI:44485	N-ethylmaleimide
+MESH	D005036	Ethylmorphine	CHEBI	CHEBI:4902	Ethylmorphine
+MESH	D005043	Etiocholanolone	CHEBI	CHEBI:28195	3alpha-hydroxy-5beta-androstan-17-one
+MESH	D005045	Etomidate	CHEBI	CHEBI:4910	etomidate
+MESH	D005047	Etoposide	CHEBI	CHEBI:4911	etoposide
+MESH	D005054	Eugenol	CHEBI	CHEBI:4917	eugenol
 MESH	D005167	Factor VII	HGNC	3544	F7
+MESH	D005204	Farnesol	CHEBI	CHEBI:28600	farnesol
+MESH	D005277	Fenfluramine	CHEBI	CHEBI:5000	fenfluramine
+MESH	D005278	Fenitrothion	CHEBI	CHEBI:34757	fenitrothion
+MESH	D005279	Fenoprofen	CHEBI	CHEBI:5004	fenoprofen
+MESH	D005284	Fenthion	CHEBI	CHEBI:34761	fenthion
 MESH	D005353	Fibronectins	HGNC	3778	FN1
+MESH	D005363	Ficusin	CHEBI	CHEBI:27616	psoralen
+MESH	D005372	Filipin	CHEBI	CHEBI:83267	filipin III
+MESH	D005422	Flavoxate	CHEBI	CHEBI:5088	flavoxate
+MESH	D005436	Floxacillin	CHEBI	CHEBI:5098	flucloxacillin
+MESH	D005437	Flucytosine	CHEBI	CHEBI:5100	flucytosine
+MESH	D005438	Fludrocortisone	CHEBI	CHEBI:50885	fludrocortisone
+MESH	D005443	Flumethasone	CHEBI	CHEBI:34764	flumethasone
+MESH	D005445	Flunitrazepam	CHEBI	CHEBI:31622	Flunitrazepam
+MESH	D005447	Fluocinonide	CHEBI	CHEBI:5109	Fluocinonide
+MESH	D005467	Floxuridine	CHEBI	CHEBI:60761	floxuridine
+MESH	D005472	Fluorouracil	CHEBI	CHEBI:46345	5-fluorouracil
+MESH	D005476	Fluphenazine	CHEBI	CHEBI:5123	fluphenazine
+MESH	D005478	Flurandrenolone	CHEBI	CHEBI:5127	Flurandrenolide
+MESH	D005480	Flurbiprofen	CHEBI	CHEBI:5130	flurbiprofen
+MESH	D005485	Flutamide	CHEBI	CHEBI:5132	flutamide
 MESH	D005486	Flavin Mononucleotide	HGNC	3768	FMN1
+MESH	D005557	Formaldehyde	CHEBI	CHEBI:16842	formaldehyde
 MESH	D005558	Arylformamidase	HGNC	20910	AFMID
+MESH	D005576	Colforsin	CHEBI	CHEBI:42471	forskolin
+MESH	D005578	Fosfomycin	CHEBI	CHEBI:28915	fosfomycin
+MESH	D005601	Framycetin	CHEBI	CHEBI:7508	framycetin
+MESH	D005632	Fructose	CHEBI	CHEBI:28757	fructose
+MESH	D005641	Tegafur	CHEBI	CHEBI:32188	Tegafur
+MESH	D005643	Fucose	CHEBI	CHEBI:33984	fucose
 MESH	D005647	Fucosyltransferases	FPLX	FUT	FUT
 MESH	D005649	Fumarate Hydratase	HGNC	3700	FH
+MESH	D005661	Furagin	CHEBI	CHEBI:131714	furagin
+MESH	D005662	Furaldehyde	CHEBI	CHEBI:34768	furfural
+MESH	D005664	Furazolidone	CHEBI	CHEBI:5195	furazolidone
+MESH	D005665	Furosemide	CHEBI	CHEBI:47426	furosemide
+MESH	D005668	Furylfuramide	CHEBI	CHEBI:15660	(Z)-2-(2-furyl)-3-(5-nitro-2-furyl)acrylamide
+MESH	D005677	G(M1) Ganglioside	CHEBI	CHEBI:61048	ganglioside GM1
+MESH	D005679	G(M3) Ganglioside	CHEBI	CHEBI:15681	alpha-N-acetylneuraminyl-(2->3)-beta-D-galactosyl-(1->4)-beta-D-glucosyl-(1<->1')-ceramide
 MESH	D005686	Galactokinase	HGNC	4118	GALK1
+MESH	D005688	Galactosamine	CHEBI	CHEBI:60312	2-amino-2-deoxy-D-galactopyranose
+MESH	D005690	Galactose	CHEBI	CHEBI:4139	D-galactopyranose
+MESH	D005690	Galactose	CHEBI	CHEBI:28260	galactose
 MESH	D005698	Galactosylceramidase	HGNC	4115	GALC
+MESH	D005702	Galantamine	CHEBI	CHEBI:42944	galanthamine
+MESH	D005711	Gallopamil	CHEBI	CHEBI:34772	Gallopamil
+MESH	D005778	Gefarnate	CHEBI	CHEBI:31646	Gefarnate
+MESH	D005867	Gestrinone	CHEBI	CHEBI:89642	Gestrinone
+MESH	D005897	Glafenine	CHEBI	CHEBI:31653	glafenine
+MESH	D005900	Glaucarubin	CHEBI	CHEBI:5370	Glaucarubin
+MESH	D005905	Glyburide	CHEBI	CHEBI:5441	glyburide
+MESH	D005907	Gliclazide	CHEBI	CHEBI:31654	gliclazide
+MESH	D005912	Gliotoxin	CHEBI	CHEBI:5385	gliotoxin
+MESH	D005913	Glipizide	CHEBI	CHEBI:5384	glipizide
+MESH	D005934	Glucagon	HGNC	4191	GCG
 MESH	D005941	Glucokinase	HGNC	4195	GCK
+MESH	D005944	Glucosamine	CHEBI	CHEBI:5417	glucosamine
+MESH	D005947	Glucose	CHEBI	CHEBI:4167	D-glucopyranose
+MESH	D005976	Glutaral	CHEBI	CHEBI:64276	glutaraldehyde
+MESH	D005984	Glutethimide	CHEBI	CHEBI:5439	Glutethimide
+MESH	D005985	Glyceraldehyde	CHEBI	CHEBI:5445	glyceraldehyde
 MESH	D005987	Glyceraldehyde-3-Phosphate Dehydrogenases	HGNC	4141	GAPDH
+MESH	D005990	Glycerol	CHEBI	CHEBI:17754	glycerol
 MESH	D005991	Glycerol Kinase	HGNC	4289	GK
+MESH	D005996	Nitroglycerin	CHEBI	CHEBI:28787	nitroglycerin
+MESH	D005997	Glycerylphosphorylcholine	CHEBI	CHEBI:16870	choline alfoscerate
+MESH	D006003	Glycogen	CHEBI	CHEBI:28087	glycogen
 MESH	D006021	Glycophorin	HGNC	4704	GYPC
+MESH	D006024	Glycopyrrolate	CHEBI	CHEBI:5494	ritropirronium bromide
+MESH	D006034	Glycyrrhetinic Acid	CHEBI	CHEBI:30853	glycyrrhetinic acid
+MESH	D006037	Glyoxal	CHEBI	CHEBI:34779	glyoxal
+MESH	D006046	Gold	CHEBI	CHEBI:29287	gold atom
+MESH	D006051	Aurothioglucose	CHEBI	CHEBI:2930	Aurothioglucose
+MESH	D006118	Griseofulvin	CHEBI	CHEBI:27779	griseofulvin
+MESH	D006139	Guaiacol	CHEBI	CHEBI:28591	guaiacol
+MESH	D006140	Guaifenesin	CHEBI	CHEBI:5551	Guaifenesin
+MESH	D006143	Guanabenz	CHEBI	CHEBI:5553	Guanabenz
+MESH	D006145	Guanethidine	CHEBI	CHEBI:5557	guanethidine
+MESH	D006147	Guanine	CHEBI	CHEBI:16235	guanine
 MESH	D006148	Guanine Deaminase	HGNC	4212	GDA
+MESH	D006151	Guanosine	CHEBI	CHEBI:16750	guanosine
+MESH	D006152	Cyclic GMP	CHEBI	CHEBI:16356	3',5'-cyclic GMP
+MESH	D006157	Guanosine Monophosphate	CHEBI	CHEBI:17345	guanosine 5'-monophosphate
+MESH	D006165	Guanylyl Imidodiphosphate	CHEBI	CHEBI:78408	guanosine 5'-[beta,gamma-imido]triphosphate
+MESH	D006206	Halcinonide	CHEBI	CHEBI:31663	Halcinonide
+MESH	D006221	Halothane	CHEBI	CHEBI:5615	halothane
 MESH	D006242	Haptoglobins	HGNC	5141	HP
+MESH	D006246	Harmaline	CHEBI	CHEBI:28172	harmaline
+MESH	D006247	Harmine	CHEBI	CHEBI:28121	harmine
+MESH	D006371	Helium	CHEBI	CHEBI:30217	helium atom
+MESH	D006418	Heme	CHEBI	CHEBI:17627	ferroheme b
+MESH	D006418	Heme	CHEBI	CHEBI:26355	heme b
+MESH	D006427	Hemin	CHEBI	CHEBI:50385	hemin
 MESH	D006466	Hemopexin	HGNC	5171	HPX
+MESH	D006492	Hempa	CHEBI	CHEBI:24565	hexamethylphosphoric triamide
+MESH	D006493	Heparin	CHEBI	CHEBI:28304	heparin
+MESH	D006531	HEPES	CHEBI	CHEBI:46756	HEPES
+MESH	D006533	Heptachlor	CHEBI	CHEBI:34785	heptachlor
+MESH	D006581	Hexachlorobenzene	CHEBI	CHEBI:5692	hexachlorobenzene
+MESH	D006591	Hexobarbital	CHEBI	CHEBI:5706	hexobarbital
+MESH	D006631	Amine Oxidase (Copper-Containing)	HGNC	80	AOC1
+MESH	D006632	Histamine	CHEBI	CHEBI:18295	histamine
 MESH	D006638	Histidine Ammonia-Lyase	HGNC	4806	HAL
 MESH	D006657	Histones	FPLX	Histone	Histone
 MESH	D006684	HLA-DR Antigens	FPLX	HLA_DR	HLA_DR
+MESH	D006690	Bisbenzimidazole	CHEBI	CHEBI:52082	pibenzimol
+MESH	D006697	Holothurin	CHEBI	CHEBI:80869	Holothurin
+MESH	D006826	Hycanthone	CHEBI	CHEBI:52768	hycanthone
+MESH	D006830	Hydralazine	CHEBI	CHEBI:5775	hydralazine
+MESH	D006853	Hydrocodone	CHEBI	CHEBI:5779	hydrocodone
+MESH	D006854	Hydrocortisone	CHEBI	CHEBI:17650	cortisol
+MESH	D006857	Hydroflumethiazide	CHEBI	CHEBI:5784	hydroflumethiazide
+MESH	D006859	Hydrogen	CHEBI	CHEBI:18276	dihydrogen
+MESH	D006879	Hydroxocobalamin	CHEBI	CHEBI:27786	hydroxocobalamin
+MESH	D006881	Hydroxyacetylaminofluorene	CHEBI	CHEBI:17931	N-hydroxy-2-acetamidofluorene
+MESH	D006893	Hydroxyeicosatetraenoic Acids	CHEBI	CHEBI:36275	HETE
+MESH	D006897	Hydroxyindoleacetic Acid	CHEBI	CHEBI:27823	(5-hydroxyindol-3-yl)acetic acid
+MESH	D006907	17-alpha-Hydroxypregnenolone	CHEBI	CHEBI:28750	17alpha-hydroxypregnenolone
+MESH	D006918	Hydroxyurea	CHEBI	CHEBI:44423	hydroxyurea
+MESH	D006919	Hydroxyzine	CHEBI	CHEBI:5818	hydroxyzine
+MESH	D006921	Hygromycin B	CHEBI	CHEBI:16976	hygromycin B
+MESH	D006923	Hymecromone	CHEBI	CHEBI:17224	4-methylumbelliferone
+MESH	D006923	Hymecromone	CHEBI	CHEBI:5679	herniarin
 MESH	D007041	Hypoxanthine Phosphoribosyltransferase	HGNC	5157	HPRT1
+MESH	D007050	Ibogaine	CHEBI	CHEBI:5852	Ibogaine
+MESH	D007052	Ibuprofen	CHEBI	CHEBI:5855	ibuprofen
+MESH	D007065	Idoxuridine	CHEBI	CHEBI:147675	5-iodo-2'-deoxyuridine
+MESH	D007069	Ifosfamide	CHEBI	CHEBI:5864	ifosfamide
+MESH	D007099	Imipramine	CHEBI	CHEBI:47499	imipramine
+MESH	D007190	Indapamide	CHEBI	CHEBI:5893	indapamide
+MESH	D007204	Indium	CHEBI	CHEBI:30430	indium atom
+MESH	D007213	Indomethacin	CHEBI	CHEBI:49662	indometacin
 MESH	D007265	Inhibins	FPLX	Inhibin	Inhibin
+MESH	D007288	Inosine	CHEBI	CHEBI:17596	inosine
+MESH	D007294	Inositol	CHEBI	CHEBI:17268	myo-inositol
 MESH	D007328	Insulin	HGNC	6081	INS
 MESH	D007334	Insulin-Like Growth Factor I	HGNC	5464	IGF1
 MESH	D007335	Insulin-Like Growth Factor II	HGNC	5466	IGF2
@@ -138,129 +738,805 @@ MESH	D007339	Insulysin	HGNC	5381	IDE
 MESH	D007375	Interleukin-1	FPLX	IL1	IL1
 MESH	D007376	Interleukin-2	HGNC	6001	IL2
 MESH	D007377	Interleukin-3	HGNC	6011	IL3
+MESH	D007444	Inulin	CHEBI	CHEBI:15443	inulin
+MESH	D007455	Iodine	CHEBI	CHEBI:17606	diiodine
+MESH	D007490	Iproniazid	CHEBI	CHEBI:5958	Iproniazid
+MESH	D007501	Iron	CHEBI	CHEBI:18248	iron atom
+MESH	D007510	Isatin	CHEBI	CHEBI:27539	isatin
+MESH	D007528	Isoetharine	CHEBI	CHEBI:6005	Isoetharine
+MESH	D007530	Isoflurane	CHEBI	CHEBI:6015	isoflurane
+MESH	D007531	Isoflurophate	CHEBI	CHEBI:17941	diisopropyl fluorophosphate
+MESH	D007534	Isomaltose	CHEBI	CHEBI:28189	isomaltose
+MESH	D007538	Isoniazid	CHEBI	CHEBI:6030	isoniazide
+MESH	D007541	Isopentenyladenosine	CHEBI	CHEBI:62881	N(6)-(Delta(2)-isopentenyl)adenosine
+MESH	D007544	Isopropyl Thiogalactoside	CHEBI	CHEBI:61448	isopropyl beta-D-thiogalactopyranoside
+MESH	D007545	Isoproterenol	CHEBI	CHEBI:64317	isoprenaline
+MESH	D007547	Isosorbide	CHEBI	CHEBI:6060	Isosorbide
+MESH	D007612	Kanamycin	CHEBI	CHEBI:6104	kanamycin
+MESH	D007631	Chlordecone	CHEBI	CHEBI:16548	chlordecone
+MESH	D007649	Ketamine	CHEBI	CHEBI:6121	ketamine
+MESH	D007650	Ketanserin	CHEBI	CHEBI:6123	ketanserin
+MESH	D007660	Ketoprofen	CHEBI	CHEBI:6128	ketoprofen
 MESH	D007703	Peptidyl-Dipeptidase A	HGNC	2707	ACE
+MESH	D007735	Kynuramine	CHEBI	CHEBI:73472	kynuramine
+MESH	D007741	Labetalol	CHEBI	CHEBI:6343	labetalol
 MESH	D007781	Lactoferrin	HGNC	6720	LTF
 MESH	D007784	Lactoperoxidase	HGNC	6678	LPO
+MESH	D007785	Lactose	CHEBI	CHEBI:36219	alpha-lactose
 MESH	D007791	Lactoylglutathione Lyase	HGNC	4323	GLO1
+MESH	D007792	Lactulose	CHEBI	CHEBI:6359	lactulose
+MESH	D007810	Lanosterol	CHEBI	CHEBI:16521	lanosterol
+MESH	D007851	Dodecanol	CHEBI	CHEBI:28878	dodecan-1-ol
+MESH	D007854	Lead	CHEBI	CHEBI:27889	lead(0)
 MESH	D007931	Leucyl Aminopeptidase	HGNC	18449	LAP3
+MESH	D007975	Leukotriene B4	CHEBI	CHEBI:15647	leukotriene B4
+MESH	D007977	Levallorphan	CHEBI	CHEBI:6431	Levallorphan
+MESH	D007981	Levorphanol	CHEBI	CHEBI:6444	Levorphanol
 MESH	D007987	Gonadotropin-Releasing Hormone	HGNC	4419	GNRH1
+MESH	D008012	Lidocaine	CHEBI	CHEBI:6456	lidocaine
+MESH	D008027	Light	CHEBI	CHEBI:30212	photon
+MESH	D008034	Lincomycin	CHEBI	CHEBI:6472	lincomycin
+MESH	D008094	Lithium	CHEBI	CHEBI:30145	lithium atom
+MESH	D008120	Lobeline	CHEBI	CHEBI:48723	(-)-lobeline
+MESH	D008127	Lofepramine	CHEBI	CHEBI:47782	lofepramine
+MESH	D008139	Loperamide	CHEBI	CHEBI:6532	loperamide
+MESH	D008148	Lovastatin	CHEBI	CHEBI:40303	lovastatin
+MESH	D008152	Loxapine	CHEBI	CHEBI:50841	loxapine
+MESH	D008154	Lucanthone	CHEBI	CHEBI:51052	lucanthone
+MESH	D008187	Lutetium	CHEBI	CHEBI:33382	lutetium atom
+MESH	D008194	Lymecycline	CHEBI	CHEBI:59040	lymecycline
 MESH	D008233	Lymphotoxin-alpha	HGNC	6709	LTA
+MESH	D008234	Lynestrenol	CHEBI	CHEBI:31790	Lynestrenol
+MESH	D008238	Lysergic Acid Diethylamide	CHEBI	CHEBI:6605	lysergic acid diethylamide
 MESH	D008245	Lysophospholipase	HGNC	30041	PLB1
+MESH	D008272	Mafenide	CHEBI	CHEBI:6633	Mafenide
+MESH	D008274	Magnesium	CHEBI	CHEBI:25107	magnesium atom
+MESH	D008294	Malathion	CHEBI	CHEBI:6651	malathion
+MESH	D008315	Malondialdehyde	CHEBI	CHEBI:566274	malonaldehyde
+MESH	D008320	Maltose	CHEBI	CHEBI:17306	maltose
+MESH	D008345	Manganese	CHEBI	CHEBI:18291	manganese atom
+MESH	D008351	Mannans	CHEBI	CHEBI:28808	mannan
+MESH	D008353	Mannitol	CHEBI	CHEBI:16899	D-mannitol
+MESH	D008358	Mannose	CHEBI	CHEBI:4208	D-mannopyranose
+MESH	D008376	Maprotiline	CHEBI	CHEBI:6690	Maprotiline
+MESH	D008453	Maytansine	CHEBI	CHEBI:6701	maytansine
+MESH	D008454	Mazindol	CHEBI	CHEBI:6702	Mazindol
+MESH	D008456	2-Methyl-4-chlorophenoxyacetic Acid	CHEBI	CHEBI:50099	(4-chloro-2-methylphenoxy)acetic acid
+MESH	D008463	Mebendazole	CHEBI	CHEBI:6704	mebendazole
+MESH	D008464	Mecamylamine	CHEBI	CHEBI:6706	Mecamylamine
+MESH	D008466	Mechlorethamine	CHEBI	CHEBI:28925	mechlorethamine
+MESH	D008468	Meclizine	CHEBI	CHEBI:6709	Meclizine
+MESH	D008472	Medazepam	CHEBI	CHEBI:31807	Medazepam
+MESH	D008529	Mefruside	CHEBI	CHEBI:31809	Mefruside
+MESH	D008535	Megestrol	CHEBI	CHEBI:6722	megestrol
+MESH	D008549	Melarsoprol	CHEBI	CHEBI:6729	Melarsoprol
+MESH	D008550	Melatonin	CHEBI	CHEBI:16796	melatonin
+MESH	D008553	Melibiose	CHEBI	CHEBI:28053	melibiose
+MESH	D008559	Memantine	CHEBI	CHEBI:64312	memantine
+MESH	D008573	Mendelevium	CHEBI	CHEBI:33395	mendelevium atom
+MESH	D008614	Meperidine	CHEBI	CHEBI:6754	Meperidine
+MESH	D008618	Mephobarbital	CHEBI	CHEBI:6758	mephobarbital
+MESH	D008620	Meprobamate	CHEBI	CHEBI:6761	Meprobamate
+MESH	D008623	Mercaptoethanol	CHEBI	CHEBI:41218	mercaptoethanol
+MESH	D008627	Mercuric Chloride	CHEBI	CHEBI:31823	mercury dichloride
+MESH	D008628	Mercury	CHEBI	CHEBI:16170	mercury(0)
+MESH	D008635	Mescaline	CHEBI	CHEBI:28346	mescaline
+MESH	D008653	Mesoridazine	CHEBI	CHEBI:6780	mesoridazine
+MESH	D008656	Mestranol	CHEBI	CHEBI:6784	mestranol
 MESH	D008668	Metallothionein	FPLX	Metallothionein	Metallothionein
+MESH	D008676	Metanephrine	CHEBI	CHEBI:89633	Metanephrine
+MESH	D008680	Metaraminol	CHEBI	CHEBI:6794	metaraminol
+MESH	D008687	Metformin	CHEBI	CHEBI:6801	metformin
+MESH	D008694	Methamphetamine	CHEBI	CHEBI:6809	methamphetamine
+MESH	D008695	Methandriol	CHEBI	CHEBI:34834	Methandriol
+MESH	D008696	Methandrostenolone	CHEBI	CHEBI:6810	Methandrostenolone
+MESH	D008697	Methane	CHEBI	CHEBI:16183	methane
+MESH	D008701	Methapyrilene	CHEBI	CHEBI:6820	methapyrilene
+MESH	D008704	Methazolamide	CHEBI	CHEBI:6822	Methazolamide
+MESH	D008712	Methicillin	CHEBI	CHEBI:6827	methicillin
+MESH	D008713	Methimazole	CHEBI	CHEBI:50673	methimazole
+MESH	D008719	Methiothepin	CHEBI	CHEBI:64203	methiothepin
+MESH	D008723	Methohexital	CHEBI	CHEBI:102216	methohexital
+MESH	D008724	Methomyl	CHEBI	CHEBI:6835	methomyl
+MESH	D008726	Methoprene	CHEBI	CHEBI:34839	methoprene
+MESH	D008727	Methotrexate	CHEBI	CHEBI:44185	methotrexate
+MESH	D008728	Methotrimeprazine	CHEBI	CHEBI:6838	methotrimeprazine
+MESH	D008729	Methoxamine	CHEBI	CHEBI:6839	methoxamine
+MESH	D008730	Methoxsalen	CHEBI	CHEBI:18358	methoxsalen
+MESH	D008731	Methoxychlor	CHEBI	CHEBI:6842	methoxychlor
+MESH	D008735	5-Methoxytryptamine	CHEBI	CHEBI:2089	O-methylserotonin
+MESH	D008736	Methyclothiazide	CHEBI	CHEBI:6847	Methyclothiazide
+MESH	D008743	Methyl Parathion	CHEBI	CHEBI:38746	parathion-methyl
+MESH	D008747	Methylcellulose	CHEBI	CHEBI:53448	methyl cellulose
+MESH	D008748	Methylcholanthrene	CHEBI	CHEBI:34342	3-methylcholanthrene
+MESH	D008751	Methylene Blue	CHEBI	CHEBI:6872	methylene blue
+MESH	D008752	Methylene Chloride	CHEBI	CHEBI:15767	dichloromethane
+MESH	D008753	Methylenebis(chloroaniline)	CHEBI	CHEBI:28124	4,4'-methylene-bis-(2-chloroaniline)
+MESH	D008755	Methylergonovine	CHEBI	CHEBI:6874	Methylergonovine
+MESH	D008760	Methylguanidine	CHEBI	CHEBI:16628	methylguanidine
+MESH	D008769	Methylnitronitrosoguanidine	CHEBI	CHEBI:21759	N-methyl-N'-nitro-N-nitrosoguanidine
+MESH	D008770	Methylnitrosourea	CHEBI	CHEBI:50102	N-methyl-N-nitrosourea
+MESH	D008777	Methyltestosterone	CHEBI	CHEBI:27436	methyltestosterone
+MESH	D008779	Methylthiouracil	CHEBI	CHEBI:82346	Methylthiouracil
+MESH	D008784	Methysergide	CHEBI	CHEBI:584020	methysergide
+MESH	D008785	Metiamide	CHEBI	CHEBI:6896	Metiamide
+MESH	D008790	Metoprolol	CHEBI	CHEBI:6904	metoprolol
+MESH	D008793	Metrizamide	CHEBI	CHEBI:31841	Metrizamide
+MESH	D008797	Metyrapone	CHEBI	CHEBI:44241	metyrapone
+MESH	D008801	Mexiletine	CHEBI	CHEBI:6916	mexiletine
+MESH	D008802	Mezlocillin	CHEBI	CHEBI:6919	mezlocillin
+MESH	D008825	Miconazole	CHEBI	CHEBI:6923	miconazole
+MESH	D008911	Minocycline	CHEBI	CHEBI:50694	minocycline
+MESH	D008917	Mirex	CHEBI	CHEBI:34852	mirex
+MESH	D008926	Plicamycin	CHEBI	CHEBI:31856	mithramycin
+MESH	D008927	Mitobronitol	CHEBI	CHEBI:34853	Mitobronitol
+MESH	D008935	Mitoguazone	CHEBI	CHEBI:43996	mitoguazone
+MESH	D008939	Mitotane	CHEBI	CHEBI:6954	Mitotane
+MESH	D008942	Mitoxantrone	CHEBI	CHEBI:50729	mitoxantrone
+MESH	D008950	MMPI	CHEBI	CHEBI:50664	matrix metalloproteinase inhibitor
+MESH	D008972	Molindone	CHEBI	CHEBI:6965	Molindone
+MESH	D008981	Molsidomine	CHEBI	CHEBI:31861	Molsidomine
+MESH	D008982	Molybdenum	CHEBI	CHEBI:28685	molybdenum atom
+MESH	D008985	Monensin	CHEBI	CHEBI:27617	monensin A
+MESH	D009020	Morphine	CHEBI	CHEBI:17303	morphine
+MESH	D009070	Moxalactam	CHEBI	CHEBI:599928	moxalactam
+MESH	D009116	Muscarine	CHEBI	CHEBI:7034	Muscarine
+MESH	D009118	Muscimol	CHEBI	CHEBI:7035	muscimol
+MESH	D009151	Mustard Gas	CHEBI	CHEBI:25434	bis(2-chloroethyl) sulfide
 MESH	D009195	Peroxidase	HGNC	7218	MPO
 MESH	D009211	Myoglobin	HGNC	6915	MB
+MESH	D009241	Ipratropium	CHEBI	CHEBI:5956	ipratropium
+MESH	D009242	N-Nitrosopyrrolidine	CHEBI	CHEBI:82362	N-Nitrosopyrrolidine
 MESH	D009249	NADP	HGNC	1063	BLVRB
+MESH	D009255	Nafenopin	CHEBI	CHEBI:7449	nafenopin
+MESH	D009256	Nafoxidine	CHEBI	CHEBI:34881	Nafoxidine
+MESH	D009266	Nalbuphine	CHEBI	CHEBI:7454	nalbuphine
+MESH	D009269	Nalorphine	CHEBI	CHEBI:7458	Nalorphine
+MESH	D009271	Naltrexone	CHEBI	CHEBI:7465	naltrexone
+MESH	D009277	Nandrolone	CHEBI	CHEBI:7466	nandrolone
+MESH	D009278	Naphazoline	CHEBI	CHEBI:7470	Naphazoline
+MESH	D009288	Naproxen	CHEBI	CHEBI:7476	naproxen
+MESH	D009320	Atrial Natriuretic Factor	HGNC	4877	HESX1
 MESH	D009320	Atrial Natriuretic Factor	HGNC	7939	NPPA
+MESH	D009327	4-Chloro-7-nitrobenzofurazan	CHEBI	CHEBI:78878	4-chloro-7-nitrobenzofurazan
+MESH	D009355	Neomycin	CHEBI	CHEBI:7507	neomycin
+MESH	D009356	Neon	CHEBI	CHEBI:33310	neon atom
+MESH	D009428	Netilmicin	CHEBI	CHEBI:7528	netilmycin
+MESH	D009499	Neutral Red	CHEBI	CHEBI:86370	neutral red
+MESH	D009525	Niacin	CHEBI	CHEBI:15940	nicotinic acid
+MESH	D009528	Nicarbazin	CHEBI	CHEBI:81725	Nicarbazin
+MESH	D009529	Nicardipine	CHEBI	CHEBI:7550	Nicardipine
+MESH	D009530	Nicergoline	CHEBI	CHEBI:31902	Nicergoline
+MESH	D009531	Niceritrol	CHEBI	CHEBI:31903	Niceritrol
+MESH	D009532	Nickel	CHEBI	CHEBI:28112	nickel atom
+MESH	D009534	Niclosamide	CHEBI	CHEBI:7553	Niclosamide
+MESH	D009536	Niacinamide	CHEBI	CHEBI:17154	nicotinamide
+MESH	D009538	Nicotine	CHEBI	CHEBI:17688	(S)-nicotine
+MESH	D009543	Nifedipine	CHEBI	CHEBI:7565	nifedipine
+MESH	D009547	Nifurtimox	CHEBI	CHEBI:7566	Nifurtimox
+MESH	D009553	Nimodipine	CHEBI	CHEBI:7575	nimodipine
+MESH	D009560	Niridazole	CHEBI	CHEBI:82349	Niridazole
+MESH	D009584	Nitrogen	CHEBI	CHEBI:17997	dinitrogen
+MESH	D009599	Nitroprusside	CHEBI	CHEBI:7596	nitroprusside
+MESH	D009610	Nitrovin	CHEBI	CHEBI:82516	Nitrovin
+MESH	D009614	Nobelium	CHEBI	CHEBI:33396	nobelium
+MESH	D009627	Nomifensine	CHEBI	CHEBI:116225	nomifensine
+MESH	D009638	Norepinephrine	CHEBI	CHEBI:18357	(R)-noradrenaline
+MESH	D009641	Norethynodrel	CHEBI	CHEBI:34895	Norethynodrel
+MESH	D009644	Norgestrel	CHEBI	CHEBI:7630	norgestrel
+MESH	D009647	Normetanephrine	CHEBI	CHEBI:89951	Normetanephrine
+MESH	D009661	Nortriptyline	CHEBI	CHEBI:7640	nortriptyline
+MESH	D009675	Novobiocin	CHEBI	CHEBI:28368	novobiocin
+MESH	D009704	Nucleoside Q	CHEBI	CHEBI:60193	queuosine
+MESH	D009762	o-Aminoazotoluene	CHEBI	CHEBI:82285	ortho-Aminoazotoluene
+MESH	D009764	o-Phthalaldehyde	CHEBI	CHEBI:70851	phthalaldehyde
+MESH	D009827	Oleandomycin	CHEBI	CHEBI:16869	oleandomycin
+MESH	D009921	Metaproterenol	CHEBI	CHEBI:82719	orciprenaline
+MESH	D009966	Orphenadrine	CHEBI	CHEBI:7789	orphenadrine
+MESH	D010042	Ouabain	CHEBI	CHEBI:472805	ouabain
+MESH	D010068	Oxacillin	CHEBI	CHEBI:7809	oxacillin
+MESH	D010074	Oxandrolone	CHEBI	CHEBI:7820	oxandrolone
+MESH	D010076	Oxazepam	CHEBI	CHEBI:7823	oxazepam
+MESH	D010095	Oxotremorine	CHEBI	CHEBI:7851	Oxotremorine
+MESH	D010098	Oxycodone	CHEBI	CHEBI:7852	oxycodone
+MESH	D010100	Oxygen	CHEBI	CHEBI:15379	dioxygen
+MESH	D010111	Oxymorphone	CHEBI	CHEBI:7865	Oxymorphone
+MESH	D010113	Oxyphenbutazone	CHEBI	CHEBI:76259	oxyphenbutazone hydrate
+MESH	D010113	Oxyphenbutazone	CHEBI	CHEBI:76258	oxyphenbutazone
+MESH	D010117	Oxypurinol	CHEBI	CHEBI:28315	alloxanthine
 MESH	D010122	Cystinyl Aminopeptidase	HGNC	6656	LNPEP
+MESH	D010129	4-Aminobenzoic Acid	CHEBI	CHEBI:30753	4-aminobenzoic acid
+MESH	D010132	p-Azobenzenearsonate	CHEBI	CHEBI:53554	4,4'-azodibenzenearsonic acid
+MESH	D010172	Palmitoylcarnitine	CHEBI	CHEBI:17490	O-palmitoyl-L-carnitine
+MESH	D010197	Pancuronium	CHEBI	CHEBI:7907	pancuronium
+MESH	D010204	Pantetheine	CHEBI	CHEBI:16753	pantetheine
+MESH	D010242	Paraldehyde	CHEBI	CHEBI:27909	paraldehyde
+MESH	D010248	Paramethasone	CHEBI	CHEBI:7922	Paramethasone
+MESH	D010261	Paraoxon	CHEBI	CHEBI:27827	paraoxon
+MESH	D010269	Paraquat	CHEBI	CHEBI:34905	paraquat
+MESH	D010278	Parathion	CHEBI	CHEBI:27928	parathion
 MESH	D010281	Parathyroid Hormone	HGNC	9606	PTH
+MESH	D010293	Pargyline	CHEBI	CHEBI:7930	Pargyline
+MESH	D010300	Parkinson Disease	CHEBI	CHEBI:74756	Pro-Asp
+MESH	D010303	Paromomycin	CHEBI	CHEBI:7934	paromomycin
+MESH	D010368	Pectins	CHEBI	CHEBI:17309	pectin
+MESH	D010400	Penicillin G	CHEBI	CHEBI:18208	benzylpenicillin
+MESH	D010404	Penicillin V	CHEBI	CHEBI:27446	phenoxymethylpenicillin
+MESH	D010416	Pentachlorophenol	CHEBI	CHEBI:17642	pentachlorophenol
+MESH	D010419	Pentamidine	CHEBI	CHEBI:45081	pentamidine
+MESH	D010424	Pentobarbital	CHEBI	CHEBI:7983	pentobarbital
+MESH	D010431	Pentoxifylline	CHEBI	CHEBI:7986	Pentoxifylline
+MESH	D010433	Pentylenetetrazole	CHEBI	CHEBI:34910	pentetrazol
 MESH	D010447	Peptide Hydrolases	FPLX	Protease	Protease
+MESH	D010464	Perazine	CHEBI	CHEBI:59118	perazine
+MESH	D010480	Perhexiline	CHEBI	CHEBI:35553	perhexiline
+MESH	D010546	Perphenazine	CHEBI	CHEBI:8028	perphenazine
+MESH	D010615	Phenacetin	CHEBI	CHEBI:8050	phenacetin
+MESH	D010622	Phencyclidine	CHEBI	CHEBI:8058	phencyclidine
+MESH	D010624	Phenelzine	CHEBI	CHEBI:8060	Phenelzine
+MESH	D010626	Phenylethyl Alcohol	CHEBI	CHEBI:49000	2-phenylethanol
+MESH	D010630	Phenindione	CHEBI	CHEBI:8066	phenindione
+MESH	D010634	Phenobarbital	CHEBI	CHEBI:8069	phenobarbital
+MESH	D010637	Phenolsulfonphthalein	CHEBI	CHEBI:31991	phenol red
+MESH	D010643	Phenoxybenzamine	CHEBI	CHEBI:8077	Phenoxybenzamine
+MESH	D010644	Phenprocoumon	CHEBI	CHEBI:50438	phenprocoumon
+MESH	D010653	Phenylbutazone	CHEBI	CHEBI:48574	phenylbutazone
+MESH	D010656	Phenylephrine	CHEBI	CHEBI:8093	phenylephrine
+MESH	D010657	Phenylethylmalonamide	CHEBI	CHEBI:8097	Phenylethylmalonamide
+MESH	D010658	Phenylglyoxal	CHEBI	CHEBI:88868	Phenylglyoxal
+MESH	D010672	Phenytoin	CHEBI	CHEBI:8107	phenytoin
+MESH	D010674	Pheophytins	CHEBI	CHEBI:8108	pheophytin
+MESH	D010693	Phloretin	CHEBI	CHEBI:17276	phloretin
+MESH	D010695	Phlorhizin	CHEBI	CHEBI:8113	phlorizin
+MESH	D010696	Phloroglucinol	CHEBI	CHEBI:16204	phloroglucinol
+MESH	D010713	Phosphatidylcholines	CHEBI	CHEBI:16110	1,2-diacyl-sn-glycero-3-phosphocholine(1+)
+MESH	D010716	Phosphatidylinositols	CHEBI	CHEBI:16749	1-phosphatidyl-1D-myo-inositol
+MESH	D010718	Phosphatidylserines	CHEBI	CHEBI:18303	phosphatidyl-L-serine
 MESH	D010727	Phosphoric Diester Hydrolases	FPLX	PDE	PDE
+MESH	D010728	Phosphoenolpyruvate	CHEBI	CHEBI:18021	phosphoenolpyruvate
 MESH	D010739	Phospholipase D	FPLX	PLD	PLD
+MESH	D010758	Phosphorus	CHEBI	CHEBI:28659	phosphorus atom
+MESH	D010767	Phosphorylcholine	CHEBI	CHEBI:18132	phosphocholine
+MESH	D010773	Leptophos	CHEBI	CHEBI:82137	Leptophos
 MESH	D010774	Phosvitin	HGNC	2460	CSNK2B
+MESH	D010830	Physostigmine	CHEBI	CHEBI:27953	physostigmine
+MESH	D010836	Phytol	CHEBI	CHEBI:17327	phytol
+MESH	D010837	Vitamin K 1	CHEBI	CHEBI:18067	phylloquinone
+MESH	D010853	Picryl Chloride	CHEBI	CHEBI:53053	1-chloro-2,4,6-trinitrobenzene
+MESH	D010862	Pilocarpine	CHEBI	CHEBI:8207	(+)-pilocarpine
+MESH	D010866	Natamycin	CHEBI	CHEBI:7488	Natamycin
+MESH	D010868	Pimozide	CHEBI	CHEBI:8212	pimozide
+MESH	D010869	Pindolol	CHEBI	CHEBI:8214	pindolol
+MESH	D010878	Piperacillin	CHEBI	CHEBI:8232	piperacillin
+MESH	D010889	Piracetam	CHEBI	CHEBI:32010	Piracetam
+MESH	D010894	Piroxicam	CHEBI	CHEBI:8249	piroxicam
+MESH	D010918	Pizotyline	CHEBI	CHEBI:50212	pizotifen
 MESH	D010958	Plasminogen	HGNC	9071	PLG
 MESH	D010959	Tissue Plasminogen Activator	HGNC	9051	PLAT
 MESH	D010959	Tissue Plasminogen Activator	HGNC	12404	TTPA
+MESH	D010971	Plastoquinone	CHEBI	CHEBI:17757	plastoquinone
+MESH	D010971	Plastoquinone	CHEBI	CHEBI:28377	plastoquinone-9
+MESH	D011034	Podophyllotoxin	CHEBI	CHEBI:50305	podophyllotoxin
+MESH	D011066	Poly C	CHEBI	CHEBI:84498	poly(cytidylic acid)
+MESH	D011068	Poly G	CHEBI	CHEBI:73278	poly(guanylic acid)
+MESH	D011070	Poly I-C	CHEBI	CHEBI:84491	poly(I:C)
+MESH	D011071	Poly T	CHEBI	CHEBI:73300	poly(deoxythymidylic acid)
+MESH	D011072	Poly U	CHEBI	CHEBI:73279	poly(uridylic acid)
+MESH	D011074	Polyanetholesulfonate	CHEBI	CHEBI:85116	sodium polyanethol sulfonate macromolecule
+MESH	D011078	Polychlorinated Biphenyls	CHEBI	CHEBI:53156	polychlorobiphenyl
+MESH	D011092	Polyethylene Glycols	CHEBI	CHEBI:46793	poly(ethylene glycol)
+MESH	D011098	Polyglactin 910	CHEBI	CHEBI:53493	poly(D,L-lactic acid-co-glycolic acid)
+MESH	D011108	Polymers	CHEBI	CHEBI:60027	polymer
+MESH	D011126	Polypropylenes	CHEBI	CHEBI:53550	poly(propylene)
+MESH	D011137	Polystyrenes	CHEBI	CHEBI:53276	poly(styrene)
+MESH	D011138	Polytetrafluoroethylene	CHEBI	CHEBI:53251	poly(tetrafluoroethylene)
+MESH	D011139	Polythiazide	CHEBI	CHEBI:8327	Polythiazide
+MESH	D011143	Polyvinyl Chloride	CHEBI	CHEBI:53243	poly(vinyl chloride)
+MESH	D011162	Porphobilinogen	CHEBI	CHEBI:17381	porphobilinogen
+MESH	D011205	Povidone	CHEBI	CHEBI:53248	poly(vinylpyrrolidone)
+MESH	D011222	Prazepam	CHEBI	CHEBI:8362	Prazepam
 MESH	D011228	Prealbumin	HGNC	12405	TTR
+MESH	D011238	Prednimustine	CHEBI	CHEBI:82524	Prednimustine
+MESH	D011241	Prednisone	CHEBI	CHEBI:8382	prednisone
 MESH	D011266	Pregnancy-Associated Plasma Protein-A	HGNC	8602	PAPPA
 MESH	D011268	Pregnancy-Specific beta 1-Glycoproteins	HGNC	9514	PSG1
+MESH	D011276	Pregnanediol	CHEBI	CHEBI:8387	Pregnanediol
+MESH	D011279	Pregnanetriol	CHEBI	CHEBI:34464	5beta-Pregnane-3alpha,17alpha,20alpha-triol
+MESH	D011284	Pregnenolone	CHEBI	CHEBI:16581	pregnenolone
+MESH	D011285	Pregnenolone Carbonitrile	CHEBI	CHEBI:35591	pregnenolone 16alpha-carbonitrile
+MESH	D011294	Prenalterol	CHEBI	CHEBI:8391	Prenalterol
+MESH	D011298	Feprazone	CHEBI	CHEBI:31603	Feprazone
+MESH	D011299	Prenylamine	CHEBI	CHEBI:8397	Prenylamine
+MESH	D011318	Prilocaine	CHEBI	CHEBI:8404	prilocaine
 MESH	D011333	Pro-Opiomelanocortin	HGNC	9201	POMC
+MESH	D011342	Procainamide	CHEBI	CHEBI:8428	procainamide
+MESH	D011343	Procaine	CHEBI	CHEBI:8430	procaine
+MESH	D011345	Fenofibrate	CHEBI	CHEBI:5001	fenofibrate
+MESH	D011346	Prochlorperazine	CHEBI	CHEBI:8435	prochlorperazine
+MESH	D011352	Procyclidine	CHEBI	CHEBI:8448	procyclidine
+MESH	D011355	Prodrugs	CHEBI	CHEBI:50266	prodrug
+MESH	D011370	Proflavine	CHEBI	CHEBI:8452	3,6-diaminoacridine
+MESH	D011374	Progesterone	CHEBI	CHEBI:17026	progesterone
 MESH	D011388	Prolactin	HGNC	9445	PRL
+MESH	D011395	Promazine	CHEBI	CHEBI:8459	promazine
+MESH	D011398	Promethazine	CHEBI	CHEBI:8461	promethazine
+MESH	D011399	Promethium	CHEBI	CHEBI:33373	promethium atom
+MESH	D011400	Prometryne	CHEBI	CHEBI:26276	prometryn
+MESH	D011413	Propantheline	CHEBI	CHEBI:8481	Propantheline
 MESH	D011414	Properdin	HGNC	8864	CFP
 MESH	D011416	Complement Factor D	HGNC	2771	CFD
+MESH	D011420	Propiolactone	CHEBI	CHEBI:49073	beta-propiolactone
+MESH	D011430	Propoxycaine	CHEBI	CHEBI:8496	Propoxycaine
+MESH	D011433	Propranolol	CHEBI	CHEBI:8499	propranolol
+MESH	D011440	Propyliodone	CHEBI	CHEBI:32064	Propyliodone
+MESH	D011441	Propylthiouracil	CHEBI	CHEBI:8502	6-propyl-2-thiouracil
+MESH	D011442	Proscillaridin	CHEBI	CHEBI:32065	Proscillaridin
+MESH	D011456	Prostaglandins B	CHEBI	CHEBI:26335	prostaglandins B
+MESH	D011457	Prostaglandins D	CHEBI	CHEBI:26337	prostaglandins D
+MESH	D011458	Prostaglandins E	CHEBI	CHEBI:26338	prostaglandins E
+MESH	D011460	Prostaglandins F	CHEBI	CHEBI:26340	prostaglandins F
+MESH	D011462	Prostaglandins G	CHEBI	CHEBI:26343	prostaglandins G
+MESH	D011464	Epoprostenol	CHEBI	CHEBI:15552	prostaglandin I2
+MESH	D011486	Protein C	HGNC	9367	PRH2
+MESH	D011515	Prothionamide	CHEBI	CHEBI:32066	Prothionamide
 MESH	D011516	Prothrombin	HGNC	3535	F2
+MESH	D011521	Protochlorophyllide	CHEBI	CHEBI:16673	protochlorophyllide
+MESH	D011530	Protriptyline	CHEBI	CHEBI:8597	protriptyline
+MESH	D011560	Pseudouridine	CHEBI	CHEBI:17802	pseudouridine
+MESH	D011562	Psilocybin	CHEBI	CHEBI:8614	psilocybin
+MESH	D011609	Psychosine	CHEBI	CHEBI:16874	psychosine
 MESH	D011623	gamma-Glutamyl Hydrolase	HGNC	4248	GGH
+MESH	D011691	Puromycin	CHEBI	CHEBI:17939	puromycin
+MESH	D011700	Putrescine	CHEBI	CHEBI:17148	putrescine
+MESH	D011718	Pyrazinamide	CHEBI	CHEBI:45285	pyrazinecarboxamide
+MESH	D011723	Chrysanthemum cinerariifolium	CHEBI	CHEBI:39098	pyrethrins
+MESH	D011727	Pyridinolcarbamate	CHEBI	CHEBI:32075	Pyricarbate
+MESH	D011730	Pyridoxal	CHEBI	CHEBI:17310	pyridoxal
+MESH	D011733	Pyridoxamine	CHEBI	CHEBI:16410	pyridoxamine
+MESH	D011736	Pyridoxine	CHEBI	CHEBI:16709	pyridoxine
+MESH	D011738	Pyrilamine	CHEBI	CHEBI:6762	mepyramine
+MESH	D011745	Pyrithiamine	CHEBI	CHEBI:15797	1-(4-amino-2-methylpyrimidin-5-ylmethyl)-3-(2-hydroxyethyl)-2-methylpyridinium bromide
+MESH	D011748	Pyrogallol	CHEBI	CHEBI:16164	pyrogallol
+MESH	D011754	Pyronine	CHEBI	CHEBI:8682	pyronin Y
+MESH	D011765	Pyruvaldehyde	CHEBI	CHEBI:17158	methylglyoxal
+MESH	D011791	Quartz	CHEBI	CHEBI:46727	quartz
+MESH	D011794	Quercetin	CHEBI	CHEBI:16243	quercetin
+MESH	D011796	Quinacrine	CHEBI	CHEBI:8711	quinacrine
+MESH	D011800	Quinestrol	CHEBI	CHEBI:8716	quinestrol
+MESH	D011802	Quinidine	CHEBI	CHEBI:28593	quinidine
+MESH	D011803	Quinine	CHEBI	CHEBI:15854	quinine
+MESH	D011839	Radiation, Ionizing	CHEBI	CHEBI:74061	Ile-Arg
+MESH	D011887	Raffinose	CHEBI	CHEBI:16634	raffinose
+MESH	D012018	Reflex	CHEBI	CHEBI:138164	fomesafen-sodium
 MESH	D012083	Renin	HGNC	9958	REN
+MESH	D012110	Reserpine	CHEBI	CHEBI:28487	reserpine
+MESH	D012146	Rest	CHEBI	CHEBI:24433	group
+MESH	D012172	Retinaldehyde	CHEBI	CHEBI:17898	all-trans-retinal
+MESH	D012211	Rhenium	CHEBI	CHEBI:49882	rhenium atom
 MESH	D012243	Rhodopsin	HGNC	10012	RHO
+MESH	D012255	Ribitol	CHEBI	CHEBI:15963	ribitol
 MESH	D012259	Ribonuclease, Pancreatic	HGNC	10044	RNASE1
+MESH	D012266	Ribose	CHEBI	CHEBI:47013	D-ribofuranose
+MESH	D012266	Ribose	CHEBI	CHEBI:27476	beta-D-ribopyranose
+MESH	D012272	Ribs	CHEBI	CHEBI:33942	ribose
+MESH	D012293	Rifampin	CHEBI	CHEBI:28077	rifampicin
+MESH	D012312	Ritodrine	CHEBI	CHEBI:8872	Ritodrine
+MESH	D012313	RNA	CHEBI	CHEBI:33697	ribonucleic acid
+MESH	D012333	RNA, Messenger	CHEBI	CHEBI:33699	messenger RNA
+MESH	D012335	RNA, Ribosomal	CHEBI	CHEBI:18111	ribosomal RNA
+MESH	D012342	RNA, Small Nuclear	CHEBI	CHEBI:74035	small nuclear RNA
+MESH	D012343	RNA, Transfer	CHEBI	CHEBI:17843	transfer RNA
+MESH	D012344	RNA, Transfer, Ala	CHEBI	CHEBI:29170	tRNA(Ala)
+MESH	D012347	RNA, Transfer, Arg	CHEBI	CHEBI:29171	tRNA(Arg)
+MESH	D012348	RNA, Transfer, Asn	CHEBI	CHEBI:29172	tRNA(Asn)
+MESH	D012349	RNA, Transfer, Asp	CHEBI	CHEBI:29186	tRNA(Asp)
+MESH	D012350	RNA, Transfer, Cys	CHEBI	CHEBI:29167	tRNA(Cys)
+MESH	D012351	RNA, Transfer, Gln	CHEBI	CHEBI:29168	tRNA(Gln)
+MESH	D012352	RNA, Transfer, Glu	CHEBI	CHEBI:29175	tRNA(Glu)
+MESH	D012353	RNA, Transfer, Gly	CHEBI	CHEBI:29176	tRNA(Gly)
+MESH	D012354	RNA, Transfer, His	CHEBI	CHEBI:29178	tRNA(His)
+MESH	D012355	RNA, Transfer, Ile	CHEBI	CHEBI:29174	tRNA(Ile)
+MESH	D012356	RNA, Transfer, Leu	CHEBI	CHEBI:29169	tRNA(Leu)
+MESH	D012357	RNA, Transfer, Lys	CHEBI	CHEBI:29185	tRNA(Lys)
+MESH	D012358	RNA, Transfer, Met	CHEBI	CHEBI:29173	tRNA(Met)
+MESH	D012360	RNA, Transfer, Phe	CHEBI	CHEBI:29184	tRNA(Phe)
+MESH	D012361	RNA, Transfer, Pro	CHEBI	CHEBI:29177	tRNA(Pro)
+MESH	D012362	RNA, Transfer, Ser	CHEBI	CHEBI:29179	tRNA(Ser)
+MESH	D012363	RNA, Transfer, Thr	CHEBI	CHEBI:29180	tRNA(Thr)
+MESH	D012364	RNA, Transfer, Trp	CHEBI	CHEBI:29181	tRNA(Trp)
+MESH	D012365	RNA, Transfer, Tyr	CHEBI	CHEBI:29182	tRNA(Tyr)
+MESH	D012366	RNA, Transfer, Val	CHEBI	CHEBI:29183	tRNA(Val)
+MESH	D012394	Rosaniline Dyes	CHEBI	CHEBI:87665	rosanilin
+MESH	D012402	Rotenone	CHEBI	CHEBI:28201	rotenone
+MESH	D012428	Ruthenium	CHEBI	CHEBI:30682	ruthenium atom
+MESH	D012431	Rutin	CHEBI	CHEBI:28527	rutin
+MESH	D012433	Ryanodine	CHEBI	CHEBI:8925	ryanodine
+MESH	D012439	Saccharin	CHEBI	CHEBI:32111	saccharin
+MESH	D012460	Sulfasalazine	CHEBI	CHEBI:9334	sulfasalazine
+MESH	D012566	Sizofiran	CHEBI	CHEBI:50653	schizophyllan
+MESH	D012601	Scopolamine	CHEBI	CHEBI:16794	scopolamine
+MESH	D012603	Scopoletin	CHEBI	CHEBI:17488	scopoletin
 MESH	D012633	Secretin	HGNC	10607	SCT
+MESH	D012642	Selegiline	CHEBI	CHEBI:9086	(-)-selegiline
+MESH	D012643	Selenium	CHEBI	CHEBI:27568	selenium atom
+MESH	D012673	Semustine	CHEBI	CHEBI:6863	semustine
+MESH	D012685	Sepharose	CHEBI	CHEBI:2511	agarose
+MESH	D012701	Serotonin	CHEBI	CHEBI:28790	serotonin
+MESH	D012721	Carbaryl	CHEBI	CHEBI:3390	carbaryl
+MESH	D012825	Silicon	CHEBI	CHEBI:27573	silicon atom
+MESH	D012834	Silver	CHEBI	CHEBI:9141	silver(0)
+MESH	D012838	Silymarin	CHEBI	CHEBI:9144	silibinin
+MESH	D012839	Simazine	CHEBI	CHEBI:27496	simazine
+MESH	D012853	Sisomicin	CHEBI	CHEBI:9169	sisomycin
+MESH	D012862	Skatole	CHEBI	CHEBI:9171	skatole
+MESH	D012992	Solanine	CHEBI	CHEBI:9188	solanine
+MESH	D012999	Soman	CHEBI	CHEBI:9195	Soman
 MESH	D013004	Somatostatin	HGNC	11329	SST
 MESH	D013006	Growth Hormone	HGNC	4261	GH1
 MESH	D013007	Growth Hormone-Releasing Hormone	HGNC	4265	GHRH
+MESH	D013012	Sorbitol	CHEBI	CHEBI:30911	glucitol
+MESH	D013013	Sorbose	CHEBI	CHEBI:27922	sorbose
+MESH	D013015	Sotalol	CHEBI	CHEBI:63622	sotalol
+MESH	D013034	Sparteine	CHEBI	CHEBI:28827	sparteine
+MESH	D013095	Spermidine	CHEBI	CHEBI:16610	spermidine
+MESH	D013096	Spermine	CHEBI	CHEBI:15746	spermine
+MESH	D013110	Sphingosine	CHEBI	CHEBI:16393	sphingosine
+MESH	D013148	Spironolactone	CHEBI	CHEBI:9241	spironolactone
+MESH	D013185	Squalene	CHEBI	CHEBI:15440	squalene
+MESH	D013196	Dihydrotestosterone	CHEBI	CHEBI:16330	17beta-hydroxy-5alpha-androstan-3-one
+MESH	D013205	Staphylococcal Protein A	HGNC	23458	CALHM3
+MESH	D013213	Starch	CHEBI	CHEBI:28017	starch
+MESH	D013241	Sterigmatocystin	CHEBI	CHEBI:18227	sterigmatocystin
 MESH	D013252	Steroid 11-beta-Hydroxylase	HGNC	2591	CYP11B1
 MESH	D013253	Steroid 12-alpha-Hydroxylase	HGNC	2653	CYP8B1
 MESH	D013254	Steroid 17-alpha-Hydroxylase	HGNC	2593	CYP17A1
+MESH	D013265	Stigmasterol	CHEBI	CHEBI:8334	Poriferasterol
+MESH	D013265	Stigmasterol	CHEBI	CHEBI:28824	stigmasterol
+MESH	D013311	Streptozocin	CHEBI	CHEBI:9288	streptozocin
+MESH	D013324	Strontium	CHEBI	CHEBI:35104	strontium(2+)
+MESH	D013327	Strophanthidin	CHEBI	CHEBI:38178	strophanthidin
+MESH	D013331	Strychnine	CHEBI	CHEBI:28973	strychnine
+MESH	D013390	Succinylcholine	CHEBI	CHEBI:45652	succinylcholine
+MESH	D013392	Sucralfate	CHEBI	CHEBI:9313	Sucralfate
+MESH	D013395	Sucrose	CHEBI	CHEBI:17992	sucrose
+MESH	D013408	Sulbenicillin	CHEBI	CHEBI:9322	sulbenicillin
+MESH	D013408	Sulbenicillin	CHEBI	CHEBI:32160	sulbenicillin disodium
+MESH	D013409	Sulfacetamide	CHEBI	CHEBI:63845	sulfacetamide
+MESH	D013411	Sulfadiazine	CHEBI	CHEBI:9328	sulfadiazine
+MESH	D013412	Sulfadimethoxine	CHEBI	CHEBI:32161	sulfadimethoxine
+MESH	D013413	Sulfadoxine	CHEBI	CHEBI:9329	sulfadoxine
+MESH	D013417	Sulfameter	CHEBI	CHEBI:53727	sulfamethoxydiazine
+MESH	D013419	Sulfamethizole	CHEBI	CHEBI:9331	sulfamethizole
+MESH	D013420	Sulfamethoxazole	CHEBI	CHEBI:9332	sulfamethoxazole
+MESH	D013421	Sulfamethoxypyridazine	CHEBI	CHEBI:102516	sulfamethoxypyridazine
+MESH	D013422	Sulfamonomethoxine	CHEBI	CHEBI:32164	Sulfamonomethoxine
+MESH	D013423	Sulfamoxole	CHEBI	CHEBI:55548	sulfamoxole
+MESH	D013427	Sulfapyridine	CHEBI	CHEBI:132842	sulfapyridine
+MESH	D013442	Sulfinpyrazone	CHEBI	CHEBI:9342	sulfinpyrazone
+MESH	D013443	Sulfisomidine	CHEBI	CHEBI:32166	sulfisomidine
+MESH	D013444	Sulfisoxazole	CHEBI	CHEBI:55548	sulfamoxole
+MESH	D013448	Sulfobromophthalein	CHEBI	CHEBI:63827	bromosulfophthalein sodium
+MESH	D013455	Sulfur	CHEBI	CHEBI:17909	polysulfur
+MESH	D013467	Sulindac	CHEBI	CHEBI:9352	sulindac
+MESH	D013498	Suramin	CHEBI	CHEBI:45906	suramin
+MESH	D013578	Synephrine	CHEBI	CHEBI:29081	synephrine
+MESH	D013605	T-2 Toxin	CHEBI	CHEBI:9381	T-2 Toxin
+MESH	D013619	Tacrine	CHEBI	CHEBI:45980	tacrine
+MESH	D013626	Talampicillin	CHEBI	CHEBI:9391	talampicillin
+MESH	D013627	Talc	CHEBI	CHEBI:32178	Talc
+MESH	D013629	Tamoxifen	CHEBI	CHEBI:41774	tamoxifen
+MESH	D013645	Tartrazine	CHEBI	CHEBI:9405	tartrazine
+MESH	D013654	Taurine	CHEBI	CHEBI:15891	taurine
+MESH	D013656	Taurocholic Acid	CHEBI	CHEBI:28865	taurocholic acid
+MESH	D013667	Technetium	CHEBI	CHEBI:33353	technetium atom
+MESH	D013693	Temazepam	CHEBI	CHEBI:9435	Temazepam
+MESH	D013721	Triethylenephosphoramide	CHEBI	CHEBI:49798	tetraethylenepentamine
+MESH	D013738	Testolactone	CHEBI	CHEBI:9460	testolactone
+MESH	D013739	Testosterone	CHEBI	CHEBI:17347	testosterone
+MESH	D013747	Tetrabenazine	CHEBI	CHEBI:9467	tetrabenazine
+MESH	D013748	Tetracaine	CHEBI	CHEBI:9468	tetracaine
+MESH	D013750	Tetrachloroethylene	CHEBI	CHEBI:17300	tetrachloroethene
+MESH	D013751	Tetrachlorvinphos	CHEBI	CHEBI:35005	tetrachlorvinphos
+MESH	D013752	Tetracycline	CHEBI	CHEBI:27902	tetracycline
 MESH	D013758	Tetragastrin	HGNC	9618	PTK7
+MESH	D013759	Dronabinol	CHEBI	CHEBI:66964	Delta(9)-tetrahydrocannabinol
+MESH	D013760	Tetrahydrocortisol	CHEBI	CHEBI:28320	tetrahydrocortisol
+MESH	D013765	Tetrahydropapaveroline	CHEBI	CHEBI:28770	norlaudanosoline
+MESH	D013774	Tetranitromethane	CHEBI	CHEBI:82372	Tetranitromethane
+MESH	D013779	Tetrodotoxin	CHEBI	CHEBI:9506	tetrodotoxin
+MESH	D013792	Thalidomide	CHEBI	CHEBI:9513	thalidomide
+MESH	D013797	Thebaine	CHEBI	CHEBI:9519	thebaine
+MESH	D013805	Theobromine	CHEBI	CHEBI:28946	theobromine
+MESH	D013806	Theophylline	CHEBI	CHEBI:28177	theophylline
+MESH	D013827	Thiabendazole	CHEBI	CHEBI:45979	thiabendazole
+MESH	D013831	Thiamine	CHEBI	CHEBI:18385	thiamine(1+)
+MESH	D013839	Thiamphenicol	CHEBI	CHEBI:32215	thiamphenicol
+MESH	D013840	Thiamylal	CHEBI	CHEBI:9536	thiamylal
+MESH	D013847	Thiethylperazine	CHEBI	CHEBI:9544	thiethylperazine
+MESH	D013849	Thimerosal	CHEBI	CHEBI:9546	thimerosal
+MESH	D013852	Thiotepa	CHEBI	CHEBI:9570	Thiotepa
+MESH	D013866	Thioguanine	CHEBI	CHEBI:9555	tioguanine
+MESH	D013874	Thiopental	CHEBI	CHEBI:102166	thiopental
 MESH	D013879	Thioredoxins	FPLX	TXN	TXN
 MESH	D013884	Thiosulfate Sulfurtransferase	HGNC	12388	TST
+MESH	D013888	Thiothixene	CHEBI	CHEBI:9571	Thiothixene
+MESH	D013890	Thiourea	CHEBI	CHEBI:36946	thiourea
+MESH	D013893	Thiram	CHEBI	CHEBI:9495	thiram
 MESH	D013925	Thromboplastin	HGNC	3541	F3
 MESH	D013926	Thrombopoietin	HGNC	11795	THPO
+MESH	D013928	Thromboxane A2	CHEBI	CHEBI:15627	thromboxane A2
+MESH	D013929	Thromboxane B2	CHEBI	CHEBI:28728	thromboxane B2
+MESH	D013936	Thymidine	CHEBI	CHEBI:17748	thymidine
 MESH	D013939	Thymidine Phosphorylase	HGNC	3148	TYMP
+MESH	D013941	Thymine	CHEBI	CHEBI:17821	thymine
+MESH	D013943	Thymol	CHEBI	CHEBI:27607	thymol
 MESH	D013954	Thyroglobulin	HGNC	11764	TG
-MESH	D013973	Thyrotropin-Releasing Hormone	HGNC	12298	TRH
+MESH	D013961	Thyroid Gland	CHEBI	CHEBI:9584	Thyroid
+MESH	D013989	Ticrynafen	CHEBI	CHEBI:9590	tienilic acid
+MESH	D013999	Timolol	CHEBI	CHEBI:9599	(S)-timolol (anhydrous)
+MESH	D014031	Tobramycin	CHEBI	CHEBI:28864	tobramycin
+MESH	D014043	Tolazoline	CHEBI	CHEBI:28502	tolazoline
+MESH	D014044	Tolbutamide	CHEBI	CHEBI:27999	tolbutamide
+MESH	D014050	Toluene	CHEBI	CHEBI:17578	toluene
+MESH	D014053	Tomatine	CHEBI	CHEBI:9630	tomatine
+MESH	D014128	Chromomycin A3	CHEBI	CHEBI:34638	chromomycin A3
 MESH	D014153	Transaldolase	HGNC	11559	TALDO1
 MESH	D014156	Transcortin	HGNC	1540	SERPINA6
 MESH	D014168	Transferrin	HGNC	11740	TF
 MESH	D014174	Transketolase	HGNC	11834	TKT
+MESH	D014191	Tranylcypromine	CHEBI	CHEBI:9652	tranylcypromine
+MESH	D014191	Tranylcypromine	CHEBI	CHEBI:131510	(1R,2S)-tranylcypromine
+MESH	D014192	Trapidil	CHEBI	CHEBI:32254	Trapidil
+MESH	D014196	Trazodone	CHEBI	CHEBI:9654	trazodone
 MESH	D014198	Trehalase	HGNC	12266	TREH
+MESH	D014199	Trehalose	CHEBI	CHEBI:16551	alpha,alpha-trehalose
+MESH	D014214	Triallate	CHEBI	CHEBI:81978	Tri-allate
+MESH	D014215	Triacetin	CHEBI	CHEBI:9661	triacetin
+MESH	D014217	Troleandomycin	CHEBI	CHEBI:45735	troleandomycin
+MESH	D014236	Trichlorfon	CHEBI	CHEBI:6908	trichlorfon
+MESH	D014241	Trichloroethylene	CHEBI	CHEBI:16602	trichloroethene
+MESH	D014260	Triclosan	CHEBI	CHEBI:164200	triclosan
+MESH	D014265	Triethylenemelamine	CHEBI	CHEBI:27919	tretamine
+MESH	D014266	Trientine	CHEBI	CHEBI:39501	2,2,2-tetramine
+MESH	D014268	Trifluoperazine	CHEBI	CHEBI:45951	trifluoperazine
+MESH	D014271	Trifluridine	CHEBI	CHEBI:75179	trifluridine
+MESH	D014280	Triglycerides	CHEBI	CHEBI:17855	triglyceride
+MESH	D014282	Trihexyphenidyl	CHEBI	CHEBI:9720	Trihexyphenidyl
+MESH	D014290	Metipranolol	CHEBI	CHEBI:6897	metipranolol
+MESH	D014291	Trimeprazine	CHEBI	CHEBI:9725	Trimeprazine
+MESH	D014293	Trimethadione	CHEBI	CHEBI:9727	Trimethadione
+MESH	D014294	Trimethaphan	CHEBI	CHEBI:9728	trimethaphan
+MESH	D014295	Trimethoprim	CHEBI	CHEBI:45924	trimethoprim
+MESH	D014299	Trimipramine	CHEBI	CHEBI:9738	trimipramine
+MESH	D014303	Trinitrotoluene	CHEBI	CHEBI:46053	2,4,6-trinitrotoluene
+MESH	D014304	Triolein	CHEBI	CHEBI:53753	triolein
+MESH	D014307	Trioxsalen	CHEBI	CHEBI:28329	trioxsalen
+MESH	D014309	Tripelennamine	CHEBI	CHEBI:9741	Tripelennamine
+MESH	D014316	Tritium	CHEBI	CHEBI:29298	ditritium
+MESH	D014325	Tromethamine	CHEBI	CHEBI:9754	tris
+MESH	D014331	Tropicamide	CHEBI	CHEBI:9757	Tropicamide
 MESH	D014333	Tropoelastin	HGNC	3327	ELN
+MESH	D014334	Tropolone	CHEBI	CHEBI:79966	Tropolone
 MESH	D014359	Trypsin Inhibitor, Kazal Pancreatic	HGNC	11244	SPINK1
 MESH	D014368	Tryptophanase	HGNC	11708	TDO2
+MESH	D014372	Tubercidin	CHEBI	CHEBI:48267	tubercidin
+MESH	D014403	Tubocurarine	CHEBI	CHEBI:9774	tubocurarine
 MESH	D014409	Tumor Necrosis Factor-alpha	HGNC	11892	TNF
+MESH	D014411	Neoplastic Stem Cells	CHEBI	CHEBI:53115	8-(3-chlorostyryl)caffeine
+MESH	D014414	Tungsten	CHEBI	CHEBI:27998	tungsten
+MESH	D014415	Tunicamycin	CHEBI	CHEBI:29699	tunicamycin
+MESH	D014439	Tyramine	CHEBI	CHEBI:15760	tyramine
 MESH	D014442	Monophenol Monooxygenase	HGNC	12442	TYR
+MESH	D014494	Unithiol	CHEBI	CHEBI:888	2,3-disulfanylpropane-1-sulfonic acid
+MESH	D014498	Uracil	CHEBI	CHEBI:17568	uracil
+MESH	D014508	Urea	CHEBI	CHEBI:16199	urea
+MESH	D014520	Urethane	CHEBI	CHEBI:17967	urethane
+MESH	D014529	Uridine	CHEBI	CHEBI:16704	uridine
+MESH	D014558	Urobilinogen	CHEBI	CHEBI:29026	urobilinogen
 MESH	D014559	Urocanate Hydratase	HGNC	26444	UROC1
+MESH	D014580	Ursodeoxycholic Acid	CHEBI	CHEBI:9907	ursodeoxycholic acid
 MESH	D014598	Uteroglobin	HGNC	12523	SCGB1A1
+MESH	D014638	Vanadates	CHEBI	CHEBI:30528	vanadium oxoanion
+MESH	D014639	Vanadium	CHEBI	CHEBI:27698	vanadium atom
+MESH	D014700	Verapamil	CHEBI	CHEBI:9948	verapamil
+MESH	D014701	Veratridine	CHEBI	CHEBI:28051	veratridine
+MESH	D014702	Veratrine	CHEBI	CHEBI:28051	veratridine
+MESH	D014740	Vidarabine	CHEBI	CHEBI:45327	adenine arabinoside
 MESH	D014746	Vimentin	HGNC	12692	VIM
+MESH	D014747	Vinblastine	CHEBI	CHEBI:27375	vincaleukoblastine
+MESH	D014749	Vincamine	CHEBI	CHEBI:9985	vincamine
+MESH	D014750	Vincristine	CHEBI	CHEBI:28445	vincristine
+MESH	D014752	Vinyl Chloride	CHEBI	CHEBI:28509	chloroethene
+MESH	D014801	Vitamin A	CHEBI	CHEBI:17336	all-trans-retinol
+MESH	D014810	Vitamin E	CHEBI	CHEBI:18145	(+)-alpha-tocopherol
+MESH	D014812	Vitamin K	CHEBI	CHEBI:28384	vitamin K
+MESH	D014815	Vitamins	CHEBI	CHEBI:33229	vitamin
+MESH	D014867	Water	CHEBI	CHEBI:15377	water
+MESH	D014975	Lutein	CHEBI	CHEBI:28838	lutein
+MESH	D014978	Xenon	CHEBI	CHEBI:49957	xenon atom
+MESH	D014993	Xylitol	CHEBI	CHEBI:17151	xylitol
+MESH	D014994	Xylose	CHEBI	CHEBI:15936	aldehydo-D-xylose
+MESH	D014994	Xylose	CHEBI	CHEBI:18222	xylose
+MESH	D015016	Yohimbine	CHEBI	CHEBI:10093	yohimbine
+MESH	D015026	Zeatin	CHEBI	CHEBI:16522	trans-zeatin
+MESH	D015049	Zoxazolamine	CHEBI	CHEBI:35053	Zoxazolamine
+MESH	D015057	1-Naphthylamine	CHEBI	CHEBI:50450	1-naphthylamine
+MESH	D015058	1-Naphthylisothiocyanate	CHEBI	CHEBI:35455	1-naphthyl isothiocyanate
+MESH	D015069	18-Hydroxycorticosterone	CHEBI	CHEBI:16485	18-hydroxycorticosterone
+MESH	D015073	2-Acetylaminofluorene	CHEBI	CHEBI:17356	2-acetamidofluorene
+MESH	D015078	2-Hydroxyphenethylamine	CHEBI	CHEBI:16343	phenylethanolamine
+MESH	D015081	2-Naphthylamine	CHEBI	CHEBI:27878	2-naphthylamine
+MESH	D015085	2,4,5-Trichlorophenoxyacetic Acid	CHEBI	CHEBI:27903	(2,4,5-trichlorophenoxy)acetic acid
+MESH	D015086	2,6-Dichloroindophenol	CHEBI	CHEBI:945	2,6-dichloroindophenol
 MESH	D015087	2',3'-Cyclic-Nucleotide Phosphodiesterases	HGNC	2158	CNP
 MESH	D015090	25-Hydroxyvitamin D3 1-alpha-Hydroxylase	HGNC	2606	CYP27B1
+MESH	D015101	3,3'-Dichlorobenzidine	CHEBI	CHEBI:82315	3,3'-Dichlorobenzidine
+MESH	D015107	4-Butyrolactone	CHEBI	CHEBI:42639	gamma-butyrolactone
+MESH	D015112	4-Nitroquinoline-1-oxide	CHEBI	CHEBI:16907	4-nitroquinoline N-oxide
+MESH	D015113	Androstane-3,17-diol	CHEBI	CHEBI:27727	androstane-3,17-diol
+MESH	D015114	Androstenediol	CHEBI	CHEBI:2710	androst-5-ene-3beta,17beta-diol
+MESH	D015122	Mercaptopurine	CHEBI	CHEBI:2208	purine-6-thiol
+MESH	D015122	Mercaptopurine	CHEBI	CHEBI:50667	mercaptopurine
+MESH	D015123	7,8-Dihydro-7,8-dihydroxybenzo(a)pyrene 9,10-oxide	CHEBI	CHEBI:30614	benzo[a]pyrene diol epoxide I
+MESH	D015125	Oxyquinoline	CHEBI	CHEBI:48981	quinolin-8-ol
+MESH	D015126	8,11,14-Eicosatrienoic Acid	CHEBI	CHEBI:53486	all-cis-icosa-8,11,14-trienoic acid
+MESH	D015127	9,10-Dimethyl-1,2-benzanthracene	CHEBI	CHEBI:254496	7,12-dimethyltetraphene
+MESH	D015215	Zidovudine	CHEBI	CHEBI:10110	zidovudine
+MESH	D015230	Prostaglandin D2	CHEBI	CHEBI:15555	prostaglandin D2
+MESH	D015232	Dinoprostone	CHEBI	CHEBI:15551	prostaglandin E2
 MESH	D015234	HLA-A Antigens	HGNC	4931	HLA-A
 MESH	D015235	HLA-B Antigens	HGNC	4932	HLA-B
 MESH	D015236	HLA-C Antigens	HGNC	4933	HLA-C
+MESH	D015237	Dinoprost	CHEBI	CHEBI:15553	prostaglandin F2alpha
+MESH	D015248	Gemfibrozil	CHEBI	CHEBI:5296	gemfibrozil
+MESH	D015251	Epirubicin	CHEBI	CHEBI:47898	4'-epidoxorubicin
+MESH	D015255	Idarubicin	CHEBI	CHEBI:42068	idarubicin
 MESH	D015260	Neprilysin	HGNC	7154	MME
-MESH	D015288	Neurokinin A	HGNC	11517	TAC1
+MESH	D015283	Citalopram	CHEBI	CHEBI:3723	citalopram
 MESH	D015292	Glycoprotein Hormones, alpha Subunit	HGNC	1885	CGA
+MESH	D015296	Ceftizoxime	CHEBI	CHEBI:553473	ceftizoxime
+MESH	D015313	Cefotetan	CHEBI	CHEBI:3499	cefotetan
+MESH	D015365	Enoxacin	CHEBI	CHEBI:157175	enoxacin
+MESH	D015366	Pefloxacin	CHEBI	CHEBI:50199	pefloxacin
+MESH	D015376	Nimustine	CHEBI	CHEBI:7576	nimustine hydrochloride
+MESH	D015378	Imipenem	CHEBI	CHEBI:471744	imipenem
+MESH	D015572	Spiramycin	CHEBI	CHEBI:85260	spiramycin I
+MESH	D015575	Roxithromycin	CHEBI	CHEBI:32109	(Z)-roxithromycin
+MESH	D015632	1-Methyl-4-phenyl-1,2,3,6-tetrahydropyridine	CHEBI	CHEBI:17963	1-methyl-4-phenyl-1,2,3,6-tetrahydropyridine
+MESH	D015636	Magnesium Chloride	CHEBI	CHEBI:6636	magnesium dichloride
+MESH	D015645	Tylosin	CHEBI	CHEBI:17658	tylosin
+MESH	D015647	2,3,4,5-Tetrahydro-7,8-dihydroxy-1-phenyl-1H-3-benzazepine	CHEBI	CHEBI:131793	SKF 38393
+MESH	D015652	25-Hydroxyvitamin D 2	CHEBI	CHEBI:86319	25-hydroxyvitamin D2
+MESH	D015655	1-Methyl-4-phenylpyridinium	CHEBI	CHEBI:641	N-methyl-4-phenylpyridinium
+MESH	D015662	Trimethoprim, Sulfamethoxazole Drug Combination	CHEBI	CHEBI:3770	co-trimoxazole
 MESH	D015675	Osteocalcin	HGNC	1043	BGLAP
 MESH	D015676	Osteonectin	HGNC	11219	SPARC
+MESH	D015735	Mifepristone	CHEBI	CHEBI:50692	mifepristone
+MESH	D015741	Metribolone	CHEBI	CHEBI:379896	17beta-hydroxy-17-methylestra-4,9,11-trien-3-one
+MESH	D015742	Propofol	CHEBI	CHEBI:44915	propofol
+MESH	D015760	Alfentanil	CHEBI	CHEBI:2569	alfentanil
+MESH	D015761	4-Aminopyridine	CHEBI	CHEBI:34385	4-aminopyridine
+MESH	D015764	Bepridil	CHEBI	CHEBI:3061	bepridil
+MESH	D015766	Albendazole	CHEBI	CHEBI:16664	albendazole
+MESH	D015774	Ganciclovir	CHEBI	CHEBI:465284	ganciclovir
 MESH	D015786	Cytochromes b5	HGNC	2570	CYB5A
+MESH	D015790	Cefonicid	CHEBI	CHEBI:3491	cefonicid
 MESH	D015844	Heparin Cofactor II	HGNC	4838	SERPIND1
 MESH	D015847	Interleukin-4	HGNC	6014	IL4
 MESH	D015848	Interleukin-5	HGNC	6016	IL5
 MESH	D015850	Interleukin-6	HGNC	6018	IL6
 MESH	D015851	Interleukin-7	HGNC	6023	IL7
+MESH	D015946	Ethylene Dibromide	CHEBI	CHEBI:28534	1,2-dibromoethane
 MESH	D015977	Eukaryotic Initiation Factor-1	HGNC	3249	EIF1
+MESH	D016047	Zalcitabine	CHEBI	CHEBI:10101	zalcitabine
+MESH	D016048	Dideoxyadenosine	CHEBI	CHEBI:91207	2',3'-dideoxyadenosine
+MESH	D016049	Didanosine	CHEBI	CHEBI:490877	didanosine
 MESH	D016173	Macrophage Colony-Stimulating Factor	HGNC	2432	CSF1
 MESH	D016178	Granulocyte-Macrophage Colony-Stimulating Factor	HGNC	2434	CSF2
 MESH	D016179	Granulocyte Colony-Stimulating Factor	HGNC	2438	CSF3
 MESH	D016189	Dystrophin	HGNC	2928	DMD
+MESH	D016190	Carboplatin	CHEBI	CHEBI:31355	carboplatin
 MESH	D016209	Interleukin-8	HGNC	6025	CXCL8
 MESH	D016211	Transforming Growth Factor alpha	HGNC	11765	TGFA
 MESH	D016212	Transforming Growth Factor beta	FPLX	TGFB	TGFB
 MESH	D016213	Cyclins	FPLX	Cyclin	Cyclin
 MESH	D016220	Fibroblast Growth Factor 1	HGNC	3665	FGF1
 MESH	D016222	Fibroblast Growth Factor 2	HGNC	3676	FGF2
+MESH	D016244	Guanosine 5'-O-(3-Thiotriphosphate)	CHEBI	CHEBI:43000	guanosine 5'-[gamma-thio]triphosphate
+MESH	D016293	Moricizine	CHEBI	CHEBI:6997	moricizine
+MESH	D016314	Ethylketocyclazocine	CHEBI	CHEBI:4901	Ethylketocyclazocine
+MESH	D016316	Guanfacine	CHEBI	CHEBI:5558	Guanfacine
 MESH	D016328	NF-kappa B	FPLX	NFkappaB	NFkappaB
+MESH	D016422	Letter	CHEBI	CHEBI:6446	levothyroxine sodium anhydrous
+MESH	D016547	Kinesin	FPLX	Kinesin	Kinesin
+MESH	D016559	Tacrolimus	CHEBI	CHEBI:61049	tacrolimus (anhydrous)
+MESH	D016590	Aphidicolin	CHEBI	CHEBI:2766	aphidicolin
+MESH	D016593	Terfenadine	CHEBI	CHEBI:9453	Terfenadine
 MESH	D016596	Vinculin	HGNC	12665	VCL
+MESH	D016604	Aflatoxin B1	CHEBI	CHEBI:2504	aflatoxin B1
+MESH	D016607	Aflatoxin M1	CHEBI	CHEBI:78576	aflatoxin M1
+MESH	D016620	Enprostil	CHEBI	CHEBI:31538	Enprostil
+MESH	D016627	Oxidopamine	CHEBI	CHEBI:78741	oxidopamine
 MESH	D016632	Apolipoprotein A-I	HGNC	600	APOA1
 MESH	D016633	Apolipoprotein A-II	HGNC	601	APOA2
+MESH	D016642	Bupropion	CHEBI	CHEBI:3219	bupropion
+MESH	D016644	Canthaxanthin	CHEBI	CHEBI:3362	canthaxanthin
+MESH	D016650	Fluorescein-5-isothiocyanate	CHEBI	CHEBI:37926	fluorescein isothiocyanate
+MESH	D016666	Fluvoxamine	CHEBI	CHEBI:5138	fluvoxamine
+MESH	D016685	Mitomycin	CHEBI	CHEBI:27504	mitomycin C
+MESH	D016686	Monocrotaline	CHEBI	CHEBI:6980	monocrotaline
+MESH	D016700	Encainide	CHEBI	CHEBI:4788	encainide
 MESH	D016708	Synaptophysin	HGNC	11506	SYP
 MESH	D016753	Interleukin-10	HGNC	5962	IL10
+MESH	D016877	Oxidants	CHEBI	CHEBI:63248	oxidising agent
 MESH	D016899	Interferon-beta	FPLX	IFNB	IFNB
 MESH	D016906	Interleukin-9	HGNC	6029	IL9
+MESH	D016912	Levonorgestrel	CHEBI	CHEBI:6443	levonorgestrel
+MESH	D017026	Swainsonine	CHEBI	CHEBI:9367	swainsonine
 MESH	D017228	Hepatocyte Growth Factor	HGNC	4236	GFER
+MESH	D017239	Paclitaxel	CHEBI	CHEBI:45863	paclitaxel
+MESH	D017245	Foscarnet	CHEBI	CHEBI:127780	phosphonoformic acid
+MESH	D017255	Acitretin	CHEBI	CHEBI:50173	all-trans-acitretin
+MESH	D017257	Ramipril	CHEBI	CHEBI:8774	ramipril
+MESH	D017259	Dimaprit	CHEBI	CHEBI:81389	Dimaprit
+MESH	D017275	Isradipine	CHEBI	CHEBI:6073	Isradipine
+MESH	D017291	Clarithromycin	CHEBI	CHEBI:3732	clarithromycin
+MESH	D017292	Doxazosin	CHEBI	CHEBI:4708	doxazosin
+MESH	D017294	Ondansetron	CHEBI	CHEBI:7773	Ondansetron
+MESH	D017298	Bisoprolol	CHEBI	CHEBI:3127	bisoprolol
+MESH	D017300	Pipecuronium	CHEBI	CHEBI:8230	Pipecuronium
 MESH	D017304	Annexin A5	HGNC	543	ANXA5
 MESH	D017305	Annexin A1	HGNC	533	ANXA1
 MESH	D017306	Annexin A2	HGNC	537	ANXA2
+MESH	D017307	Xamoterol	CHEBI	CHEBI:10055	Xamoterol
 MESH	D017310	Annexin A7	HGNC	545	ANXA7
+MESH	D017313	Fenretinide	CHEBI	CHEBI:42588	4-hydroxyphenyl retinamide
 MESH	D017314	Annexin A4	HGNC	542	ANXA4
 MESH	D017317	Annexin A6	HGNC	544	ANXA6
 MESH	D017318	Annexin A3	HGNC	541	ANXA3
+MESH	D017336	Loratadine	CHEBI	CHEBI:6538	Loratadine
 MESH	D017337	Sermorelin	HGNC	4265	GHRH
+MESH	D017338	Cladribine	CHEBI	CHEBI:567361	cladribine
 MESH	D017370	Interleukin-11	HGNC	5966	IL11
+MESH	D017371	8-Hydroxy-2-(di-n-propylamino)tetralin	CHEBI	CHEBI:73364	8-OH-DPAT
+MESH	D017374	Paroxetine	CHEBI	CHEBI:7936	paroxetine
+MESH	D017382	Reactive Oxygen Species	CHEBI	CHEBI:26523	reactive oxygen species
 MESH	D017395	Plasminogen Activator Inhibitor 1	HGNC	8583	SERPINE1
 MESH	D017396	Plasminogen Activator Inhibitor 2	HGNC	8584	SERPINB2
 MESH	D017430	Prostate-Specific Antigen	HGNC	6364	KLK3
+MESH	D017485	1-Deoxynojirimycin	CHEBI	CHEBI:44369	duvoglustat
+MESH	D017572	Leukotriene A4	CHEBI	CHEBI:15651	leukotriene A4
+MESH	D017630	Connexins	FPLX	GJ	GJ
+MESH	D017638	Asbestos, Crocidolite	CHEBI	CHEBI:46666	crocidolite asbestos
+MESH	D017639	Asbestos, Amosite	CHEBI	CHEBI:46678	amosite asbestos
+MESH	D017828	Rifabutin	CHEBI	CHEBI:45367	rifabutin
+MESH	D017835	Nedocromil	CHEBI	CHEBI:7492	nedocromil
+MESH	D017878	4,4'-Diisothiocyanostilbene-2,2'-Disulfonic Acid	CHEBI	CHEBI:4286	4,4'-diisothiocyano-trans-stilbene-2,2'-disulfonic acid
+MESH	D017964	Itraconazole	CHEBI	CHEBI:6076	itraconazole
+MESH	D017984	Enoxaparin	CHEBI	CHEBI:28304	heparin
+MESH	D017997	Leukotriene C4	CHEBI	CHEBI:16978	leukotriene C4
+MESH	D017998	Leukotriene D4	CHEBI	CHEBI:28666	leukotriene D4
+MESH	D017999	Leukotriene E4	CHEBI	CHEBI:15650	leukotriene E4
 MESH	D018008	Myogenin	HGNC	7612	MYOG
 MESH	D018031	Connexin 43	HGNC	4274	GJA1
 MESH	D018046	Protein C Inhibitor	HGNC	8723	SERPINA5
+MESH	D018119	Stavudine	CHEBI	CHEBI:63581	stavudine
+MESH	D018171	Agrin	HGNC	329	AGRN
 MESH	D018180	Thrombomodulin	HGNC	11784	THBD
 MESH	D018260	Gelsolin	HGNC	4620	GSN
+MESH	D018350	alpha-Amino-3-hydroxy-5-methyl-4-isoxazolepropionic Acid	CHEBI	CHEBI:28812	(aminomethyl)phosphonic acid
 MESH	D018394	CA-125 Antigen	HGNC	15582	MUC16
 MESH	D018396	Mucin-1	HGNC	7508	MUC1
 MESH	D018664	Interleukin-12	FPLX	IL12	IL12
 MESH	D018719	Receptor, ErbB-2	HGNC	3430	ERBB2
+MESH	D018723	Bethanechol	CHEBI	CHEBI:3084	bethanechol
+MESH	D018738	Hexamethonium	CHEBI	CHEBI:5700	Hexamethonium
+MESH	D018750	6-Cyano-7-nitroquinoxaline-2,3-dione	CHEBI	CHEBI:34468	6-Cyano-7-nitroquinoxaline-2,3-dione
 MESH	D018793	Interleukin-13	HGNC	5973	IL13
 MESH	D018799	Intercellular Adhesion Molecule-1	HGNC	5344	ICAM1
 MESH	D018808	Transcription Factor AP-1	FPLX	AP1	AP1
 MESH	D018809	Proliferating Cell Nuclear Antigen	HGNC	8729	PCNA
+MESH	D018817	N-Methyl-3,4-methylenedioxyamphetamine	CHEBI	CHEBI:1391	3,4-methylenedioxymethamphetamine
 MESH	D018826	CD13 Antigens	HGNC	500	ANPEP
 MESH	D018834	Chaperonin 60	HGNC	5261	HSPD1
 MESH	D018835	Chaperonin 10	HGNC	5269	HSPE1
@@ -283,12 +1559,23 @@ MESH	D019041	L-Selectin	HGNC	10720	SELL
 MESH	D019063	Tenascin	HGNC	5318	TNC
 MESH	D019063	Tenascin	FPLX	TN	TN
 MESH	D019096	Vitronectin	HGNC	12724	VTN
+MESH	D019207	beta Carotene	CHEBI	CHEBI:17579	beta-carotene
 MESH	D019208	Brain-Derived Neurotrophic Factor	HGNC	1033	BDNF
 MESH	D019255	NADPH Oxidases	FPLX	NADPH_oxidase	NADPH_oxidase
+MESH	D019256	Cadmium Chloride	CHEBI	CHEBI:35456	cadmium dichloride
+MESH	D019259	Lamivudine	CHEBI	CHEBI:63577	lamivudine
+MESH	D019271	Hypoxanthine	CHEBI	CHEBI:17368	hypoxanthine
+MESH	D019284	Thapsigargin	CHEBI	CHEBI:9516	thapsigargin
+MESH	D019297	2,4-Dinitrophenol	CHEBI	CHEBI:42017	2,4-dinitrophenol
+MESH	D019307	1-(5-Isoquinolinesulfonyl)-2-Methylpiperazine	CHEBI	CHEBI:83438	1-(5-isoquinolinesulfonyl)-2-methylpiperazine
+MESH	D019311	Staurosporine	CHEBI	CHEBI:15738	staurosporine
+MESH	D019329	Idazoxan	CHEBI	CHEBI:5862	idazoxan
 MESH	D019332	Endothelin-1	HGNC	3176	EDN1
 MESH	D019333	Endothelin-2	HGNC	3177	EDN2
 MESH	D019334	Endothelin-3	HGNC	3178	EDN3
 MESH	D019363	Cytochrome P-450 CYP1A1	HGNC	2595	CYP1A1
+MESH	D019377	12-Hydroxy-5,8,10,14-eicosatetraenoic Acid	CHEBI	CHEBI:19138	12-HETE
+MESH	D019386	Alendronate	CHEBI	CHEBI:2567	alendronic acid
 MESH	D019388	Cytochrome P-450 CYP1A2	HGNC	2596	CYP1A2
 MESH	D019389	Cytochrome P-450 CYP2D6	HGNC	2625	CYP2D6
 MESH	D019392	Cytochrome P-450 CYP2E1	HGNC	2631	CYP2E1
@@ -297,6 +1584,9 @@ MESH	D019405	Cytochrome P-450 CYP11B2	HGNC	2592	CYP11B2
 MESH	D019408	Platelet Endothelial Cell Adhesion Molecule-1	HGNC	8823	PECAM1
 MESH	D019409	Interleukin-15	HGNC	5977	IL15
 MESH	D019410	Interleukin-16	HGNC	5980	IL16
+MESH	D019415	Torque	CHEBI	CHEBI:39294	fenbutatin oxide
+MESH	D019469	Indinavir	CHEBI	CHEBI:44032	indinavir
+MESH	D019587	Dietary Supplements	CHEBI	CHEBI:50733	nutraceutical
 MESH	D019679	Kininogen, High-Molecular-Weight	HGNC	6383	KNG1
 MESH	D019699	Thrombospondins	FPLX	THBS	THBS
 MESH	D019700	Thrombospondin 1	HGNC	11785	THBS1
@@ -304,13 +1594,47 @@ MESH	D019715	Tissue Inhibitor of Metalloproteinase-1	HGNC	11820	TIMP1
 MESH	D019716	Tissue Inhibitor of Metalloproteinase-2	HGNC	11821	TIMP2
 MESH	D019717	Tissue Inhibitor of Metalloproteinase-3	HGNC	11822	TIMP3
 MESH	D019718	Receptors, CXCR4	HGNC	2561	CXCR4
+MESH	D019741	Haemophilus influenzae type b	CHEBI	CHEBI:143719	H. influenzae type B capsular polysaccharide
+MESH	D019772	Topotecan	CHEBI	CHEBI:63632	topotecan
+MESH	D019782	Riluzole	CHEBI	CHEBI:8863	Riluzole
+MESH	D019788	Fluorodeoxyglucose F18	CHEBI	CHEBI:49134	2-deoxy-2-((18)F)fluoro-D-glucose
+MESH	D019789	Tetraethylammonium	CHEBI	CHEBI:44296	tetraethylammonium
+MESH	D019800	Phenol	CHEBI	CHEBI:15882	phenol
+MESH	D019804	Mesalamine	CHEBI	CHEBI:6775	mesalamine
+MESH	D019806	Cromakalim	CHEBI	CHEBI:3921	Cromakalim
+MESH	D019808	Losartan	CHEBI	CHEBI:6541	losartan
+MESH	D019811	Hydroxylamine	CHEBI	CHEBI:15429	hydroxylamine
+MESH	D019821	Simvastatin	CHEBI	CHEBI:9150	simvastatin
+MESH	D019829	Nevirapine	CHEBI	CHEBI:63613	nevirapine
+MESH	D019830	Adenosine-5'-(N-ethylcarboxamide)	CHEBI	CHEBI:73284	N-ethyl-5'-carboxamidoadenosine
+MESH	D019840	2-Propanol	CHEBI	CHEBI:17824	propan-2-ol
+MESH	D019855	Ethylene Glycol	CHEBI	CHEBI:30742	ethylene glycol
+MESH	D019856	Ethanolamine	CHEBI	CHEBI:16000	ethanolamine
 MESH	D019869	Phosphatidylinositol 3-Kinases	FPLX	PI3K	PI3K
 MESH	D019894	Peptide YY	HGNC	9748	PYY
+MESH	D019905	Benzyl Alcohol	CHEBI	CHEBI:17987	benzyl alcohol
 MESH	D019922	GAP-43 Protein	HGNC	4140	GAP43
 MESH	D019925	Cyclin A	FPLX	Cyclin_A	Cyclin_A
+MESH	D019946	Propylene Glycol	CHEBI	CHEBI:16997	propane-1,2-diol
+MESH	D020001	1-Butanol	CHEBI	CHEBI:28885	butan-1-ol
+MESH	D020003	1-Octanol	CHEBI	CHEBI:16188	octan-1-ol
+MESH	D020008	Delavirdine	CHEBI	CHEBI:119573	delavirdine
 MESH	D020051	N-Acetylgalactosamine-4-Sulfatase	HGNC	714	ARSB
+MESH	D020058	Styrene	CHEBI	CHEBI:27452	styrene
 MESH	D020059	Cathepsin E	HGNC	2530	CTSE
+MESH	D020105	Milrinone	CHEBI	CHEBI:50693	milrinone
+MESH	D020106	Acrylamide	CHEBI	CHEBI:28619	acrylamide
+MESH	D020110	Pinacidil	CHEBI	CHEBI:34923	Pinacidil
+MESH	D020111	Chlorodiphenyl (54% Chlorine)	CHEBI	CHEBI:63933	Aroclor 1254
+MESH	D020112	Rhodamine 123	CHEBI	CHEBI:8828	rhodamine 123
 MESH	D020115	Pepsinogen C	HGNC	8890	PGC
+MESH	D020117	Cisapride	CHEBI	CHEBI:3720	cisapride
+MESH	D020122	tert-Butylhydroperoxide	CHEBI	CHEBI:64090	tert-butyl hydroperoxide
+MESH	D020123	Sirolimus	CHEBI	CHEBI:9168	sirolimus
+MESH	D020126	Brefeldin A	CHEBI	CHEBI:48080	brefeldin A
+MESH	D020245	p-Chloromercuribenzoic Acid	CHEBI	CHEBI:28420	p-chloromercuribenzoic acid
+MESH	D020280	Sertraline	CHEBI	CHEBI:9123	sertraline
+MESH	D020366	Methylmethacrylate	CHEBI	CHEBI:34840	methyl methacrylate
 MESH	D020381	Interleukin-17	HGNC	5981	IL17A
 MESH	D020382	Interleukin-18	HGNC	5986	IL18
 MESH	D020410	Activated-Leukocyte Cell Adhesion Molecule	HGNC	400	ALCAM
@@ -321,6 +1645,7 @@ MESH	D020691	rab GTP-Binding Proteins	FPLX	RAB	RAB
 MESH	D020717	Eukaryotic Initiation Factor-2B	FPLX	EIF2B	EIF2B
 MESH	D020717	Eukaryotic Initiation Factor-2B	HGNC	3257	EIF2B1
 MESH	D020738	Leptin	HGNC	6553	LEP
+MESH	D020748	Mibefradil	CHEBI	CHEBI:6920	Mibefradil
 MESH	D020778	Matrix Metalloproteinase 2	HGNC	7166	MMP2
 MESH	D020780	Matrix Metalloproteinase 9	HGNC	7176	MMP9
 MESH	D020782	Matrix Metalloproteinases	FPLX	MMP	MMP
@@ -331,8 +1656,11 @@ MESH	D020797	Receptor, Platelet-Derived Growth Factor beta	HGNC	8804	PDGFRB
 MESH	D020842	Plasma Kallikrein	HGNC	6371	KLKB1
 MESH	D020880	Neuregulins	FPLX	NRG	NRG
 MESH	D020904	Glia Maturation Factor	HGNC	4373	GMFB
+MESH	D020909	Acarbose	CHEBI	CHEBI:2376	acarbose
+MESH	D020927	Dexmedetomidine	CHEBI	CHEBI:4466	dexmedetomidine
 MESH	D020932	Nerve Growth Factor	HGNC	7808	NGF
 MESH	D020934	Ciliary Neurotrophic Factor	HGNC	2169	CNTF
+MESH	D020959	Polyethylene	CHEBI	CHEBI:53227	poly(ethylene)
 MESH	D021984	Cyclophilin A	HGNC	9253	PPIA
 MESH	D022061	Tacrolimus Binding Protein 1A	HGNC	3711	FKBP1A
 MESH	D023201	CD40 Ligand	HGNC	11935	CD40LG
@@ -341,7 +1669,16 @@ MESH	D024241	HMGN1 Protein	HGNC	4984	HMGN1
 MESH	D024242	HMGN2 Protein	HGNC	4986	HMGN2
 MESH	D024243	HMGB1 Protein	HGNC	4983	HMGB1
 MESH	D024261	HMGB2 Protein	HGNC	5000	HMGB2
+MESH	D024321	zeta Carotene	CHEBI	CHEBI:28068	all-trans-zeta-carotene
+MESH	D024482	Vitamin K 2	CHEBI	CHEBI:16374	menaquinone
+MESH	D024482	Vitamin K 2	CHEBI	CHEBI:78277	menatetrenone
+MESH	D024483	Vitamin K 3	CHEBI	CHEBI:28869	menadione
+MESH	D024502	alpha-Tocopherol	CHEBI	CHEBI:18145	(+)-alpha-tocopherol
+MESH	D024503	beta-Tocopherol	CHEBI	CHEBI:47771	beta-tocopherol
+MESH	D024504	gamma-Tocopherol	CHEBI	CHEBI:18185	gamma-tocopherol
+MESH	D024505	Tocopherols	CHEBI	CHEBI:27013	tocopherol
 MESH	D024982	Glycogen Phosphorylase, Muscle Form	HGNC	9726	PYGM
+MESH	D025101	Vitamin B 6	CHEBI	CHEBI:27306	vitamin B6
 MESH	D025542	Neurofibromin 1	HGNC	7765	NF1
 MESH	D025581	Neurofibromin 2	HGNC	7773	NF2
 MESH	D025765	HMGB3 Protein	HGNC	5004	HMGB3
@@ -349,13 +1686,19 @@ MESH	D025801	Ubiquitin	FPLX	Ubiquitin	Ubiquitin
 MESH	D025803	Tumor Suppressor Protein p14ARF	HGNC	1787	CDKN2A
 MESH	D025842	SUMO-1 Protein	HGNC	12502	SUMO1
 MESH	D025901	Carboxypeptidase B2	HGNC	2300	CPB2
+MESH	D026023	Permethrin	CHEBI	CHEBI:34911	permethrin
 MESH	D026122	Factor XIIIa	HGNC	11780	TGM4
 MESH	D026261	Diazepam Binding Inhibitor	HGNC	2690	DBI
 MESH	D026561	Low Density Lipoprotein Receptor-Related Protein-2	HGNC	6694	LRP2
 MESH	D026563	LDL-Receptor Related Protein-Associated Protein	HGNC	6701	LRPAP1
 MESH	D027201	Cationic Amino Acid Transporter 1	HGNC	11057	SLC7A1
+MESH	D027261	Fusion Regulatory Protein-1	HGNC	10776	SFRP1
 MESH	D027283	Large Neutral Amino Acid-Transporter 1	HGNC	11063	SLC7A5
+MESH	D027622	Crocus	CHEBI	CHEBI:79068	crocin-1
 MESH	D028341	Activins	FPLX	Activin	Activin
+MESH	D029866	Derris	CHEBI	CHEBI:28201	rotenone
+MESH	D031309	Ryania	CHEBI	CHEBI:8925	ryanodine
+MESH	D031605	Cocculus	CHEBI	CHEBI:134126	picrotoxin
 MESH	D034284	Dynamin I	HGNC	2972	DNM1
 MESH	D034285	Dynamin II	HGNC	2974	DNM2
 MESH	D034641	Heterogeneous-Nuclear Ribonucleoprotein K	HGNC	5044	HNRNPK
@@ -375,6 +1718,8 @@ MESH	D036386	Ephrin-A5	HGNC	3225	EFNA5
 MESH	D036387	Ephrin-B1	HGNC	3226	EFNB1
 MESH	D036388	Ephrin-B2	HGNC	3227	EFNB2
 MESH	D036389	Ephrin-B3	HGNC	3228	EFNB3
+MESH	D036563	Cyclic ADP-Ribose	CHEBI	CHEBI:31445	cyclic ADP-ribose
+MESH	D036625	Stevia	CHEBI	CHEBI:145012	rebaudioside A
 MESH	D037201	Follicle Stimulating Hormone, beta Subunit	HGNC	3964	FSHB
 MESH	D037281	Calnexin	HGNC	1473	CANX
 MESH	D037282	Calreticulin	HGNC	1455	CALR
@@ -384,6 +1729,7 @@ MESH	D037501	Galectin 2	HGNC	6562	LGALS2
 MESH	D037502	Galectin 3	HGNC	6563	LGALS3
 MESH	D037541	Galectin 4	HGNC	6565	LGALS4
 MESH	D037663	Pulmonary Surfactant-Associated Protein D	HGNC	10803	SFTPD
+MESH	D037741	Fullerenes	CHEBI	CHEBI:33128	C60 fullerene
 MESH	D038362	Glycogen Synthase Kinase 3	FPLX	GSK3	GSK3
 MESH	D038681	Follistatin	HGNC	3971	FST
 MESH	D038744	Ribosomal Protein S6 Kinases, 90-kDa	HGNC	10430	RPS6KA1
@@ -427,15 +1773,21 @@ MESH	D043425	Glutamate Carboxypeptidase II	HGNC	13636	FOLH1B
 MESH	D043425	Glutamate Carboxypeptidase II	HGNC	14526	NAALAD2
 MESH	D043425	Glutamate Carboxypeptidase II	HGNC	23536	NAALADL1
 MESH	D043523	Biotinidase	HGNC	1122	BTD
-MESH	D044162	Parathyroid Hormone-Related Protein	HGNC	9607	PTHLH
+MESH	D043582	5-alpha-Dihydroprogesterone	CHEBI	CHEBI:28952	5alpha-pregnane-3,20-dione
+MESH	D044262	Prostaglandin H2	CHEBI	CHEBI:15554	prostaglandin H2
+MESH	D044503	5-Methylcytosine	CHEBI	CHEBI:27551	5-methylcytosine
+MESH	D044646	Ascophyllum	CHEBI	CHEBI:53311	sodium alginate
 MESH	D044844	beta-Transducin Repeat-Containing Proteins	HGNC	1144	BTRC
 MESH	D044942	Acyl-CoA Dehydrogenase, Long-Chain	HGNC	92	ACADVL
+MESH	D045162	Thiazolidinediones	CHEBI	CHEBI:50990	thiazolidinediones
 MESH	D045265	Natriuretic Peptides	FPLX	Natriuretic_peptide	Natriuretic_peptide
 MESH	D045303	Cytochromes b	HGNC	7427	MT-CYB
 MESH	D045304	Cytochromes c	HGNC	19986	CYCS
 MESH	D045683	Furin	HGNC	8568	FURIN
 MESH	D045702	Proprotein Convertase 5	HGNC	8747	PCSK5
 MESH	D047150	Eosinophil Cationic Protein	HGNC	10046	RNASE3
+MESH	D047310	Apigenin	CHEBI	CHEBI:18388	apigenin
+MESH	D047311	Luteolin	CHEBI	CHEBI:15864	luteolin
 MESH	D047492	Peroxisome Proliferator-Activated Receptors	FPLX	PPAR	PPAR
 MESH	D047495	PPAR gamma	HGNC	9236	PPARG
 MESH	D047628	Estrogen Receptor alpha	HGNC	3467	ESR1
@@ -447,6 +1799,7 @@ MESH	D048015	TNF Receptor-Associated Factor 5	HGNC	12035	TRAF5
 MESH	D048029	TNF Receptor-Associated Factor 6	HGNC	12036	TRAF6
 MESH	D048051	p38 Mitogen-Activated Protein Kinases	FPLX	p38	p38
 MESH	D048068	PPAR-beta	HGNC	9235	PPARD
+MESH	D048271	Chitosan	CHEBI	CHEBI:16261	chitosan
 MESH	D048290	Mitogen-Activated Protein Kinase 11	HGNC	6873	MAPK11
 MESH	D048291	Mitogen-Activated Protein Kinase 12	HGNC	6874	MAPK12
 MESH	D048292	Mitogen-Activated Protein Kinase 13	HGNC	6875	MAPK13
@@ -456,6 +1809,7 @@ MESH	D048848	MAP Kinase Kinase Kinase 5	HGNC	6857	MAP3K5
 MESH	D049030	Dystroglycans	HGNC	2666	DAG1
 MESH	D049071	Endopeptidase Clp	HGNC	2084	CLPP
 MESH	D049411	Utrophin	HGNC	12635	UTRN
+MESH	D049971	Thiazides	CHEBI	CHEBI:50264	thiazide
 MESH	D050646	Methylmalonate-Semialdehyde Dehydrogenase (Acylating)	HGNC	7179	ALDH6A1
 MESH	D050718	Complement C1 Inhibitor Protein	HGNC	1228	SERPING1
 MESH	D050777	Stathmin	HGNC	6510	STMN1
@@ -500,13 +1854,13 @@ MESH	D051966	Phospholipase C gamma	FPLX	PLCG	PLCG
 MESH	D052003	NF-kappa B p52 Subunit	HGNC	7795	NFKB2
 MESH	D052242	Adiponectin	HGNC	13633	ADIPOQ
 MESH	D052243	Resistin	HGNC	20389	RETN
+MESH	D053139	Oseltamivir	CHEBI	CHEBI:7798	oseltamivir
 MESH	D053143	Caspase 2	HGNC	1503	CASP2
 MESH	D053146	Myeloblastin	HGNC	9495	PRTN3
 MESH	D053148	Caspase 3	HGNC	1504	CASP3
 MESH	D053178	Caspase 6	HGNC	1507	CASP6
 MESH	D053179	Caspase 7	HGNC	1508	CASP7
 MESH	D053181	Caspase 8	HGNC	1509	CASP8
-MESH	D053241	Apoprotein(a)	HGNC	6667	LPA
 MESH	D053244	Osteoprotegerin	HGNC	11909	TNFRSF11B
 MESH	D053299	Apolipoprotein B-100	HGNC	603	APOB
 MESH	D053302	Apolipoprotein C-I	HGNC	607	APOC1
@@ -517,6 +1871,7 @@ MESH	D053331	Ectodysplasins	HGNC	3157	EDA
 MESH	D053378	Chromogranin B	HGNC	1930	CHGB
 MESH	D053381	Secretogranin II	HGNC	10575	SCG2
 MESH	D053399	Apolipoproteins D	HGNC	612	APOD
+MESH	D053444	Inhibitory Postsynaptic Potentials	CHEBI	CHEBI:82134	IPSP
 MESH	D053449	TNF Receptor-Associated Factor 4	HGNC	12034	TRAF4
 MESH	D053453	Caspase 9	HGNC	1511	CASP9
 MESH	D053455	Caspase 10	HGNC	1500	CASP10
@@ -565,6 +1920,7 @@ MESH	D053773	Transforming Growth Factor beta1	HGNC	11766	TGFB1
 MESH	D053782	Transforming Growth Factor beta3	HGNC	11769	TGFB3
 MESH	D053802	Tryptases	FPLX	Tryptase	Tryptase
 MESH	D053818	Chymases	HGNC	2097	CMA1
+MESH	D054199	Pseudoephedrine	CHEBI	CHEBI:51209	pseudoephedrine
 MESH	D054353	Perforin	HGNC	9360	PRF1
 MESH	D054409	Nicotinamide Phosphoribosyltransferase	HGNC	30092	NAMPT
 MESH	D054418	Chemokine CCL20	HGNC	10619	CCL20
@@ -578,6 +1934,7 @@ MESH	D054467	Phospholipases A2	HGNC	9030	PLA2G1B
 MESH	D054509	Group X Phospholipases A2	HGNC	9029	PLA2G10
 MESH	D054578	Protein Tyrosine Phosphatase, Non-Receptor Type 2	HGNC	9650	PTPN2
 MESH	D054594	Protein Tyrosine Phosphatase, Non-Receptor Type 12	HGNC	9645	PTPN12
+MESH	D054659	Diketopiperazines	CHEBI	CHEBI:16535	piperazine-2,5-dione
 MESH	D054703	Cyclic Nucleotide Phosphodiesterases, Type 4	FPLX	PDE4	PDE4
 MESH	D054706	Cyclic Nucleotide Phosphodiesterases, Type 5	HGNC	8784	PDE5A
 MESH	D054707	Cyclic Nucleotide Phosphodiesterases, Type 6	FPLX	PDE6	PDE6
@@ -604,6 +1961,7 @@ MESH	D055436	Growth Differentiation Factor 15	HGNC	30142	GDF15
 MESH	D055451	Growth Differentiation Factor 3	HGNC	4218	GDF3
 MESH	D055452	Growth Differentiation Factor 1	HGNC	4214	GDF1
 MESH	D055513	Connective Tissue Growth Factor	HGNC	2500	CCN2
+MESH	D056564	Sirtuin 1	HGNC	14929	SIRT1
 MESH	D056646	Cathepsin F	HGNC	2531	CTSF
 MESH	D056649	Cathepsin G	HGNC	2532	CTSG
 MESH	D056657	Cathepsin K	HGNC	2536	CTSK
@@ -632,13 +1990,15 @@ MESH	D060167	Uroplakin Ia	HGNC	12577	UPK1A
 MESH	D060169	Uroplakin Ib	HGNC	12578	UPK1B
 MESH	D060170	Uroplakin II	HGNC	12579	UPK2
 MESH	D060171	Uroplakin III	HGNC	12580	UPK3A
-MESH	D060245	Tetraspanin-29	HGNC	1709	CD9
-MESH	D060265	Tetraspanin-25	HGNC	1686	CD53
+MESH	D060245	Tetraspanin 29	HGNC	1709	CD9
+MESH	D060265	Tetraspanin 25	HGNC	1686	CD53
 MESH	D060589	Zyxin	HGNC	13200	ZYX
+MESH	D060749	alpha-2-HS-Glycoprotein	HGNC	349	AHSG
 MESH	D060752	Fetuin-B	HGNC	3658	FETUB
 MESH	D060785	Mammaglobin A	HGNC	7050	SCGB2A2
 MESH	D060788	Mammaglobin B	HGNC	7051	SCGB2A1
 MESH	D061105	Peroxiredoxin III	HGNC	9354	PRDX3
+MESH	D061466	Lopinavir	CHEBI	CHEBI:31781	lopinavir
 MESH	D062445	Claudin-1	HGNC	2032	CLDN1
 MESH	D062446	Claudin-2	HGNC	2041	CLDN2
 MESH	D062465	Claudin-3	HGNC	2045	CLDN3
@@ -661,7 +2021,10 @@ MESH	D064231	Nestin	HGNC	7756	NES
 MESH	D064247	Separase	HGNC	16856	ESPL1
 MESH	D064248	Geminin	HGNC	17493	GMNN
 MESH	D064249	Securin	HGNC	9690	PTTG1
+MESH	D064412	Levalbuterol	CHEBI	CHEBI:8746	(R)-salbutamol
 MESH	D064451	Hepcidins	HGNC	15598	HAMP
+MESH	D064750	Rabeprazole	CHEBI	CHEBI:8768	rabeprazole
+MESH	D064805	Bunolol	CHEBI	CHEBI:29110	(+-)-5-[3-(tert-butylamino)-2-hydroxypropoxy]-3,4-dihydronaphthalen-1(2H)-one
 MESH	D065668	Vitamin D3 24-Hydroxylase	HGNC	2602	CYP24A1
 MESH	D065702	Cytochrome P-450 CYP2B6	HGNC	2615	CYP2B6
 MESH	D065727	Cytochrome P-450 CYP2C8	HGNC	2622	CYP2C8

--- a/gilda/resources/mesh_mappings.tsv
+++ b/gilda/resources/mesh_mappings.tsv
@@ -9,6 +9,8 @@ MESH	D000067736	Ataxin-10	HGNC	10549	ATXN10
 MESH	D000068180	Aripiprazole	CHEBI	CHEBI:31236	aripiprazole
 MESH	D000068256	Darbepoetin alfa	HGNC	4392	GNAS
 MESH	D000068338	Everolimus	CHEBI	CHEBI:68478	everolimus
+MESH	D000068437	Pemetrexed	CHEBI	CHEBI:17509	5'-S-methyl-5'-thioadenosine
+MESH	D000068576	Interferon beta-1b	CHEBI	CHEBI:5938	Interferon beta-1b
 MESH	D000068579	Celecoxib	CHEBI	CHEBI:41423	celecoxib
 MESH	D000068677	Sildenafil Citrate	CHEBI	CHEBI:58987	sildenafil citrate
 MESH	D000068679	Emtricitabine	CHEBI	CHEBI:31536	emtricitabine
@@ -103,8 +105,6 @@ MESH	D000077205	Pioglitazone	CHEBI	CHEBI:8228	pioglitazone
 MESH	D000077208	Remifentanil	CHEBI	CHEBI:8802	remifentanil
 MESH	D000077210	Sunitinib	CHEBI	CHEBI:38940	sunitinib
 MESH	D000077212	Ropivacaine	CHEBI	CHEBI:8890	(S)-ropivacaine
-MESH	D000077214	Becaplermin	HGNC	8800	PDGFB
-MESH	D000077214	Becaplermin	FPLX	PDGF_BB	PDGF_BB
 MESH	D000077222	Limonene	CHEBI	CHEBI:15384	limonene
 MESH	D000077236	Topiramate	CHEBI	CHEBI:63631	topiramate
 MESH	D000077237	Arsenic Trioxide	CHEBI	CHEBI:30621	diarsenic trioxide
@@ -122,6 +122,7 @@ MESH	D000077294	Receptor, Transforming Growth Factor-beta Type II	HGNC	11773	TGF
 MESH	D000077297	Pregnane X Receptor	HGNC	7968	NR1I2
 MESH	D000077333	Telmisartan	CHEBI	CHEBI:9434	telmisartan
 MESH	D000077335	Desflurane	CHEBI	CHEBI:4445	desflurane
+MESH	D000077336	Caspofungin	CHEBI	CHEBI:474180	caspofungin
 MESH	D000077339	Leflunomide	CHEBI	CHEBI:6402	leflunomide
 MESH	D000077385	Silybin	CHEBI	CHEBI:9144	silibinin
 MESH	D000077404	Cidofovir	CHEBI	CHEBI:3696	cidofovir anhydrous
@@ -133,6 +134,7 @@ MESH	D000077423	Polidocanol	CHEBI	CHEBI:46859	polidocanol
 MESH	D000077430	Nabumetone	CHEBI	CHEBI:7443	nabumetone
 MESH	D000077443	Acamprosate	CHEBI	CHEBI:51041	acamprosate
 MESH	D000077465	Cabergoline	CHEBI	CHEBI:3286	cabergoline
+MESH	D000077466	Tirofiban	CHEBI	CHEBI:9605	tirofiban
 MESH	D000077484	Vemurafenib	CHEBI	CHEBI:63637	vemurafenib
 MESH	D000077489	Piperazine	CHEBI	CHEBI:28568	piperazine
 MESH	D000077543	Deferiprone	CHEBI	CHEBI:68554	deferiprone
@@ -172,15 +174,15 @@ MESH	D000093	Acetoin	CHEBI	CHEBI:15688	acetoin
 MESH	D000096	Acetone	CHEBI	CHEBI:15347	acetone
 MESH	D000099	Acetoxyacetylaminofluorene	CHEBI	CHEBI:76331	N-acetoxy-2-acetamidofluorene
 MESH	D000103	Acetyl-CoA Carboxylase	FPLX	ACC	ACC
+MESH	D000105	Acetyl Coenzyme A	CHEBI	CHEBI:15351	acetyl-CoA
 MESH	D000109	Acetylcholine	CHEBI	CHEBI:15355	acetylcholine
 MESH	D000110	Acetylcholinesterase	HGNC	108	ACHE
+MESH	D000111	Acetylcysteine	CHEBI	CHEBI:28939	N-acetyl-L-cysteine
 MESH	D000114	Acetylene	CHEBI	CHEBI:27518	acetylene
 MESH	D000115	Acetylesterase	HGNC	18717	ABHD2
 MESH	D000117	Acetylglucosamine	CHEBI	CHEBI:28009	N-acetyl-beta-D-glucosamine
 MESH	D000121	Acetylserotonin O-Methyltransferase	HGNC	750	ASMT
 MESH	D000157	Aconitine	CHEBI	CHEBI:2430	aconitine
-MESH	D000165	Acridine Orange	CHEBI	CHEBI:87346	acridine orange free base
-MESH	D000165	Acridine Orange	CHEBI	CHEBI:51739	acridine orange
 MESH	D000171	Acrolein	CHEBI	CHEBI:15368	acrolein
 MESH	D000175	Acronine	CHEBI	CHEBI:2437	acronycine
 MESH	D000176	Acrosin	HGNC	126	ACR
@@ -193,7 +195,6 @@ MESH	D000246	Adenosine Diphosphate Ribose	CHEBI	CHEBI:16960	ADP-D-ribose
 MESH	D000263	Adenylate Kinase	HGNC	361	AK1
 MESH	D000264	Adenylosuccinate Lyase	HGNC	291	ADSL
 MESH	D000266	Adenylyl Imidodiphosphate	CHEBI	CHEBI:47785	AMP-PNP
-MESH	D000324	Adrenocorticotropic Hormone	HGNC	9201	POMC
 MESH	D000376	Agmatine	CHEBI	CHEBI:17431	agmatine
 MESH	D000404	Ajmaline	CHEBI	CHEBI:28462	ajmaline
 MESH	D000420	Albuterol	CHEBI	CHEBI:2549	albuterol
@@ -210,6 +211,7 @@ MESH	D000493	Allopurinol	CHEBI	CHEBI:40279	allopurinol
 MESH	D000500	Allylestrenol	CHEBI	CHEBI:31189	Allylestrenol
 MESH	D000514	alpha 1-Antichymotrypsin	HGNC	16	SERPINA3
 MESH	D000515	alpha 1-Antitrypsin	HGNC	8941	SERPINA1
+MESH	D000518	Eflornithine	CHEBI	CHEBI:41948	eflornithine
 MESH	D000519	alpha-Galactosidase	HGNC	4296	GLA
 MESH	D000523	Algestone	CHEBI	CHEBI:763	algestone
 MESH	D000525	Alprazolam	CHEBI	CHEBI:2611	alprazolam
@@ -227,7 +229,6 @@ MESH	D000638	Amiodarone	CHEBI	CHEBI:2663	amiodarone
 MESH	D000639	Amitriptyline	CHEBI	CHEBI:2666	amitriptyline
 MESH	D000640	Amitrole	CHEBI	CHEBI:40036	amitrole
 MESH	D000641	Ammonia	CHEBI	CHEBI:16134	ammonia
-MESH	D000650	Amnion	CHEBI	CHEBI:73806	Ala-Met
 MESH	D000654	Amobarbital	CHEBI	CHEBI:2673	amobarbital
 MESH	D000655	Amodiaquine	CHEBI	CHEBI:2674	amodiaquine
 MESH	D000657	Amoxapine	CHEBI	CHEBI:2675	amoxapine
@@ -242,20 +243,30 @@ MESH	D000691	Anabasine	CHEBI	CHEBI:74	(S)-anabasine
 MESH	D000735	Androstenedione	CHEBI	CHEBI:16422	androst-4-ene-3,17-dione
 MESH	D000738	Androsterone	CHEBI	CHEBI:16032	androsterone
 MESH	D000781	Anethole Trithione	CHEBI	CHEBI:31221	Anetholtrithion
+MESH	D000803	Angiotensin I	CHEBI	CHEBI:2718	Angiotensin I
+MESH	D000804	Angiotensin II	CHEBI	CHEBI:2719	Ile(5)-angiotensin II
+MESH	D000805	Angiotensin III	CHEBI	CHEBI:89666	Angiotensin III
+MESH	D000808	Angiotensinogen	CHEBI	CHEBI:2720	Angiotensinogen
+MESH	D000809	Angiotensins	CHEBI	CHEBI:2719	Ile(5)-angiotensin II
 MESH	D000841	Anisomycin	CHEBI	CHEBI:338412	(-)-anisomycin
+MESH	D000861	Anserine	CHEBI	CHEBI:18323	anserine
 MESH	D000894	Anti-Inflammatory Agents, Non-Steroidal	CHEBI	CHEBI:35475	non-steroidal anti-inflammatory drug
 MESH	D000979	alpha-2-Antiplasmin	HGNC	9075	SERPINF2
 MESH	D000983	Antipyrine	CHEBI	CHEBI:31225	antipyrine
 MESH	D000990	Antithrombin III	HGNC	775	SERPINC1
 MESH	D001032	Apazone	CHEBI	CHEBI:38010	apazone
+MESH	D001052	Apoferritins	CHEBI	CHEBI:2784	Apoferritin
 MESH	D001053	Apolipoproteins	FPLX	Apolipoprotein	Apolipoprotein
 MESH	D001054	Apolipoproteins A	FPLX	APOA	APOA
 MESH	D001057	Apolipoproteins E	HGNC	613	APOE
 MESH	D001074	Propoxur	CHEBI	CHEBI:34938	propoxur
 MESH	D001104	Arbutin	CHEBI	CHEBI:18305	hydroquinone O-beta-D-glucopyranoside
+MESH	D001127	Arginine Vasopressin	CHEBI	CHEBI:34543	argipressin
 MESH	D001141	Aromatase	HGNC	2594	CYP19A1
 MESH	D001151	Arsenic	CHEBI	CHEBI:27563	arsenic atom
 MESH	D001153	Arsphenamine	CHEBI	CHEBI:9016	arsphenamine
+MESH	D001216	Asparagine	CHEBI	CHEBI:17196	L-asparagine
+MESH	D001218	Aspartame	CHEBI	CHEBI:2877	aspartame
 MESH	D001227	Aspartylglucosylaminase	HGNC	318	AGA
 MESH	D001241	Aspirin	CHEBI	CHEBI:15365	acetylsalicylic acid
 MESH	D001278	Atractyloside	CHEBI	CHEBI:2913	Atractyloside
@@ -267,6 +278,7 @@ MESH	D001374	Azacitidine	CHEBI	CHEBI:2038	5-azacytidine
 MESH	D001375	Azaguanine	CHEBI	CHEBI:63486	8-azaguanine
 MESH	D001380	Azauridine	CHEBI	CHEBI:35668	6-azauridine
 MESH	D001387	Azinphosmethyl	CHEBI	CHEBI:2953	azinphos-methyl
+MESH	D001414	Bacitracin	CHEBI	CHEBI:28669	bacitracin
 MESH	D001455	Bambermycins	CHEBI	CHEBI:28908	bambermycin
 MESH	D001462	Barbital	CHEBI	CHEBI:31252	5,5-diethylbarbituric acid
 MESH	D001507	Beclomethasone	CHEBI	CHEBI:3001	beclomethasone
@@ -283,16 +295,22 @@ MESH	D001590	Benztropine	CHEBI	CHEBI:3048	benzatropine
 MESH	D001599	Berberine	CHEBI	CHEBI:16118	berberine
 MESH	D001603	Berkelium	CHEBI	CHEBI:33391	berkelium atom
 MESH	D001608	Beryllium	CHEBI	CHEBI:30501	beryllium atom
+MESH	D001615	beta-Endorphin	CHEBI	CHEBI:10415	beta-endorphin
 MESH	D001622	Betaine	CHEBI	CHEBI:17750	glycine betaine
 MESH	D001623	Betamethasone	CHEBI	CHEBI:3077	betamethasone
 MESH	D001640	Bicuculline	CHEBI	CHEBI:3092	bicuculline
 MESH	D001663	Bilirubin	CHEBI	CHEBI:16990	bilirubin IXalpha
 MESH	D001664	Biliverdine	CHEBI	CHEBI:17033	biliverdin
+MESH	D001708	Biopterin	CHEBI	CHEBI:15373	biopterin
+MESH	D001710	Biotin	CHEBI	CHEBI:15956	biotin
 MESH	D001726	Bisacodyl	CHEBI	CHEBI:3125	Bisacodyl
 MESH	D001728	Dicumarol	CHEBI	CHEBI:4513	dicoumarol
 MESH	D001735	Bithionol	CHEBI	CHEBI:3131	bithionol
 MESH	D001737	Biuret	CHEBI	CHEBI:18138	biuret
+MESH	D001761	Bleomycin	CHEBI	CHEBI:3139	bleomycin A2
+MESH	D001839	Bombesin	CHEBI	CHEBI:80229	Bombesin
 MESH	D001895	Boron	CHEBI	CHEBI:27560	boron atom
+MESH	D001920	Bradykinin	CHEBI	CHEBI:3165	bradykinin
 MESH	D001960	Bromazepam	CHEBI	CHEBI:31302	Bromazepam
 MESH	D001968	Bromisovalum	CHEBI	CHEBI:31304	bromisoval
 MESH	D001971	Bromocriptine	CHEBI	CHEBI:3181	bromocriptine
@@ -316,10 +334,12 @@ MESH	D002110	Caffeine	CHEBI	CHEBI:27732	caffeine
 MESH	D002112	Calcifediol	CHEBI	CHEBI:17933	calcidiol
 MESH	D002116	Calcitonin	HGNC	1437	CALCA
 MESH	D002117	Calcitriol	CHEBI	CHEBI:17823	calcitriol
+MESH	D002118	Calcium	CHEBI	CHEBI:22984	calcium atom
 MESH	D002125	Calcium Gluconate	CHEBI	CHEBI:3309	Calcium Gluconate
 MESH	D002147	Calmodulin	FPLX	CALM	CALM
 MESH	D002164	Camphor	CHEBI	CHEBI:36773	camphor
 MESH	D002166	Camptothecin	CHEBI	CHEBI:27656	camptothecin
+MESH	D002172	Canavanine	CHEBI	CHEBI:609827	L-canavanine
 MESH	D002174	Candicidin	CHEBI	CHEBI:354984	candicidin
 MESH	D002187	Cannabinol	CHEBI	CHEBI:3360	Cannabinol
 MESH	D002193	Cantharidin	CHEBI	CHEBI:64213	cantharidin
@@ -337,6 +357,7 @@ MESH	D002323	Carfecillin	CHEBI	CHEBI:3414	carfecillin
 MESH	D002328	Carisoprodol	CHEBI	CHEBI:3419	carisoprodol
 MESH	D002329	Carmine	CHEBI	CHEBI:78310	carminic acid
 MESH	D002330	Carmustine	CHEBI	CHEBI:3423	carmustine
+MESH	D002336	Carnosine	CHEBI	CHEBI:15727	carnosine
 MESH	D002351	Carrageenan	CHEBI	CHEBI:3435	carrageenan
 MESH	D002354	Carteolol	CHEBI	CHEBI:3437	carteolol
 MESH	D002360	Carubicin	CHEBI	CHEBI:31359	carminomycin
@@ -356,8 +377,6 @@ MESH	D002444	Cefuroxime	CHEBI	CHEBI:3515	cefuroxime
 MESH	D002475	Cellobiose	CHEBI	CHEBI:17057	cellobiose
 MESH	D002482	Cellulose	CHEBI	CHEBI:18246	(1->4)-beta-D-glucan
 MESH	D002504	Meclofenoxate	CHEBI	CHEBI:6712	Meclofenoxate
-MESH	D002506	Cephalexin	CHEBI	CHEBI:3534	cephalexin
-MESH	D002506	Cephalexin	CHEBI	CHEBI:3535	cephalexin monohydrate
 MESH	D002507	Cephaloglycin	CHEBI	CHEBI:34613	cefaloglycin
 MESH	D002509	Cephaloridine	CHEBI	CHEBI:3537	cefaloridine
 MESH	D002512	Cephalothin	CHEBI	CHEBI:124991	cefalotin
@@ -400,6 +419,7 @@ MESH	D002857	Chromium	CHEBI	CHEBI:28073	chromium atom
 MESH	D002936	Cinnarizine	CHEBI	CHEBI:31403	cinnarizine
 MESH	D002939	Ciprofloxacin	CHEBI	CHEBI:100241	ciprofloxacin
 MESH	D002945	Cisplatin	CHEBI	CHEBI:27899	cisplatin
+MESH	D002955	Leucovorin	CHEBI	CHEBI:15640	5-formyltetrahydrofolic acid
 MESH	D002974	Clemastine	CHEBI	CHEBI:3738	clemastine
 MESH	D002981	Clindamycin	CHEBI	CHEBI:3745	clindamycin
 MESH	D002994	Clofibrate	CHEBI	CHEBI:3750	clofibrate
@@ -410,9 +430,12 @@ MESH	D003023	Cloxacillin	CHEBI	CHEBI:49566	cloxacillin
 MESH	D003024	Clozapine	CHEBI	CHEBI:3766	clozapine
 MESH	D003042	Cocaine	CHEBI	CHEBI:27958	cocaine
 MESH	D003061	Codeine	CHEBI	CHEBI:16714	codeine
+MESH	D003065	Coenzyme A	CHEBI	CHEBI:15346	coenzyme A
 MESH	D003070	Coformycin	CHEBI	CHEBI:16213	coformycin
 MESH	D003078	Colchicine	CHEBI	CHEBI:27882	(S)-colchicine
 MESH	D003084	Colestipol	CHEBI	CHEBI:3814	colestipol
+MESH	D003091	Colistin	CHEBI	CHEBI:37943	colistin
+MESH	D003094	Collagen	CHEBI	CHEBI:3815	Collagen
 MESH	D003101	Collodion	CHEBI	CHEBI:53325	nitrocellulose
 MESH	D003175	Complement C2	HGNC	1248	C2
 MESH	D003176	Complement C3	HGNC	1318	C3
@@ -424,8 +447,10 @@ MESH	D003345	Corticosterone	CHEBI	CHEBI:16827	corticosterone
 MESH	D003346	Corticotropin-Releasing Hormone	HGNC	2355	CRH
 MESH	D003348	Cortisone	CHEBI	CHEBI:16962	cortisone
 MESH	D003350	Cortodoxone	CHEBI	CHEBI:28324	11-deoxycortisol
+MESH	D003366	Cosyntropin	CHEBI	CHEBI:3901	cosyntropin
 MESH	D003372	Coumaphos	CHEBI	CHEBI:3903	coumaphos
 MESH	D003375	Coumestrol	CHEBI	CHEBI:3908	coumestrol
+MESH	D003401	Creatine	CHEBI	CHEBI:16919	creatine
 MESH	D003404	Creatinine	CHEBI	CHEBI:16737	creatinine
 MESH	D003474	Curcumin	CHEBI	CHEBI:3962	curcumin
 MESH	D003484	Cyanamide	CHEBI	CHEBI:16698	cyanamide
@@ -436,25 +461,28 @@ MESH	D003501	Cyclizine	CHEBI	CHEBI:3994	cyclizine
 MESH	D003504	Ancitabine	CHEBI	CHEBI:74843	ancitabine hydrochloride
 MESH	D003506	Cyclofenil	CHEBI	CHEBI:31446	Cyclofenil
 MESH	D003513	Cycloheximide	CHEBI	CHEBI:27641	cycloheximide
+MESH	D003515	Cycloleucine	CHEBI	CHEBI:40547	1-aminocyclopentanecarboxylic acid
 MESH	D003519	Cyclopentolate	CHEBI	CHEBI:4024	cyclopentolate
 MESH	D003520	Cyclophosphamide	CHEBI	CHEBI:4026	cyclophosphamide hydrate
 MESH	D003529	Cymarine	CHEBI	CHEBI:4037	Cymarin
 MESH	D003533	Cyproheptadine	CHEBI	CHEBI:4046	cyproheptadine
 MESH	D003538	Cystamine	CHEBI	CHEBI:78757	cystamine
+MESH	D003540	Cystathionine	CHEBI	CHEBI:17755	cystathionine
 MESH	D003543	Cysteamine	CHEBI	CHEBI:17141	cysteamine
+MESH	D003544	Cysteic Acid	CHEBI	CHEBI:21260	cysteic acid
+MESH	D003548	Cysteinyldopa	CHEBI	CHEBI:81392	Cysteinyldopa
 MESH	D003561	Cytarabine	CHEBI	CHEBI:28680	cytarabine
 MESH	D003562	Cytidine	CHEBI	CHEBI:17562	cytidine
 MESH	D003566	Cytidine Diphosphate Choline	CHEBI	CHEBI:16436	CDP-choline
 MESH	D003571	Cytochalasin B	CHEBI	CHEBI:23527	cytochalasin B
-MESH	D003575	Cytochromes c1	HGNC	2579	CYC1
+MESH	D003580	Cytochromes	CHEBI	CHEBI:4056	cytochrome
 MESH	D003596	Cytosine	CHEBI	CHEBI:16040	cytosine
 MESH	D003606	Dacarbazine	CHEBI	CHEBI:4305	dacarbazine
+MESH	D003609	Dactinomycin	CHEBI	CHEBI:27666	actinomycin D
 MESH	D003620	Dantrolene	CHEBI	CHEBI:4317	dantrolene
 MESH	D003622	Dapsone	CHEBI	CHEBI:4325	dapsone
 MESH	D003630	Daunorubicin	CHEBI	CHEBI:41977	daunorubicin
 MESH	D003632	Dichlorodiphenyldichloroethane	CHEBI	CHEBI:27841	DDD
-MESH	D003633	Dichlorodiphenyl Dichloroethylene	CHEBI	CHEBI:16598	DDE
-MESH	D003633	Dichlorodiphenyl Dichloroethylene	CHEBI	CHEBI:27454	1-chloro-2,2-bis(4'-chlorophenyl)ethylene
 MESH	D003634	DDT	CHEBI	CHEBI:16130	DDT
 MESH	D003642	Deanol	CHEBI	CHEBI:271436	N,N-dimethylethanolamine
 MESH	D003647	Debrisoquin	CHEBI	CHEBI:34665	debrisoquin
@@ -549,17 +577,18 @@ MESH	D004394	Dydrogesterone	CHEBI	CHEBI:31527	dydrogesterone
 MESH	D004400	Dyphylline	CHEBI	CHEBI:4728	dyphylline
 MESH	D004440	Ecdysone	CHEBI	CHEBI:16688	ecdysone
 MESH	D004441	Ecdysterone	CHEBI	CHEBI:16587	20-hydroxyecdysone
+MESH	D004448	Echinomycin	CHEBI	CHEBI:80052	Quinomycin A
 MESH	D004464	Econazole	CHEBI	CHEBI:4754	econazole
 MESH	D004491	Edrophonium	CHEBI	CHEBI:251408	edrophonium
 MESH	D004533	Egtazic Acid	CHEBI	CHEBI:30740	ethylene glycol bis(2-aminoethyl)tetraacetic acid
 MESH	D004549	Elastin	HGNC	3327	ELN
-MESH	D004562	Electrocardiography	CHEBI	CHEBI:70255	(-)-epicatechin-3-O-gallate
-MESH	D004569	Electroencephalography	CHEBI	CHEBI:73494	Glu-Glu-Gly
 MESH	D004640	Emetine	CHEBI	CHEBI:4781	emetine
 MESH	D004642	Emodin	CHEBI	CHEBI:42223	emodin
+MESH	D004656	Enalapril	CHEBI	CHEBI:4784	enalapril
 MESH	D004726	Endosulfan	CHEBI	CHEBI:4791	endosulfan
 MESH	D004732	Endrin	CHEBI	CHEBI:81526	Endrin
 MESH	D004737	Enflurane	CHEBI	CHEBI:4792	enflurane
+MESH	D004758	Enterobactin	CHEBI	CHEBI:28855	enterobactin
 MESH	D004765	Enteropeptidase	HGNC	9490	TMPRSS15
 MESH	D004801	Eosine Yellowish-(YS)	CHEBI	CHEBI:52053	eosin YS dye
 MESH	D004809	Ephedrine	CHEBI	CHEBI:15407	(-)-ephedrine
@@ -587,6 +616,7 @@ MESH	D004980	Ethane	CHEBI	CHEBI:6015	isoflurane
 MESH	D004986	Ether	CHEBI	CHEBI:35702	diethyl ether
 MESH	D004999	Amifostine	CHEBI	CHEBI:2636	amifostine
 MESH	D005000	Ethionamide	CHEBI	CHEBI:4885	ethionamide
+MESH	D005001	Ethionine	CHEBI	CHEBI:4886	L-ethionine
 MESH	D005013	Ethosuximide	CHEBI	CHEBI:4887	ethosuximide
 MESH	D005015	Ethoxyquin	CHEBI	CHEBI:77323	ethoxyquin
 MESH	D005031	Ethylenethiourea	CHEBI	CHEBI:34750	Ethylenethiourea
@@ -597,14 +627,22 @@ MESH	D005045	Etomidate	CHEBI	CHEBI:4910	etomidate
 MESH	D005047	Etoposide	CHEBI	CHEBI:4911	etoposide
 MESH	D005054	Eugenol	CHEBI	CHEBI:4917	eugenol
 MESH	D005167	Factor VII	HGNC	3544	F7
+MESH	D005170	Factor X	CHEBI	CHEBI:4964	Factor X
 MESH	D005204	Farnesol	CHEBI	CHEBI:28600	farnesol
+MESH	D005259	Felypressin	CHEBI	CHEBI:60564	felypressin
 MESH	D005277	Fenfluramine	CHEBI	CHEBI:5000	fenfluramine
 MESH	D005278	Fenitrothion	CHEBI	CHEBI:34757	fenitrothion
 MESH	D005279	Fenoprofen	CHEBI	CHEBI:5004	fenoprofen
 MESH	D005284	Fenthion	CHEBI	CHEBI:34761	fenthion
+MESH	D005288	Ferredoxins	CHEBI	CHEBI:5017	ferredoxin
+MESH	D005291	Ferrichrome	CHEBI	CHEBI:5019	ferrichrome
+MESH	D005293	Ferritins	CHEBI	CHEBI:82594	Ferritin
+MESH	D005337	Fibrin	CHEBI	CHEBI:5054	Fibrin
+MESH	D005345	Fibrinopeptide B	CHEBI	CHEBI:5057	Fibrinopeptide B
 MESH	D005353	Fibronectins	HGNC	3778	FN1
 MESH	D005363	Ficusin	CHEBI	CHEBI:27616	psoralen
 MESH	D005372	Filipin	CHEBI	CHEBI:83267	filipin III
+MESH	D005420	Flavoproteins	CHEBI	CHEBI:5086	flavoprotein
 MESH	D005422	Flavoxate	CHEBI	CHEBI:5088	flavoxate
 MESH	D005436	Floxacillin	CHEBI	CHEBI:5098	flucloxacillin
 MESH	D005437	Flucytosine	CHEBI	CHEBI:5100	flucytosine
@@ -636,10 +674,9 @@ MESH	D005665	Furosemide	CHEBI	CHEBI:47426	furosemide
 MESH	D005668	Furylfuramide	CHEBI	CHEBI:15660	(Z)-2-(2-furyl)-3-(5-nitro-2-furyl)acrylamide
 MESH	D005677	G(M1) Ganglioside	CHEBI	CHEBI:61048	ganglioside GM1
 MESH	D005679	G(M3) Ganglioside	CHEBI	CHEBI:15681	alpha-N-acetylneuraminyl-(2->3)-beta-D-galactosyl-(1->4)-beta-D-glucosyl-(1<->1')-ceramide
+MESH	D005680	gamma-Aminobutyric Acid	CHEBI	CHEBI:16865	gamma-aminobutyric acid
 MESH	D005686	Galactokinase	HGNC	4118	GALK1
 MESH	D005688	Galactosamine	CHEBI	CHEBI:60312	2-amino-2-deoxy-D-galactopyranose
-MESH	D005690	Galactose	CHEBI	CHEBI:4139	D-galactopyranose
-MESH	D005690	Galactose	CHEBI	CHEBI:28260	galactose
 MESH	D005698	Galactosylceramidase	HGNC	4115	GALC
 MESH	D005702	Galantamine	CHEBI	CHEBI:42944	galanthamine
 MESH	D005711	Gallopamil	CHEBI	CHEBI:34772	Gallopamil
@@ -651,11 +688,13 @@ MESH	D005905	Glyburide	CHEBI	CHEBI:5441	glyburide
 MESH	D005907	Gliclazide	CHEBI	CHEBI:31654	gliclazide
 MESH	D005912	Gliotoxin	CHEBI	CHEBI:5385	gliotoxin
 MESH	D005913	Glipizide	CHEBI	CHEBI:5384	glipizide
+MESH	D005914	Globins	CHEBI	CHEBI:5386	globin
 MESH	D005934	Glucagon	HGNC	4191	GCG
 MESH	D005941	Glucokinase	HGNC	4195	GCK
 MESH	D005944	Glucosamine	CHEBI	CHEBI:5417	glucosamine
 MESH	D005947	Glucose	CHEBI	CHEBI:4167	D-glucopyranose
 MESH	D005976	Glutaral	CHEBI	CHEBI:64276	glutaraldehyde
+MESH	D005978	Glutathione	CHEBI	CHEBI:16856	glutathione
 MESH	D005984	Glutethimide	CHEBI	CHEBI:5439	Glutethimide
 MESH	D005985	Glyceraldehyde	CHEBI	CHEBI:5445	glyceraldehyde
 MESH	D005987	Glyceraldehyde-3-Phosphate Dehydrogenases	HGNC	4141	GAPDH
@@ -663,9 +702,12 @@ MESH	D005990	Glycerol	CHEBI	CHEBI:17754	glycerol
 MESH	D005991	Glycerol Kinase	HGNC	4289	GK
 MESH	D005996	Nitroglycerin	CHEBI	CHEBI:28787	nitroglycerin
 MESH	D005997	Glycerylphosphorylcholine	CHEBI	CHEBI:16870	choline alfoscerate
+MESH	D005998	Glycine	CHEBI	CHEBI:15428	glycine
 MESH	D006003	Glycogen	CHEBI	CHEBI:28087	glycogen
 MESH	D006021	Glycophorin	HGNC	4704	GYPC
+MESH	D006023	Glycoproteins	CHEBI	CHEBI:17089	glycoprotein
 MESH	D006024	Glycopyrrolate	CHEBI	CHEBI:5494	ritropirronium bromide
+MESH	D006033	Glycylglycine	CHEBI	CHEBI:17201	glycylglycine
 MESH	D006034	Glycyrrhetinic Acid	CHEBI	CHEBI:30853	glycyrrhetinic acid
 MESH	D006037	Glyoxal	CHEBI	CHEBI:34779	glyoxal
 MESH	D006046	Gold	CHEBI	CHEBI:29287	gold atom
@@ -687,9 +729,8 @@ MESH	D006242	Haptoglobins	HGNC	5141	HP
 MESH	D006246	Harmaline	CHEBI	CHEBI:28172	harmaline
 MESH	D006247	Harmine	CHEBI	CHEBI:28121	harmine
 MESH	D006371	Helium	CHEBI	CHEBI:30217	helium atom
-MESH	D006418	Heme	CHEBI	CHEBI:17627	ferroheme b
-MESH	D006418	Heme	CHEBI	CHEBI:26355	heme b
 MESH	D006427	Hemin	CHEBI	CHEBI:50385	hemin
+MESH	D006454	Hemoglobins	CHEBI	CHEBI:5656	deoxyhemoglobin
 MESH	D006466	Hemopexin	HGNC	5171	HPX
 MESH	D006492	Hempa	CHEBI	CHEBI:24565	hexamethylphosphoric triamide
 MESH	D006493	Heparin	CHEBI	CHEBI:28304	heparin
@@ -704,6 +745,10 @@ MESH	D006657	Histones	FPLX	Histone	Histone
 MESH	D006684	HLA-DR Antigens	FPLX	HLA_DR	HLA_DR
 MESH	D006690	Bisbenzimidazole	CHEBI	CHEBI:52082	pibenzimol
 MESH	D006697	Holothurin	CHEBI	CHEBI:80869	Holothurin
+MESH	D006709	Homoarginine	CHEBI	CHEBI:27747	L-homoarginine
+MESH	D006710	Homocysteine	CHEBI	CHEBI:17230	homocysteine
+MESH	D006711	Homocystine	CHEBI	CHEBI:17485	homocystine
+MESH	D006714	Homoserine	CHEBI	CHEBI:15699	L-homoserine
 MESH	D006826	Hycanthone	CHEBI	CHEBI:52768	hycanthone
 MESH	D006830	Hydralazine	CHEBI	CHEBI:5775	hydralazine
 MESH	D006853	Hydrocodone	CHEBI	CHEBI:5779	hydrocodone
@@ -715,11 +760,10 @@ MESH	D006881	Hydroxyacetylaminofluorene	CHEBI	CHEBI:17931	N-hydroxy-2-acetamidof
 MESH	D006893	Hydroxyeicosatetraenoic Acids	CHEBI	CHEBI:36275	HETE
 MESH	D006897	Hydroxyindoleacetic Acid	CHEBI	CHEBI:27823	(5-hydroxyindol-3-yl)acetic acid
 MESH	D006907	17-alpha-Hydroxypregnenolone	CHEBI	CHEBI:28750	17alpha-hydroxypregnenolone
+MESH	D006909	Hydroxyproline	CHEBI	CHEBI:18095	trans-4-hydroxy-L-proline
 MESH	D006918	Hydroxyurea	CHEBI	CHEBI:44423	hydroxyurea
 MESH	D006919	Hydroxyzine	CHEBI	CHEBI:5818	hydroxyzine
 MESH	D006921	Hygromycin B	CHEBI	CHEBI:16976	hygromycin B
-MESH	D006923	Hymecromone	CHEBI	CHEBI:17224	4-methylumbelliferone
-MESH	D006923	Hymecromone	CHEBI	CHEBI:5679	herniarin
 MESH	D007041	Hypoxanthine Phosphoribosyltransferase	HGNC	5157	HPRT1
 MESH	D007050	Ibogaine	CHEBI	CHEBI:5852	Ibogaine
 MESH	D007052	Ibuprofen	CHEBI	CHEBI:5855	ibuprofen
@@ -747,12 +791,14 @@ MESH	D007510	Isatin	CHEBI	CHEBI:27539	isatin
 MESH	D007528	Isoetharine	CHEBI	CHEBI:6005	Isoetharine
 MESH	D007530	Isoflurane	CHEBI	CHEBI:6015	isoflurane
 MESH	D007531	Isoflurophate	CHEBI	CHEBI:17941	diisopropyl fluorophosphate
+MESH	D007532	Isoleucine	CHEBI	CHEBI:17191	L-isoleucine
 MESH	D007534	Isomaltose	CHEBI	CHEBI:28189	isomaltose
 MESH	D007538	Isoniazid	CHEBI	CHEBI:6030	isoniazide
 MESH	D007541	Isopentenyladenosine	CHEBI	CHEBI:62881	N(6)-(Delta(2)-isopentenyl)adenosine
 MESH	D007544	Isopropyl Thiogalactoside	CHEBI	CHEBI:61448	isopropyl beta-D-thiogalactopyranoside
 MESH	D007545	Isoproterenol	CHEBI	CHEBI:64317	isoprenaline
 MESH	D007547	Isosorbide	CHEBI	CHEBI:6060	Isosorbide
+MESH	D007609	Kallidin	CHEBI	CHEBI:6102	Kallidin
 MESH	D007612	Kanamycin	CHEBI	CHEBI:6104	kanamycin
 MESH	D007631	Chlordecone	CHEBI	CHEBI:16548	chlordecone
 MESH	D007649	Ketamine	CHEBI	CHEBI:6121	ketamine
@@ -760,6 +806,7 @@ MESH	D007650	Ketanserin	CHEBI	CHEBI:6123	ketanserin
 MESH	D007660	Ketoprofen	CHEBI	CHEBI:6128	ketoprofen
 MESH	D007703	Peptidyl-Dipeptidase A	HGNC	2707	ACE
 MESH	D007735	Kynuramine	CHEBI	CHEBI:73472	kynuramine
+MESH	D007737	Kynurenine	CHEBI	CHEBI:28683	kynurenine
 MESH	D007741	Labetalol	CHEBI	CHEBI:6343	labetalol
 MESH	D007781	Lactoferrin	HGNC	6720	LTF
 MESH	D007784	Lactoperoxidase	HGNC	6678	LPO
@@ -769,14 +816,16 @@ MESH	D007792	Lactulose	CHEBI	CHEBI:6359	lactulose
 MESH	D007810	Lanosterol	CHEBI	CHEBI:16521	lanosterol
 MESH	D007851	Dodecanol	CHEBI	CHEBI:28878	dodecan-1-ol
 MESH	D007854	Lead	CHEBI	CHEBI:27889	lead(0)
+MESH	D007930	Leucine	CHEBI	CHEBI:15603	L-leucine
 MESH	D007931	Leucyl Aminopeptidase	HGNC	18449	LAP3
 MESH	D007975	Leukotriene B4	CHEBI	CHEBI:15647	leukotriene B4
 MESH	D007977	Levallorphan	CHEBI	CHEBI:6431	Levallorphan
+MESH	D007980	Levodopa	CHEBI	CHEBI:15765	L-dopa
 MESH	D007981	Levorphanol	CHEBI	CHEBI:6444	Levorphanol
-MESH	D007987	Gonadotropin-Releasing Hormone	HGNC	4419	GNRH1
 MESH	D008012	Lidocaine	CHEBI	CHEBI:6456	lidocaine
-MESH	D008027	Light	CHEBI	CHEBI:30212	photon
 MESH	D008034	Lincomycin	CHEBI	CHEBI:6472	lincomycin
+MESH	D008074	Lipoproteins	CHEBI	CHEBI:6495	lipoprotein
+MESH	D008083	beta-Lipotropin	CHEBI	CHEBI:80247	beta-Lipotropin
 MESH	D008094	Lithium	CHEBI	CHEBI:30145	lithium atom
 MESH	D008120	Lobeline	CHEBI	CHEBI:48723	(-)-lobeline
 MESH	D008127	Lofepramine	CHEBI	CHEBI:47782	lofepramine
@@ -788,7 +837,9 @@ MESH	D008187	Lutetium	CHEBI	CHEBI:33382	lutetium atom
 MESH	D008194	Lymecycline	CHEBI	CHEBI:59040	lymecycline
 MESH	D008233	Lymphotoxin-alpha	HGNC	6709	LTA
 MESH	D008234	Lynestrenol	CHEBI	CHEBI:31790	Lynestrenol
+MESH	D008236	Lypressin	CHEBI	CHEBI:6603	Lypressin
 MESH	D008238	Lysergic Acid Diethylamide	CHEBI	CHEBI:6605	lysergic acid diethylamide
+MESH	D008239	Lysine	CHEBI	CHEBI:18019	L-lysine
 MESH	D008245	Lysophospholipase	HGNC	30041	PLB1
 MESH	D008272	Mafenide	CHEBI	CHEBI:6633	Mafenide
 MESH	D008274	Magnesium	CHEBI	CHEBI:25107	magnesium atom
@@ -810,15 +861,19 @@ MESH	D008468	Meclizine	CHEBI	CHEBI:6709	Meclizine
 MESH	D008472	Medazepam	CHEBI	CHEBI:31807	Medazepam
 MESH	D008529	Mefruside	CHEBI	CHEBI:31809	Mefruside
 MESH	D008535	Megestrol	CHEBI	CHEBI:6722	megestrol
+MESH	D008543	Melanins	CHEBI	CHEBI:89634	Melanin
 MESH	D008549	Melarsoprol	CHEBI	CHEBI:6729	Melarsoprol
 MESH	D008550	Melatonin	CHEBI	CHEBI:16796	melatonin
 MESH	D008553	Melibiose	CHEBI	CHEBI:28053	melibiose
+MESH	D008555	Melitten	CHEBI	CHEBI:6736	melittin
+MESH	D008558	Melphalan	CHEBI	CHEBI:28876	melphalan
 MESH	D008559	Memantine	CHEBI	CHEBI:64312	memantine
 MESH	D008573	Mendelevium	CHEBI	CHEBI:33395	mendelevium atom
 MESH	D008614	Meperidine	CHEBI	CHEBI:6754	Meperidine
 MESH	D008618	Mephobarbital	CHEBI	CHEBI:6758	mephobarbital
 MESH	D008620	Meprobamate	CHEBI	CHEBI:6761	Meprobamate
 MESH	D008623	Mercaptoethanol	CHEBI	CHEBI:41218	mercaptoethanol
+MESH	D008625	Tiopronin	CHEBI	CHEBI:32229	Tiopronin
 MESH	D008627	Mercuric Chloride	CHEBI	CHEBI:31823	mercury dichloride
 MESH	D008628	Mercury	CHEBI	CHEBI:16170	mercury(0)
 MESH	D008635	Mescaline	CHEBI	CHEBI:28346	mescaline
@@ -850,6 +905,7 @@ MESH	D008736	Methyclothiazide	CHEBI	CHEBI:6847	Methyclothiazide
 MESH	D008743	Methyl Parathion	CHEBI	CHEBI:38746	parathion-methyl
 MESH	D008747	Methylcellulose	CHEBI	CHEBI:53448	methyl cellulose
 MESH	D008748	Methylcholanthrene	CHEBI	CHEBI:34342	3-methylcholanthrene
+MESH	D008750	Methyldopa	CHEBI	CHEBI:61058	alpha-methyl-L-dopa
 MESH	D008751	Methylene Blue	CHEBI	CHEBI:6872	methylene blue
 MESH	D008752	Methylene Chloride	CHEBI	CHEBI:15767	dichloromethane
 MESH	D008753	Methylenebis(chloroaniline)	CHEBI	CHEBI:28124	4,4'-methylene-bis-(2-chloroaniline)
@@ -874,20 +930,21 @@ MESH	D008927	Mitobronitol	CHEBI	CHEBI:34853	Mitobronitol
 MESH	D008935	Mitoguazone	CHEBI	CHEBI:43996	mitoguazone
 MESH	D008939	Mitotane	CHEBI	CHEBI:6954	Mitotane
 MESH	D008942	Mitoxantrone	CHEBI	CHEBI:50729	mitoxantrone
-MESH	D008950	MMPI	CHEBI	CHEBI:50664	matrix metalloproteinase inhibitor
 MESH	D008972	Molindone	CHEBI	CHEBI:6965	Molindone
 MESH	D008981	Molsidomine	CHEBI	CHEBI:31861	Molsidomine
 MESH	D008982	Molybdenum	CHEBI	CHEBI:28685	molybdenum atom
 MESH	D008985	Monensin	CHEBI	CHEBI:27617	monensin A
 MESH	D009020	Morphine	CHEBI	CHEBI:17303	morphine
+MESH	D009037	Motilin	CHEBI	CHEBI:80269	Motilin
 MESH	D009070	Moxalactam	CHEBI	CHEBI:599928	moxalactam
+MESH	D009074	Melanocyte-Stimulating Hormones	CHEBI	CHEBI:16768	mycothiol
 MESH	D009116	Muscarine	CHEBI	CHEBI:7034	Muscarine
 MESH	D009118	Muscimol	CHEBI	CHEBI:7035	muscimol
 MESH	D009151	Mustard Gas	CHEBI	CHEBI:25434	bis(2-chloroethyl) sulfide
-MESH	D009195	Peroxidase	HGNC	7218	MPO
 MESH	D009211	Myoglobin	HGNC	6915	MB
 MESH	D009241	Ipratropium	CHEBI	CHEBI:5956	ipratropium
 MESH	D009242	N-Nitrosopyrrolidine	CHEBI	CHEBI:82362	N-Nitrosopyrrolidine
+MESH	D009243	NAD	CHEBI	CHEBI:15846	NAD(+)
 MESH	D009249	NADP	HGNC	1063	BLVRB
 MESH	D009255	Nafenopin	CHEBI	CHEBI:7449	nafenopin
 MESH	D009256	Nafoxidine	CHEBI	CHEBI:34881	Nafoxidine
@@ -897,12 +954,12 @@ MESH	D009271	Naltrexone	CHEBI	CHEBI:7465	naltrexone
 MESH	D009277	Nandrolone	CHEBI	CHEBI:7466	nandrolone
 MESH	D009278	Naphazoline	CHEBI	CHEBI:7470	Naphazoline
 MESH	D009288	Naproxen	CHEBI	CHEBI:7476	naproxen
-MESH	D009320	Atrial Natriuretic Factor	HGNC	4877	HESX1
-MESH	D009320	Atrial Natriuretic Factor	HGNC	7939	NPPA
 MESH	D009327	4-Chloro-7-nitrobenzofurazan	CHEBI	CHEBI:78878	4-chloro-7-nitrobenzofurazan
 MESH	D009355	Neomycin	CHEBI	CHEBI:7507	neomycin
 MESH	D009356	Neon	CHEBI	CHEBI:33310	neon atom
 MESH	D009428	Netilmicin	CHEBI	CHEBI:7528	netilmycin
+MESH	D009478	Neuropeptide Y	CHEBI	CHEBI:80201	Neuropeptide Y
+MESH	D009496	Neurotensin	CHEBI	CHEBI:7542	neurotensin
 MESH	D009499	Neutral Red	CHEBI	CHEBI:86370	neutral red
 MESH	D009525	Niacin	CHEBI	CHEBI:15940	nicotinic acid
 MESH	D009528	Nicarbazin	CHEBI	CHEBI:81725	Nicarbazin
@@ -933,6 +990,7 @@ MESH	D009762	o-Aminoazotoluene	CHEBI	CHEBI:82285	ortho-Aminoazotoluene
 MESH	D009764	o-Phthalaldehyde	CHEBI	CHEBI:70851	phthalaldehyde
 MESH	D009827	Oleandomycin	CHEBI	CHEBI:16869	oleandomycin
 MESH	D009921	Metaproterenol	CHEBI	CHEBI:82719	orciprenaline
+MESH	D009952	Ornithine	CHEBI	CHEBI:18257	ornithine
 MESH	D009966	Orphenadrine	CHEBI	CHEBI:7789	orphenadrine
 MESH	D010042	Ouabain	CHEBI	CHEBI:472805	ouabain
 MESH	D010068	Oxacillin	CHEBI	CHEBI:7809	oxacillin
@@ -941,13 +999,14 @@ MESH	D010076	Oxazepam	CHEBI	CHEBI:7823	oxazepam
 MESH	D010095	Oxotremorine	CHEBI	CHEBI:7851	Oxotremorine
 MESH	D010098	Oxycodone	CHEBI	CHEBI:7852	oxycodone
 MESH	D010100	Oxygen	CHEBI	CHEBI:15379	dioxygen
+MESH	D010108	Oxyhemoglobins	CHEBI	CHEBI:7861	oxyhemoglobin
 MESH	D010111	Oxymorphone	CHEBI	CHEBI:7865	Oxymorphone
-MESH	D010113	Oxyphenbutazone	CHEBI	CHEBI:76259	oxyphenbutazone hydrate
-MESH	D010113	Oxyphenbutazone	CHEBI	CHEBI:76258	oxyphenbutazone
 MESH	D010117	Oxypurinol	CHEBI	CHEBI:28315	alloxanthine
+MESH	D010121	Oxytocin	CHEBI	CHEBI:7872	oxytocin
 MESH	D010122	Cystinyl Aminopeptidase	HGNC	6656	LNPEP
 MESH	D010129	4-Aminobenzoic Acid	CHEBI	CHEBI:30753	4-aminobenzoic acid
 MESH	D010132	p-Azobenzenearsonate	CHEBI	CHEBI:53554	4,4'-azodibenzenearsonic acid
+MESH	D010135	p-Fluorophenylalanine	CHEBI	CHEBI:84060	4-fluorophenylalanine
 MESH	D010172	Palmitoylcarnitine	CHEBI	CHEBI:17490	O-palmitoyl-L-carnitine
 MESH	D010197	Pancuronium	CHEBI	CHEBI:7907	pancuronium
 MESH	D010204	Pantetheine	CHEBI	CHEBI:16753	pantetheine
@@ -958,20 +1017,22 @@ MESH	D010269	Paraquat	CHEBI	CHEBI:34905	paraquat
 MESH	D010278	Parathion	CHEBI	CHEBI:27928	parathion
 MESH	D010281	Parathyroid Hormone	HGNC	9606	PTH
 MESH	D010293	Pargyline	CHEBI	CHEBI:7930	Pargyline
-MESH	D010300	Parkinson Disease	CHEBI	CHEBI:74756	Pro-Asp
 MESH	D010303	Paromomycin	CHEBI	CHEBI:7934	paromomycin
 MESH	D010368	Pectins	CHEBI	CHEBI:17309	pectin
 MESH	D010400	Penicillin G	CHEBI	CHEBI:18208	benzylpenicillin
 MESH	D010404	Penicillin V	CHEBI	CHEBI:27446	phenoxymethylpenicillin
 MESH	D010416	Pentachlorophenol	CHEBI	CHEBI:17642	pentachlorophenol
+MESH	D010418	Pentagastrin	CHEBI	CHEBI:31974	Pentagastrin
 MESH	D010419	Pentamidine	CHEBI	CHEBI:45081	pentamidine
 MESH	D010424	Pentobarbital	CHEBI	CHEBI:7983	pentobarbital
 MESH	D010431	Pentoxifylline	CHEBI	CHEBI:7986	Pentoxifylline
 MESH	D010433	Pentylenetetrazole	CHEBI	CHEBI:34910	pentetrazol
 MESH	D010447	Peptide Hydrolases	FPLX	Protease	Protease
+MESH	D010457	Peptidoglycan	CHEBI	CHEBI:8005	peptidoglycan
 MESH	D010464	Perazine	CHEBI	CHEBI:59118	perazine
 MESH	D010480	Perhexiline	CHEBI	CHEBI:35553	perhexiline
 MESH	D010546	Perphenazine	CHEBI	CHEBI:8028	perphenazine
+MESH	D010590	Phalloidine	CHEBI	CHEBI:8040	phalloidin
 MESH	D010615	Phenacetin	CHEBI	CHEBI:8050	phenacetin
 MESH	D010622	Phencyclidine	CHEBI	CHEBI:8058	phencyclidine
 MESH	D010624	Phenelzine	CHEBI	CHEBI:8060	Phenelzine
@@ -993,11 +1054,13 @@ MESH	D010696	Phloroglucinol	CHEBI	CHEBI:16204	phloroglucinol
 MESH	D010713	Phosphatidylcholines	CHEBI	CHEBI:16110	1,2-diacyl-sn-glycero-3-phosphocholine(1+)
 MESH	D010716	Phosphatidylinositols	CHEBI	CHEBI:16749	1-phosphatidyl-1D-myo-inositol
 MESH	D010718	Phosphatidylserines	CHEBI	CHEBI:18303	phosphatidyl-L-serine
+MESH	D010725	Phosphocreatine	CHEBI	CHEBI:17287	N-phosphocreatine
 MESH	D010727	Phosphoric Diester Hydrolases	FPLX	PDE	PDE
 MESH	D010728	Phosphoenolpyruvate	CHEBI	CHEBI:18021	phosphoenolpyruvate
 MESH	D010739	Phospholipase D	FPLX	PLD	PLD
 MESH	D010758	Phosphorus	CHEBI	CHEBI:28659	phosphorus atom
 MESH	D010767	Phosphorylcholine	CHEBI	CHEBI:18132	phosphocholine
+MESH	D010769	Phosphothreonine	CHEBI	CHEBI:37525	O-phospho-L-threonine
 MESH	D010773	Leptophos	CHEBI	CHEBI:82137	Leptophos
 MESH	D010774	Phosvitin	HGNC	2460	CSNK2B
 MESH	D010830	Physostigmine	CHEBI	CHEBI:27953	physostigmine
@@ -1013,10 +1076,7 @@ MESH	D010889	Piracetam	CHEBI	CHEBI:32010	Piracetam
 MESH	D010894	Piroxicam	CHEBI	CHEBI:8249	piroxicam
 MESH	D010918	Pizotyline	CHEBI	CHEBI:50212	pizotifen
 MESH	D010958	Plasminogen	HGNC	9071	PLG
-MESH	D010959	Tissue Plasminogen Activator	HGNC	9051	PLAT
-MESH	D010959	Tissue Plasminogen Activator	HGNC	12404	TTPA
-MESH	D010971	Plastoquinone	CHEBI	CHEBI:17757	plastoquinone
-MESH	D010971	Plastoquinone	CHEBI	CHEBI:28377	plastoquinone-9
+MESH	D010972	Platelet Activating Factor	CHEBI	CHEBI:52450	2-O-acetyl-1-O-octadecyl-sn-glycero-3-phosphocholine
 MESH	D011034	Podophyllotoxin	CHEBI	CHEBI:50305	podophyllotoxin
 MESH	D011066	Poly C	CHEBI	CHEBI:84498	poly(cytidylic acid)
 MESH	D011068	Poly G	CHEBI	CHEBI:73278	poly(guanylic acid)
@@ -1059,6 +1119,7 @@ MESH	D011355	Prodrugs	CHEBI	CHEBI:50266	prodrug
 MESH	D011370	Proflavine	CHEBI	CHEBI:8452	3,6-diaminoacridine
 MESH	D011374	Progesterone	CHEBI	CHEBI:17026	progesterone
 MESH	D011388	Prolactin	HGNC	9445	PRL
+MESH	D011392	Proline	CHEBI	CHEBI:17203	L-proline
 MESH	D011395	Promazine	CHEBI	CHEBI:8459	promazine
 MESH	D011398	Promethazine	CHEBI	CHEBI:8461	promethazine
 MESH	D011399	Promethium	CHEBI	CHEBI:33373	promethium atom
@@ -1079,6 +1140,7 @@ MESH	D011460	Prostaglandins F	CHEBI	CHEBI:26340	prostaglandins F
 MESH	D011462	Prostaglandins G	CHEBI	CHEBI:26343	prostaglandins G
 MESH	D011464	Epoprostenol	CHEBI	CHEBI:15552	prostaglandin I2
 MESH	D011486	Protein C	HGNC	9367	PRH2
+MESH	D011509	Proteoglycans	CHEBI	CHEBI:37396	proteoglycan
 MESH	D011515	Prothionamide	CHEBI	CHEBI:32066	Prothionamide
 MESH	D011516	Prothrombin	HGNC	3535	F2
 MESH	D011521	Protochlorophyllide	CHEBI	CHEBI:16673	protochlorophyllide
@@ -1090,7 +1152,6 @@ MESH	D011623	gamma-Glutamyl Hydrolase	HGNC	4248	GGH
 MESH	D011691	Puromycin	CHEBI	CHEBI:17939	puromycin
 MESH	D011700	Putrescine	CHEBI	CHEBI:17148	putrescine
 MESH	D011718	Pyrazinamide	CHEBI	CHEBI:45285	pyrazinecarboxamide
-MESH	D011723	Chrysanthemum cinerariifolium	CHEBI	CHEBI:39098	pyrethrins
 MESH	D011727	Pyridinolcarbamate	CHEBI	CHEBI:32075	Pyricarbate
 MESH	D011730	Pyridoxal	CHEBI	CHEBI:17310	pyridoxal
 MESH	D011733	Pyridoxamine	CHEBI	CHEBI:16410	pyridoxamine
@@ -1099,6 +1160,7 @@ MESH	D011738	Pyrilamine	CHEBI	CHEBI:6762	mepyramine
 MESH	D011745	Pyrithiamine	CHEBI	CHEBI:15797	1-(4-amino-2-methylpyrimidin-5-ylmethyl)-3-(2-hydroxyethyl)-2-methylpyridinium bromide
 MESH	D011748	Pyrogallol	CHEBI	CHEBI:16164	pyrogallol
 MESH	D011754	Pyronine	CHEBI	CHEBI:8682	pyronin Y
+MESH	D011761	Pyrrolidonecarboxylic Acid	CHEBI	CHEBI:16010	5-oxoproline
 MESH	D011765	Pyruvaldehyde	CHEBI	CHEBI:17158	methylglyoxal
 MESH	D011791	Quartz	CHEBI	CHEBI:46727	quartz
 MESH	D011794	Quercetin	CHEBI	CHEBI:16243	quercetin
@@ -1106,20 +1168,17 @@ MESH	D011796	Quinacrine	CHEBI	CHEBI:8711	quinacrine
 MESH	D011800	Quinestrol	CHEBI	CHEBI:8716	quinestrol
 MESH	D011802	Quinidine	CHEBI	CHEBI:28593	quinidine
 MESH	D011803	Quinine	CHEBI	CHEBI:15854	quinine
-MESH	D011839	Radiation, Ionizing	CHEBI	CHEBI:74061	Ile-Arg
 MESH	D011887	Raffinose	CHEBI	CHEBI:16634	raffinose
-MESH	D012018	Reflex	CHEBI	CHEBI:138164	fomesafen-sodium
 MESH	D012083	Renin	HGNC	9958	REN
 MESH	D012110	Reserpine	CHEBI	CHEBI:28487	reserpine
-MESH	D012146	Rest	CHEBI	CHEBI:24433	group
+MESH	D012155	Reticulin	CHEBI	CHEBI:24750	5'-hydroxystreptomycin
 MESH	D012172	Retinaldehyde	CHEBI	CHEBI:17898	all-trans-retinal
 MESH	D012211	Rhenium	CHEBI	CHEBI:49882	rhenium atom
 MESH	D012243	Rhodopsin	HGNC	10012	RHO
 MESH	D012255	Ribitol	CHEBI	CHEBI:15963	ribitol
+MESH	D012256	Riboflavin	CHEBI	CHEBI:17015	riboflavin
 MESH	D012259	Ribonuclease, Pancreatic	HGNC	10044	RNASE1
-MESH	D012266	Ribose	CHEBI	CHEBI:47013	D-ribofuranose
-MESH	D012266	Ribose	CHEBI	CHEBI:27476	beta-D-ribopyranose
-MESH	D012272	Ribs	CHEBI	CHEBI:33942	ribose
+MESH	D012276	Ricin	CHEBI	CHEBI:8852	Ricin
 MESH	D012293	Rifampin	CHEBI	CHEBI:28077	rifampicin
 MESH	D012312	Ritodrine	CHEBI	CHEBI:8872	Ritodrine
 MESH	D012313	RNA	CHEBI	CHEBI:33697	ribonucleic acid
@@ -1152,8 +1211,10 @@ MESH	D012402	Rotenone	CHEBI	CHEBI:28201	rotenone
 MESH	D012428	Ruthenium	CHEBI	CHEBI:30682	ruthenium atom
 MESH	D012431	Rutin	CHEBI	CHEBI:28527	rutin
 MESH	D012433	Ryanodine	CHEBI	CHEBI:8925	ryanodine
+MESH	D012435	S-Adenosylhomocysteine	CHEBI	CHEBI:16680	S-adenosyl-L-homocysteine
 MESH	D012439	Saccharin	CHEBI	CHEBI:32111	saccharin
 MESH	D012460	Sulfasalazine	CHEBI	CHEBI:9334	sulfasalazine
+MESH	D012521	Sarcosine	CHEBI	CHEBI:15611	sarcosine
 MESH	D012566	Sizofiran	CHEBI	CHEBI:50653	schizophyllan
 MESH	D012601	Scopolamine	CHEBI	CHEBI:16794	scopolamine
 MESH	D012603	Scopoletin	CHEBI	CHEBI:17488	scopoletin
@@ -1162,6 +1223,7 @@ MESH	D012642	Selegiline	CHEBI	CHEBI:9086	(-)-selegiline
 MESH	D012643	Selenium	CHEBI	CHEBI:27568	selenium atom
 MESH	D012673	Semustine	CHEBI	CHEBI:6863	semustine
 MESH	D012685	Sepharose	CHEBI	CHEBI:2511	agarose
+MESH	D012694	Serine	CHEBI	CHEBI:17115	L-serine
 MESH	D012701	Serotonin	CHEBI	CHEBI:28790	serotonin
 MESH	D012721	Carbaryl	CHEBI	CHEBI:3390	carbaryl
 MESH	D012825	Silicon	CHEBI	CHEBI:27573	silicon atom
@@ -1172,7 +1234,6 @@ MESH	D012853	Sisomicin	CHEBI	CHEBI:9169	sisomycin
 MESH	D012862	Skatole	CHEBI	CHEBI:9171	skatole
 MESH	D012992	Solanine	CHEBI	CHEBI:9188	solanine
 MESH	D012999	Soman	CHEBI	CHEBI:9195	Soman
-MESH	D013004	Somatostatin	HGNC	11329	SST
 MESH	D013006	Growth Hormone	HGNC	4261	GH1
 MESH	D013007	Growth Hormone-Releasing Hormone	HGNC	4265	GHRH
 MESH	D013012	Sorbitol	CHEBI	CHEBI:30911	glucitol
@@ -1191,17 +1252,14 @@ MESH	D013241	Sterigmatocystin	CHEBI	CHEBI:18227	sterigmatocystin
 MESH	D013252	Steroid 11-beta-Hydroxylase	HGNC	2591	CYP11B1
 MESH	D013253	Steroid 12-alpha-Hydroxylase	HGNC	2653	CYP8B1
 MESH	D013254	Steroid 17-alpha-Hydroxylase	HGNC	2593	CYP17A1
-MESH	D013265	Stigmasterol	CHEBI	CHEBI:8334	Poriferasterol
-MESH	D013265	Stigmasterol	CHEBI	CHEBI:28824	stigmasterol
 MESH	D013311	Streptozocin	CHEBI	CHEBI:9288	streptozocin
 MESH	D013324	Strontium	CHEBI	CHEBI:35104	strontium(2+)
 MESH	D013327	Strophanthidin	CHEBI	CHEBI:38178	strophanthidin
 MESH	D013331	Strychnine	CHEBI	CHEBI:28973	strychnine
+MESH	D013373	Substance P	CHEBI	CHEBI:80308	Substance P
 MESH	D013390	Succinylcholine	CHEBI	CHEBI:45652	succinylcholine
 MESH	D013392	Sucralfate	CHEBI	CHEBI:9313	Sucralfate
 MESH	D013395	Sucrose	CHEBI	CHEBI:17992	sucrose
-MESH	D013408	Sulbenicillin	CHEBI	CHEBI:9322	sulbenicillin
-MESH	D013408	Sulbenicillin	CHEBI	CHEBI:32160	sulbenicillin disodium
 MESH	D013409	Sulfacetamide	CHEBI	CHEBI:63845	sulfacetamide
 MESH	D013411	Sulfadiazine	CHEBI	CHEBI:9328	sulfadiazine
 MESH	D013412	Sulfadimethoxine	CHEBI	CHEBI:32161	sulfadimethoxine
@@ -1232,6 +1290,7 @@ MESH	D013656	Taurocholic Acid	CHEBI	CHEBI:28865	taurocholic acid
 MESH	D013667	Technetium	CHEBI	CHEBI:33353	technetium atom
 MESH	D013693	Temazepam	CHEBI	CHEBI:9435	Temazepam
 MESH	D013721	Triethylenephosphoramide	CHEBI	CHEBI:49798	tetraethylenepentamine
+MESH	D013722	Teprotide	CHEBI	CHEBI:9444	Teprotide
 MESH	D013738	Testolactone	CHEBI	CHEBI:9460	testolactone
 MESH	D013739	Testosterone	CHEBI	CHEBI:17347	testosterone
 MESH	D013747	Tetrabenazine	CHEBI	CHEBI:9467	tetrabenazine
@@ -1259,10 +1318,13 @@ MESH	D013852	Thiotepa	CHEBI	CHEBI:9570	Thiotepa
 MESH	D013866	Thioguanine	CHEBI	CHEBI:9555	tioguanine
 MESH	D013874	Thiopental	CHEBI	CHEBI:102166	thiopental
 MESH	D013879	Thioredoxins	FPLX	TXN	TXN
+MESH	D013883	Thiostrepton	CHEBI	CHEBI:29693	thiostrepton
 MESH	D013884	Thiosulfate Sulfurtransferase	HGNC	12388	TST
 MESH	D013888	Thiothixene	CHEBI	CHEBI:9571	Thiothixene
 MESH	D013890	Thiourea	CHEBI	CHEBI:36946	thiourea
 MESH	D013893	Thiram	CHEBI	CHEBI:9495	thiram
+MESH	D013912	Threonine	CHEBI	CHEBI:16857	L-threonine
+MESH	D013917	Thrombin	CHEBI	CHEBI:9574	Thrombin
 MESH	D013925	Thromboplastin	HGNC	3541	F3
 MESH	D013926	Thrombopoietin	HGNC	11795	THPO
 MESH	D013928	Thromboxane A2	CHEBI	CHEBI:15627	thromboxane A2
@@ -1272,7 +1334,7 @@ MESH	D013939	Thymidine Phosphorylase	HGNC	3148	TYMP
 MESH	D013941	Thymine	CHEBI	CHEBI:17821	thymine
 MESH	D013943	Thymol	CHEBI	CHEBI:27607	thymol
 MESH	D013954	Thyroglobulin	HGNC	11764	TG
-MESH	D013961	Thyroid Gland	CHEBI	CHEBI:9584	Thyroid
+MESH	D013973	Thyrotropin-Releasing Hormone	CHEBI	CHEBI:35940	protirelin
 MESH	D013989	Ticrynafen	CHEBI	CHEBI:9590	tienilic acid
 MESH	D013999	Timolol	CHEBI	CHEBI:9599	(S)-timolol (anhydrous)
 MESH	D014031	Tobramycin	CHEBI	CHEBI:28864	tobramycin
@@ -1280,13 +1342,12 @@ MESH	D014043	Tolazoline	CHEBI	CHEBI:28502	tolazoline
 MESH	D014044	Tolbutamide	CHEBI	CHEBI:27999	tolbutamide
 MESH	D014050	Toluene	CHEBI	CHEBI:17578	toluene
 MESH	D014053	Tomatine	CHEBI	CHEBI:9630	tomatine
+MESH	D014108	Tosylphenylalanyl Chloromethyl Ketone	CHEBI	CHEBI:9642	N-tosyl-L-phenylalanyl chloromethyl ketone
 MESH	D014128	Chromomycin A3	CHEBI	CHEBI:34638	chromomycin A3
 MESH	D014153	Transaldolase	HGNC	11559	TALDO1
 MESH	D014156	Transcortin	HGNC	1540	SERPINA6
 MESH	D014168	Transferrin	HGNC	11740	TF
 MESH	D014174	Transketolase	HGNC	11834	TKT
-MESH	D014191	Tranylcypromine	CHEBI	CHEBI:9652	tranylcypromine
-MESH	D014191	Tranylcypromine	CHEBI	CHEBI:131510	(1R,2S)-tranylcypromine
 MESH	D014192	Trapidil	CHEBI	CHEBI:32254	Trapidil
 MESH	D014196	Trazodone	CHEBI	CHEBI:9654	trazodone
 MESH	D014198	Trehalase	HGNC	12266	TREH
@@ -1303,6 +1364,7 @@ MESH	D014268	Trifluoperazine	CHEBI	CHEBI:45951	trifluoperazine
 MESH	D014271	Trifluridine	CHEBI	CHEBI:75179	trifluridine
 MESH	D014280	Triglycerides	CHEBI	CHEBI:17855	triglyceride
 MESH	D014282	Trihexyphenidyl	CHEBI	CHEBI:9720	Trihexyphenidyl
+MESH	D014284	Triiodothyronine	CHEBI	CHEBI:18258	3,3',5-triiodo-L-thyronine
 MESH	D014290	Metipranolol	CHEBI	CHEBI:6897	metipranolol
 MESH	D014291	Trimeprazine	CHEBI	CHEBI:9725	Trimeprazine
 MESH	D014293	Trimethadione	CHEBI	CHEBI:9727	Trimethadione
@@ -1318,16 +1380,20 @@ MESH	D014325	Tromethamine	CHEBI	CHEBI:9754	tris
 MESH	D014331	Tropicamide	CHEBI	CHEBI:9757	Tropicamide
 MESH	D014333	Tropoelastin	HGNC	3327	ELN
 MESH	D014334	Tropolone	CHEBI	CHEBI:79966	Tropolone
+MESH	D014357	Trypsin	CHEBI	CHEBI:9765	Trypsin
 MESH	D014359	Trypsin Inhibitor, Kazal Pancreatic	HGNC	11244	SPINK1
+MESH	D014364	Tryptophan	CHEBI	CHEBI:16828	L-tryptophan
 MESH	D014368	Tryptophanase	HGNC	11708	TDO2
 MESH	D014372	Tubercidin	CHEBI	CHEBI:48267	tubercidin
 MESH	D014403	Tubocurarine	CHEBI	CHEBI:9774	tubocurarine
+MESH	D014405	Tuftsin	CHEBI	CHEBI:88947	Tuftsin
 MESH	D014409	Tumor Necrosis Factor-alpha	HGNC	11892	TNF
-MESH	D014411	Neoplastic Stem Cells	CHEBI	CHEBI:53115	8-(3-chlorostyryl)caffeine
 MESH	D014414	Tungsten	CHEBI	CHEBI:27998	tungsten
 MESH	D014415	Tunicamycin	CHEBI	CHEBI:29699	tunicamycin
 MESH	D014439	Tyramine	CHEBI	CHEBI:15760	tyramine
 MESH	D014442	Monophenol Monooxygenase	HGNC	12442	TYR
+MESH	D014443	Tyrosine	CHEBI	CHEBI:17895	L-tyrosine
+MESH	D014451	Ubiquinone	CHEBI	CHEBI:16389	ubiquinones
 MESH	D014494	Unithiol	CHEBI	CHEBI:888	2,3-disulfanylpropane-1-sulfonic acid
 MESH	D014498	Uracil	CHEBI	CHEBI:17568	uracil
 MESH	D014508	Urea	CHEBI	CHEBI:16199	urea
@@ -1337,8 +1403,13 @@ MESH	D014558	Urobilinogen	CHEBI	CHEBI:29026	urobilinogen
 MESH	D014559	Urocanate Hydratase	HGNC	26444	UROC1
 MESH	D014580	Ursodeoxycholic Acid	CHEBI	CHEBI:9907	ursodeoxycholic acid
 MESH	D014598	Uteroglobin	HGNC	12523	SCGB1A1
+MESH	D014633	Valine	CHEBI	CHEBI:16414	L-valine
+MESH	D014634	Valinomycin	CHEBI	CHEBI:28545	valinomycin
 MESH	D014638	Vanadates	CHEBI	CHEBI:30528	vanadium oxoanion
 MESH	D014639	Vanadium	CHEBI	CHEBI:27698	vanadium atom
+MESH	D014640	Vancomycin	CHEBI	CHEBI:28001	vancomycin
+MESH	D014667	Vasopressins	CHEBI	CHEBI:9937	vasopressin
+MESH	D014668	Vasotocin	CHEBI	CHEBI:78364	vasotocin
 MESH	D014700	Verapamil	CHEBI	CHEBI:9948	verapamil
 MESH	D014701	Veratridine	CHEBI	CHEBI:28051	veratridine
 MESH	D014702	Veratrine	CHEBI	CHEBI:28051	veratridine
@@ -1348,16 +1419,14 @@ MESH	D014747	Vinblastine	CHEBI	CHEBI:27375	vincaleukoblastine
 MESH	D014749	Vincamine	CHEBI	CHEBI:9985	vincamine
 MESH	D014750	Vincristine	CHEBI	CHEBI:28445	vincristine
 MESH	D014752	Vinyl Chloride	CHEBI	CHEBI:28509	chloroethene
+MESH	D014756	Viomycin	CHEBI	CHEBI:15782	viomycin
 MESH	D014801	Vitamin A	CHEBI	CHEBI:17336	all-trans-retinol
 MESH	D014810	Vitamin E	CHEBI	CHEBI:18145	(+)-alpha-tocopherol
 MESH	D014812	Vitamin K	CHEBI	CHEBI:28384	vitamin K
-MESH	D014815	Vitamins	CHEBI	CHEBI:33229	vitamin
 MESH	D014867	Water	CHEBI	CHEBI:15377	water
 MESH	D014975	Lutein	CHEBI	CHEBI:28838	lutein
 MESH	D014978	Xenon	CHEBI	CHEBI:49957	xenon atom
 MESH	D014993	Xylitol	CHEBI	CHEBI:17151	xylitol
-MESH	D014994	Xylose	CHEBI	CHEBI:15936	aldehydo-D-xylose
-MESH	D014994	Xylose	CHEBI	CHEBI:18222	xylose
 MESH	D015016	Yohimbine	CHEBI	CHEBI:10093	yohimbine
 MESH	D015026	Zeatin	CHEBI	CHEBI:16522	trans-zeatin
 MESH	D015049	Zoxazolamine	CHEBI	CHEBI:35053	Zoxazolamine
@@ -1371,13 +1440,12 @@ MESH	D015085	2,4,5-Trichlorophenoxyacetic Acid	CHEBI	CHEBI:27903	(2,4,5-trichlor
 MESH	D015086	2,6-Dichloroindophenol	CHEBI	CHEBI:945	2,6-dichloroindophenol
 MESH	D015087	2',3'-Cyclic-Nucleotide Phosphodiesterases	HGNC	2158	CNP
 MESH	D015090	25-Hydroxyvitamin D3 1-alpha-Hydroxylase	HGNC	2606	CYP27B1
+MESH	D015091	beta-Alanine	CHEBI	CHEBI:16958	beta-alanine
 MESH	D015101	3,3'-Dichlorobenzidine	CHEBI	CHEBI:82315	3,3'-Dichlorobenzidine
 MESH	D015107	4-Butyrolactone	CHEBI	CHEBI:42639	gamma-butyrolactone
 MESH	D015112	4-Nitroquinoline-1-oxide	CHEBI	CHEBI:16907	4-nitroquinoline N-oxide
 MESH	D015113	Androstane-3,17-diol	CHEBI	CHEBI:27727	androstane-3,17-diol
 MESH	D015114	Androstenediol	CHEBI	CHEBI:2710	androst-5-ene-3beta,17beta-diol
-MESH	D015122	Mercaptopurine	CHEBI	CHEBI:2208	purine-6-thiol
-MESH	D015122	Mercaptopurine	CHEBI	CHEBI:50667	mercaptopurine
 MESH	D015123	7,8-Dihydro-7,8-dihydroxybenzo(a)pyrene 9,10-oxide	CHEBI	CHEBI:30614	benzo[a]pyrene diol epoxide I
 MESH	D015125	Oxyquinoline	CHEBI	CHEBI:48981	quinolin-8-ol
 MESH	D015126	8,11,14-Eicosatrienoic Acid	CHEBI	CHEBI:53486	all-cis-icosa-8,11,14-trienoic acid
@@ -1389,11 +1457,15 @@ MESH	D015234	HLA-A Antigens	HGNC	4931	HLA-A
 MESH	D015235	HLA-B Antigens	HGNC	4932	HLA-B
 MESH	D015236	HLA-C Antigens	HGNC	4933	HLA-C
 MESH	D015237	Dinoprost	CHEBI	CHEBI:15553	prostaglandin F2alpha
+MESH	D015244	Thiorphan	CHEBI	CHEBI:9568	Thiorphan
 MESH	D015248	Gemfibrozil	CHEBI	CHEBI:5296	gemfibrozil
 MESH	D015251	Epirubicin	CHEBI	CHEBI:47898	4'-epidoxorubicin
 MESH	D015255	Idarubicin	CHEBI	CHEBI:42068	idarubicin
 MESH	D015260	Neprilysin	HGNC	7154	MME
 MESH	D015283	Citalopram	CHEBI	CHEBI:3723	citalopram
+MESH	D015286	Kassinin	CHEBI	CHEBI:80145	Kassinin
+MESH	D015287	Neurokinin B	CHEBI	CHEBI:80312	Neurokinin B
+MESH	D015288	Neurokinin A	CHEBI	CHEBI:80311	Neurokinin A
 MESH	D015292	Glycoprotein Hormones, alpha Subunit	HGNC	1885	CGA
 MESH	D015296	Ceftizoxime	CHEBI	CHEBI:553473	ceftizoxime
 MESH	D015313	Cefotetan	CHEBI	CHEBI:3499	cefotetan
@@ -1419,15 +1491,17 @@ MESH	D015760	Alfentanil	CHEBI	CHEBI:2569	alfentanil
 MESH	D015761	4-Aminopyridine	CHEBI	CHEBI:34385	4-aminopyridine
 MESH	D015764	Bepridil	CHEBI	CHEBI:3061	bepridil
 MESH	D015766	Albendazole	CHEBI	CHEBI:16664	albendazole
+MESH	D015773	Enalaprilat	CHEBI	CHEBI:4786	enalaprilat (anhydrous)
 MESH	D015774	Ganciclovir	CHEBI	CHEBI:465284	ganciclovir
-MESH	D015786	Cytochromes b5	HGNC	2570	CYB5A
 MESH	D015790	Cefonicid	CHEBI	CHEBI:3491	cefonicid
 MESH	D015844	Heparin Cofactor II	HGNC	4838	SERPIND1
 MESH	D015847	Interleukin-4	HGNC	6014	IL4
 MESH	D015848	Interleukin-5	HGNC	6016	IL5
 MESH	D015850	Interleukin-6	HGNC	6018	IL6
 MESH	D015851	Interleukin-7	HGNC	6023	IL7
+MESH	D015942	Factor VIIa	CHEBI	CHEBI:3777	Coagulation Factor VIIa
 MESH	D015946	Ethylene Dibromide	CHEBI	CHEBI:28534	1,2-dibromoethane
+MESH	D015951	Factor Xa	CHEBI	CHEBI:3783	Coagulation Factor Xa
 MESH	D015977	Eukaryotic Initiation Factor-1	HGNC	3249	EIF1
 MESH	D016047	Zalcitabine	CHEBI	CHEBI:10101	zalcitabine
 MESH	D016048	Dideoxyadenosine	CHEBI	CHEBI:91207	2',3'-dideoxyadenosine
@@ -1437,6 +1511,7 @@ MESH	D016178	Granulocyte-Macrophage Colony-Stimulating Factor	HGNC	2434	CSF2
 MESH	D016179	Granulocyte Colony-Stimulating Factor	HGNC	2438	CSF3
 MESH	D016189	Dystrophin	HGNC	2928	DMD
 MESH	D016190	Carboplatin	CHEBI	CHEBI:31355	carboplatin
+MESH	D016202	N-Methylaspartate	CHEBI	CHEBI:31882	N-methyl-D-aspartic acid
 MESH	D016209	Interleukin-8	HGNC	6025	CXCL8
 MESH	D016211	Transforming Growth Factor alpha	HGNC	11765	TGFA
 MESH	D016212	Transforming Growth Factor beta	FPLX	TGFB	TGFB
@@ -1448,9 +1523,9 @@ MESH	D016293	Moricizine	CHEBI	CHEBI:6997	moricizine
 MESH	D016314	Ethylketocyclazocine	CHEBI	CHEBI:4901	Ethylketocyclazocine
 MESH	D016316	Guanfacine	CHEBI	CHEBI:5558	Guanfacine
 MESH	D016328	NF-kappa B	FPLX	NFkappaB	NFkappaB
-MESH	D016422	Letter	CHEBI	CHEBI:6446	levothyroxine sodium anhydrous
 MESH	D016547	Kinesin	FPLX	Kinesin	Kinesin
 MESH	D016559	Tacrolimus	CHEBI	CHEBI:61049	tacrolimus (anhydrous)
+MESH	D016572	Cyclosporine	CHEBI	CHEBI:4031	cyclosporin A
 MESH	D016590	Aphidicolin	CHEBI	CHEBI:2766	aphidicolin
 MESH	D016593	Terfenadine	CHEBI	CHEBI:9453	Terfenadine
 MESH	D016596	Vinculin	HGNC	12665	VCL
@@ -1468,6 +1543,7 @@ MESH	D016685	Mitomycin	CHEBI	CHEBI:27504	mitomycin C
 MESH	D016686	Monocrotaline	CHEBI	CHEBI:6980	monocrotaline
 MESH	D016700	Encainide	CHEBI	CHEBI:4788	encainide
 MESH	D016708	Synaptophysin	HGNC	11506	SYP
+MESH	D016729	Leuprolide	CHEBI	CHEBI:6427	leuprolide
 MESH	D016753	Interleukin-10	HGNC	5962	IL10
 MESH	D016877	Oxidants	CHEBI	CHEBI:63248	oxidising agent
 MESH	D016899	Interferon-beta	FPLX	IFNB	IFNB
@@ -1481,6 +1557,8 @@ MESH	D017245	Foscarnet	CHEBI	CHEBI:127780	phosphonoformic acid
 MESH	D017255	Acitretin	CHEBI	CHEBI:50173	all-trans-acitretin
 MESH	D017257	Ramipril	CHEBI	CHEBI:8774	ramipril
 MESH	D017259	Dimaprit	CHEBI	CHEBI:81389	Dimaprit
+MESH	D017273	Goserelin	CHEBI	CHEBI:5523	Goserelin
+MESH	D017274	Nafarelin	CHEBI	CHEBI:7445	Nafarelin
 MESH	D017275	Isradipine	CHEBI	CHEBI:6073	Isradipine
 MESH	D017291	Clarithromycin	CHEBI	CHEBI:3732	clarithromycin
 MESH	D017292	Doxazosin	CHEBI	CHEBI:4708	doxazosin
@@ -1496,6 +1574,7 @@ MESH	D017313	Fenretinide	CHEBI	CHEBI:42588	4-hydroxyphenyl retinamide
 MESH	D017314	Annexin A4	HGNC	542	ANXA4
 MESH	D017317	Annexin A6	HGNC	544	ANXA6
 MESH	D017318	Annexin A3	HGNC	541	ANXA3
+MESH	D017328	Fosinopril	CHEBI	CHEBI:5163	fosinopril
 MESH	D017336	Loratadine	CHEBI	CHEBI:6538	Loratadine
 MESH	D017337	Sermorelin	HGNC	4265	GHRH
 MESH	D017338	Cladribine	CHEBI	CHEBI:567361	cladribine
@@ -1505,12 +1584,17 @@ MESH	D017374	Paroxetine	CHEBI	CHEBI:7936	paroxetine
 MESH	D017382	Reactive Oxygen Species	CHEBI	CHEBI:26523	reactive oxygen species
 MESH	D017395	Plasminogen Activator Inhibitor 1	HGNC	8583	SERPINE1
 MESH	D017396	Plasminogen Activator Inhibitor 2	HGNC	8584	SERPINB2
+MESH	D017412	Ribonucleoprotein, U1 Small Nuclear	GO	GO:0005685	U1 snRNP
+MESH	D017413	Ribonucleoprotein, U2 Small Nuclear	GO	GO:0005686	U2 snRNP
+MESH	D017415	Ribonucleoprotein, U5 Small Nuclear	GO	GO:0005682	U5 snRNP
 MESH	D017430	Prostate-Specific Antigen	HGNC	6364	KLK3
 MESH	D017485	1-Deoxynojirimycin	CHEBI	CHEBI:44369	duvoglustat
 MESH	D017572	Leukotriene A4	CHEBI	CHEBI:15651	leukotriene A4
+MESH	D017576	Daptomycin	CHEBI	CHEBI:600103	daptomycin
 MESH	D017630	Connexins	FPLX	GJ	GJ
 MESH	D017638	Asbestos, Crocidolite	CHEBI	CHEBI:46666	crocidolite asbestos
 MESH	D017639	Asbestos, Amosite	CHEBI	CHEBI:46678	amosite asbestos
+MESH	D017706	Lisinopril	CHEBI	CHEBI:6503	lisinopril dihydrate
 MESH	D017828	Rifabutin	CHEBI	CHEBI:45367	rifabutin
 MESH	D017835	Nedocromil	CHEBI	CHEBI:7492	nedocromil
 MESH	D017878	4,4'-Diisothiocyanostilbene-2,2'-Disulfonic Acid	CHEBI	CHEBI:4286	4,4'-diisothiocyano-trans-stilbene-2,2'-disulfonic acid
@@ -1539,6 +1623,8 @@ MESH	D018799	Intercellular Adhesion Molecule-1	HGNC	5344	ICAM1
 MESH	D018808	Transcription Factor AP-1	FPLX	AP1	AP1
 MESH	D018809	Proliferating Cell Nuclear Antigen	HGNC	8729	PCNA
 MESH	D018817	N-Methyl-3,4-methylenedioxyamphetamine	CHEBI	CHEBI:1391	3,4-methylenedioxymethamphetamine
+MESH	D018822	alpha-Endorphin	CHEBI	CHEBI:80245	alpha-Endorphin
+MESH	D018823	gamma-Endorphin	CHEBI	CHEBI:80246	gamma-Endorphin
 MESH	D018826	CD13 Antigens	HGNC	500	ANPEP
 MESH	D018834	Chaperonin 60	HGNC	5261	HSPD1
 MESH	D018835	Chaperonin 10	HGNC	5269	HSPE1
@@ -1552,26 +1638,29 @@ MESH	D018972	Insulin-Like Growth Factor Binding Protein 3	HGNC	5472	IGFBP3
 MESH	D018974	Insulin-Like Growth Factor Binding Protein 4	HGNC	5473	IGFBP4
 MESH	D018975	Insulin-Like Growth Factor Binding Protein 5	HGNC	5474	IGFBP5
 MESH	D018976	Insulin-Like Growth Factor Binding Protein 6	HGNC	5475	IGFBP6
+MESH	D019000	Phosphotyrosine	CHEBI	CHEBI:37788	O(4)-phospho-L-tyrosine
+MESH	D019004	Galanin	CHEBI	CHEBI:80161	Galanin
 MESH	D019006	Neural Cell Adhesion Molecules	HGNC	7656	NCAM1
 MESH	D019007	P-Selectin	HGNC	10721	SELP
 MESH	D019009	Proto-Oncogene Proteins c-kit	HGNC	6342	KIT
 MESH	D019010	Vascular Cell Adhesion Molecule-1	HGNC	12663	VCAM1
 MESH	D019040	E-Selectin	HGNC	10718	SELE
 MESH	D019041	L-Selectin	HGNC	10720	SELL
-MESH	D019063	Tenascin	HGNC	5318	TNC
-MESH	D019063	Tenascin	FPLX	TN	TN
 MESH	D019096	Vitronectin	HGNC	12724	VTN
 MESH	D019207	beta Carotene	CHEBI	CHEBI:17579	beta-carotene
 MESH	D019208	Brain-Derived Neurotrophic Factor	HGNC	1033	BDNF
 MESH	D019255	NADPH Oxidases	FPLX	NADPH_oxidase	NADPH_oxidase
 MESH	D019256	Cadmium Chloride	CHEBI	CHEBI:35456	cadmium dichloride
 MESH	D019259	Lamivudine	CHEBI	CHEBI:63577	lamivudine
+MESH	D019268	Antibodies, Antineutrophil Cytoplasmic	CHEBI	CHEBI:34507	9-anthroic acid
 MESH	D019271	Hypoxanthine	CHEBI	CHEBI:17368	hypoxanthine
 MESH	D019284	Thapsigargin	CHEBI	CHEBI:9516	thapsigargin
 MESH	D019297	2,4-Dinitrophenol	CHEBI	CHEBI:42017	2,4-dinitrophenol
 MESH	D019307	1-(5-Isoquinolinesulfonyl)-2-Methylpiperazine	CHEBI	CHEBI:83438	1-(5-isoquinolinesulfonyl)-2-methylpiperazine
 MESH	D019311	Staurosporine	CHEBI	CHEBI:15738	staurosporine
+MESH	D019323	omega-N-Methylarginine	CHEBI	CHEBI:28229	N(omega)-methyl-L-arginine
 MESH	D019329	Idazoxan	CHEBI	CHEBI:5862	idazoxan
+MESH	D019331	NG-Nitroarginine Methyl Ester	CHEBI	CHEBI:7549	N(gamma)-nitro-L-arginine methyl ester
 MESH	D019332	Endothelin-1	HGNC	3176	EDN1
 MESH	D019333	Endothelin-2	HGNC	3177	EDN2
 MESH	D019334	Endothelin-3	HGNC	3178	EDN3
@@ -1586,9 +1675,7 @@ MESH	D019405	Cytochrome P-450 CYP11B2	HGNC	2592	CYP11B2
 MESH	D019408	Platelet Endothelial Cell Adhesion Molecule-1	HGNC	8823	PECAM1
 MESH	D019409	Interleukin-15	HGNC	5977	IL15
 MESH	D019410	Interleukin-16	HGNC	5980	IL16
-MESH	D019415	Torque	CHEBI	CHEBI:39294	fenbutatin oxide
 MESH	D019469	Indinavir	CHEBI	CHEBI:44032	indinavir
-MESH	D019587	Dietary Supplements	CHEBI	CHEBI:50733	nutraceutical
 MESH	D019679	Kininogen, High-Molecular-Weight	HGNC	6383	KNG1
 MESH	D019699	Thrombospondins	FPLX	THBS	THBS
 MESH	D019700	Thrombospondin 1	HGNC	11785	THBS1
@@ -1596,17 +1683,19 @@ MESH	D019715	Tissue Inhibitor of Metalloproteinase-1	HGNC	11820	TIMP1
 MESH	D019716	Tissue Inhibitor of Metalloproteinase-2	HGNC	11821	TIMP2
 MESH	D019717	Tissue Inhibitor of Metalloproteinase-3	HGNC	11822	TIMP3
 MESH	D019718	Receptors, CXCR4	HGNC	2561	CXCR4
-MESH	D019741	Haemophilus influenzae type b	CHEBI	CHEBI:143719	H. influenzae type B capsular polysaccharide
 MESH	D019772	Topotecan	CHEBI	CHEBI:63632	topotecan
 MESH	D019782	Riluzole	CHEBI	CHEBI:8863	Riluzole
 MESH	D019788	Fluorodeoxyglucose F18	CHEBI	CHEBI:49134	2-deoxy-2-((18)F)fluoro-D-glucose
 MESH	D019789	Tetraethylammonium	CHEBI	CHEBI:44296	tetraethylammonium
 MESH	D019800	Phenol	CHEBI	CHEBI:15882	phenol
+MESH	D019803	Glutathione Disulfide	CHEBI	CHEBI:17858	glutathione disulfide
 MESH	D019804	Mesalamine	CHEBI	CHEBI:6775	mesalamine
+MESH	D019805	alpha-Methyltyrosine	CHEBI	CHEBI:6912	alpha-methyl-L-tyrosine
 MESH	D019806	Cromakalim	CHEBI	CHEBI:3921	Cromakalim
 MESH	D019808	Losartan	CHEBI	CHEBI:6541	losartan
 MESH	D019811	Hydroxylamine	CHEBI	CHEBI:15429	hydroxylamine
 MESH	D019821	Simvastatin	CHEBI	CHEBI:9150	simvastatin
+MESH	D019825	gamma-MSH	CHEBI	CHEBI:80349	gamma-Melanotropin
 MESH	D019829	Nevirapine	CHEBI	CHEBI:63613	nevirapine
 MESH	D019830	Adenosine-5'-(N-ethylcarboxamide)	CHEBI	CHEBI:73284	N-ethyl-5'-carboxamidoadenosine
 MESH	D019840	2-Propanol	CHEBI	CHEBI:17824	propan-2-ol
@@ -1644,8 +1733,6 @@ MESH	D020558	GTP Phosphohydrolases	FPLX	GTPase	GTPase
 MESH	D020574	Proto-Oncogene Proteins c-sis	HGNC	8800	PDGFB
 MESH	D020652	Peptide Elongation Factor 2	HGNC	3214	EEF2
 MESH	D020691	rab GTP-Binding Proteins	FPLX	RAB	RAB
-MESH	D020717	Eukaryotic Initiation Factor-2B	FPLX	EIF2B	EIF2B
-MESH	D020717	Eukaryotic Initiation Factor-2B	HGNC	3257	EIF2B1
 MESH	D020738	Leptin	HGNC	6553	LEP
 MESH	D020748	Mibefradil	CHEBI	CHEBI:6920	Mibefradil
 MESH	D020778	Matrix Metalloproteinase 2	HGNC	7166	MMP2
@@ -1657,6 +1744,8 @@ MESH	D020796	Receptor, Platelet-Derived Growth Factor alpha	HGNC	8803	PDGFRA
 MESH	D020797	Receptor, Platelet-Derived Growth Factor beta	HGNC	8804	PDGFRB
 MESH	D020842	Plasma Kallikrein	HGNC	6371	KLKB1
 MESH	D020880	Neuregulins	FPLX	NRG	NRG
+MESH	D020881	Enkephalin, D-Penicillamine (2,5)-	CHEBI	CHEBI:73356	DPDPE
+MESH	D020885	Ribonucleoprotein, U7 Small Nuclear	GO	GO:0005683	U7 snRNP
 MESH	D020904	Glia Maturation Factor	HGNC	4373	GMFB
 MESH	D020909	Acarbose	CHEBI	CHEBI:2376	acarbose
 MESH	D020927	Dexmedetomidine	CHEBI	CHEBI:4466	dexmedetomidine
@@ -1672,8 +1761,6 @@ MESH	D024242	HMGN2 Protein	HGNC	4986	HMGN2
 MESH	D024243	HMGB1 Protein	HGNC	4983	HMGB1
 MESH	D024261	HMGB2 Protein	HGNC	5000	HMGB2
 MESH	D024321	zeta Carotene	CHEBI	CHEBI:28068	all-trans-zeta-carotene
-MESH	D024482	Vitamin K 2	CHEBI	CHEBI:16374	menaquinone
-MESH	D024482	Vitamin K 2	CHEBI	CHEBI:78277	menatetrenone
 MESH	D024483	Vitamin K 3	CHEBI	CHEBI:28869	menadione
 MESH	D024502	alpha-Tocopherol	CHEBI	CHEBI:18145	(+)-alpha-tocopherol
 MESH	D024503	beta-Tocopherol	CHEBI	CHEBI:47771	beta-tocopherol
@@ -1681,6 +1768,8 @@ MESH	D024504	gamma-Tocopherol	CHEBI	CHEBI:18185	gamma-tocopherol
 MESH	D024505	Tocopherols	CHEBI	CHEBI:27013	tocopherol
 MESH	D024982	Glycogen Phosphorylase, Muscle Form	HGNC	9726	PYGM
 MESH	D025101	Vitamin B 6	CHEBI	CHEBI:27306	vitamin B6
+MESH	D025364	Streptogramin A	CHEBI	CHEBI:9997	pristinamycin IIA
+MESH	D025381	Streptogramin B	CHEBI	CHEBI:8417	pristinamycin IA
 MESH	D025542	Neurofibromin 1	HGNC	7765	NF1
 MESH	D025581	Neurofibromin 2	HGNC	7773	NF2
 MESH	D025765	HMGB3 Protein	HGNC	5004	HMGB3
@@ -1696,11 +1785,7 @@ MESH	D026563	LDL-Receptor Related Protein-Associated Protein	HGNC	6701	LRPAP1
 MESH	D027201	Cationic Amino Acid Transporter 1	HGNC	11057	SLC7A1
 MESH	D027261	Fusion Regulatory Protein-1	HGNC	10776	SFRP1
 MESH	D027283	Large Neutral Amino Acid-Transporter 1	HGNC	11063	SLC7A5
-MESH	D027622	Crocus	CHEBI	CHEBI:79068	crocin-1
 MESH	D028341	Activins	FPLX	Activin	Activin
-MESH	D029866	Derris	CHEBI	CHEBI:28201	rotenone
-MESH	D031309	Ryania	CHEBI	CHEBI:8925	ryanodine
-MESH	D031605	Cocculus	CHEBI	CHEBI:134126	picrotoxin
 MESH	D034284	Dynamin I	HGNC	2972	DNM1
 MESH	D034285	Dynamin II	HGNC	2974	DNM2
 MESH	D034641	Heterogeneous-Nuclear Ribonucleoprotein K	HGNC	5044	HNRNPK
@@ -1721,7 +1806,6 @@ MESH	D036387	Ephrin-B1	HGNC	3226	EFNB1
 MESH	D036388	Ephrin-B2	HGNC	3227	EFNB2
 MESH	D036389	Ephrin-B3	HGNC	3228	EFNB3
 MESH	D036563	Cyclic ADP-Ribose	CHEBI	CHEBI:31445	cyclic ADP-ribose
-MESH	D036625	Stevia	CHEBI	CHEBI:145012	rebaudioside A
 MESH	D037201	Follicle Stimulating Hormone, beta Subunit	HGNC	3964	FSHB
 MESH	D037281	Calnexin	HGNC	1473	CANX
 MESH	D037282	Calreticulin	HGNC	1455	CALR
@@ -1731,7 +1815,6 @@ MESH	D037501	Galectin 2	HGNC	6562	LGALS2
 MESH	D037502	Galectin 3	HGNC	6563	LGALS3
 MESH	D037541	Galectin 4	HGNC	6565	LGALS4
 MESH	D037663	Pulmonary Surfactant-Associated Protein D	HGNC	10803	SFTPD
-MESH	D037741	Fullerenes	CHEBI	CHEBI:33128	C60 fullerene
 MESH	D038362	Glycogen Synthase Kinase 3	FPLX	GSK3	GSK3
 MESH	D038681	Follistatin	HGNC	3971	FST
 MESH	D038744	Ribosomal Protein S6 Kinases, 90-kDa	HGNC	10430	RPS6KA1
@@ -1753,8 +1836,6 @@ MESH	D040201	Platelet Membrane Glycoprotein IIb	HGNC	6138	ITGA2B
 MESH	D040281	Vascular Endothelial Growth Factor Receptor-1	HGNC	3763	FLT1
 MESH	D040301	Vascular Endothelial Growth Factor Receptor-2	HGNC	6307	KDR
 MESH	D040321	Vascular Endothelial Growth Factor Receptor-3	HGNC	3767	FLT4
-MESH	D042461	Vascular Endothelial Growth Factor A	FPLX	VEGF	VEGF
-MESH	D042461	Vascular Endothelial Growth Factor A	HGNC	12680	VEGFA
 MESH	D042561	Vascular Endothelial Growth Factor B	HGNC	12681	VEGFB
 MESH	D042582	Vascular Endothelial Growth Factor C	HGNC	12682	VEGFC
 MESH	D042643	Vascular Endothelial Growth Factor D	HGNC	3708	VEGFD
@@ -1771,20 +1852,17 @@ MESH	D043384	Glutamyl Aminopeptidase	HGNC	3355	ENPEP
 MESH	D043402	Cathepsin A	HGNC	9251	CTSA
 MESH	D043423	Carboxypeptidase H	HGNC	2303	CPE
 MESH	D043424	Carboxypeptidase B	HGNC	2299	CPB1
-MESH	D043425	Glutamate Carboxypeptidase II	HGNC	13636	FOLH1B
-MESH	D043425	Glutamate Carboxypeptidase II	HGNC	14526	NAALAD2
-MESH	D043425	Glutamate Carboxypeptidase II	HGNC	23536	NAALADL1
 MESH	D043523	Biotinidase	HGNC	1122	BTD
 MESH	D043582	5-alpha-Dihydroprogesterone	CHEBI	CHEBI:28952	5alpha-pregnane-3,20-dione
 MESH	D044262	Prostaglandin H2	CHEBI	CHEBI:15554	prostaglandin H2
 MESH	D044503	5-Methylcytosine	CHEBI	CHEBI:27551	5-methylcytosine
-MESH	D044646	Ascophyllum	CHEBI	CHEBI:53311	sodium alginate
 MESH	D044844	beta-Transducin Repeat-Containing Proteins	HGNC	1144	BTRC
 MESH	D044942	Acyl-CoA Dehydrogenase, Long-Chain	HGNC	92	ACADVL
 MESH	D045162	Thiazolidinediones	CHEBI	CHEBI:50990	thiazolidinediones
 MESH	D045265	Natriuretic Peptides	FPLX	Natriuretic_peptide	Natriuretic_peptide
 MESH	D045303	Cytochromes b	HGNC	7427	MT-CYB
-MESH	D045304	Cytochromes c	HGNC	19986	CYCS
+MESH	D045362	Cytochromes c2	CHEBI	CHEBI:16707	ferrocytochrome c2
+MESH	D045542	PQQ Cofactor	CHEBI	CHEBI:18315	pyrroloquinoline quinone
 MESH	D045683	Furin	HGNC	8568	FURIN
 MESH	D045702	Proprotein Convertase 5	HGNC	8747	PCSK5
 MESH	D047150	Eosinophil Cationic Protein	HGNC	10046	RNASE3
@@ -1873,7 +1951,6 @@ MESH	D053331	Ectodysplasins	HGNC	3157	EDA
 MESH	D053378	Chromogranin B	HGNC	1930	CHGB
 MESH	D053381	Secretogranin II	HGNC	10575	SCG2
 MESH	D053399	Apolipoproteins D	HGNC	612	APOD
-MESH	D053444	Inhibitory Postsynaptic Potentials	CHEBI	CHEBI:82134	IPSP
 MESH	D053449	TNF Receptor-Associated Factor 4	HGNC	12034	TRAF4
 MESH	D053453	Caspase 9	HGNC	1511	CASP9
 MESH	D053455	Caspase 10	HGNC	1500	CASP10
@@ -1882,6 +1959,7 @@ MESH	D053475	Receptor-Interacting Protein Serine-Threonine Kinase 2	HGNC	10020	R
 MESH	D053482	beta 2-Glycoprotein I	HGNC	616	APOH
 MESH	D053492	Elafin	HGNC	8947	PI3
 MESH	D053495	Osteopontin	HGNC	11255	SPP1
+MESH	D053500	gamma-Lipotropin	CHEBI	CHEBI:80248	gamma-Lipotropin
 MESH	D053509	Matrix Metalloproteinase 13	HGNC	7159	MMP13
 MESH	D053511	Matrix Metalloproteinase 14	HGNC	7160	MMP14
 MESH	D053513	Matrix Metalloproteinase 16	HGNC	7162	MMP16
@@ -1908,16 +1986,17 @@ MESH	D053569	Keratin-15	HGNC	6421	KRT15
 MESH	D053577	Interleukin-1 Receptor Accessory Protein	HGNC	5995	IL1RAP
 MESH	D053582	Interleukin-1alpha	HGNC	5991	IL1A
 MESH	D053583	Interleukin-1beta	HGNC	5992	IL1B
+MESH	D053607	Adrenomedullin	CHEBI	CHEBI:80339	Adrenomedullin
 MESH	D053655	Receptors, Interleukin-21	HGNC	6006	IL21R
 MESH	D053668	Syndecan-1	HGNC	10658	SDC1
 MESH	D053669	Syndecan-2	HGNC	10659	SDC2
 MESH	D053670	Syndecan-3	HGNC	10660	SDC3
 MESH	D053671	Syndecan-4	HGNC	10661	SDC4
-MESH	D053759	Interleukin-23	HGNC	15488	IL23A
-MESH	D053759	Interleukin-23	HGNC	15563	IL37
 MESH	D053760	Interleukin-23 Subunit p19	HGNC	15488	IL23A
 MESH	D053764	Presenilin-1	HGNC	9508	PSEN1
 MESH	D053766	Presenilin-2	HGNC	9509	PSEN2
+MESH	D053771	Glicentin	CHEBI	CHEBI:80272	Glicentin
+MESH	D053772	Oxyntomodulin	CHEBI	CHEBI:81576	Oxyntomodulin
 MESH	D053773	Transforming Growth Factor beta1	HGNC	11766	TGFB1
 MESH	D053782	Transforming Growth Factor beta3	HGNC	11769	TGFB3
 MESH	D053802	Tryptases	FPLX	Tryptase	Tryptase
@@ -2025,6 +2104,7 @@ MESH	D064248	Geminin	HGNC	17493	GMNN
 MESH	D064249	Securin	HGNC	9690	PTTG1
 MESH	D064412	Levalbuterol	CHEBI	CHEBI:8746	(R)-salbutamol
 MESH	D064451	Hepcidins	HGNC	15598	HAMP
+MESH	D064697	Racemethionine	CHEBI	CHEBI:16811	methionine
 MESH	D064750	Rabeprazole	CHEBI	CHEBI:8768	rabeprazole
 MESH	D064805	Bunolol	CHEBI	CHEBI:29110	(+-)-5-[3-(tert-butylamino)-2-hydroxypropoxy]-3,4-dihydronaphthalen-1(2H)-one
 MESH	D065668	Vitamin D3 24-Hydroxylase	HGNC	2602	CYP24A1

--- a/gilda/resources/mesh_mappings.tsv
+++ b/gilda/resources/mesh_mappings.tsv
@@ -262,6 +262,7 @@ MESH	D001278	Atractyloside	CHEBI	CHEBI:2913	Atractyloside
 MESH	D001279	Atracurium	CHEBI	CHEBI:2914	atracurium
 MESH	D001280	Atrazine	CHEBI	CHEBI:15930	atrazine
 MESH	D001285	Atropine	CHEBI	CHEBI:16684	atropine
+MESH	D001343	Autophagy	GO	GO:0006914	autophagy
 MESH	D001374	Azacitidine	CHEBI	CHEBI:2038	5-azacytidine
 MESH	D001375	Azaguanine	CHEBI	CHEBI:63486	8-azaguanine
 MESH	D001380	Azauridine	CHEBI	CHEBI:35668	6-azauridine
@@ -1473,6 +1474,7 @@ MESH	D016899	Interferon-beta	FPLX	IFNB	IFNB
 MESH	D016906	Interleukin-9	HGNC	6029	IL9
 MESH	D016912	Levonorgestrel	CHEBI	CHEBI:6443	levonorgestrel
 MESH	D017026	Swainsonine	CHEBI	CHEBI:9367	swainsonine
+MESH	D017209	Apoptosis	GO	GO:0006915	apoptotic process
 MESH	D017228	Hepatocyte Growth Factor	HGNC	4236	GFER
 MESH	D017239	Paclitaxel	CHEBI	CHEBI:45863	paclitaxel
 MESH	D017245	Foscarnet	CHEBI	CHEBI:127780	phosphonoformic acid

--- a/scripts/generate_mesh_mappings.py
+++ b/scripts/generate_mesh_mappings.py
@@ -1,7 +1,9 @@
 import os
+from collections import defaultdict
 from gilda.generate_terms import generate_famplex_terms, generate_hgnc_terms, \
-    generate_mesh_terms, generate_uniprot_terms, filter_out_duplicates
-from indra.databases import mesh_client, hgnc_client
+    generate_mesh_terms, generate_uniprot_terms, generate_chebi_terms, \
+    filter_out_duplicates
+from indra.databases import mesh_client
 
 
 mesh_protein = 'D000602'
@@ -14,56 +16,61 @@ def dump_mappings(mappings, fname):
     mappings = sorted(mappings.values(), key=lambda x: x[0].id)
     with open(fname, 'w') as fh:
         for me, te in mappings:
-            mesh_name = mesh_client.get_mesh_name(me.id)
-            if te.db == 'HGNC':
-                tname = hgnc_client.get_hgnc_name(te.id)
-            elif te.db == 'FPLX':
-                tname = te.id
-            fh.write('\t'.join([me.db, me.id, mesh_name,
-                                te.db, te.id, tname]) + '\n')
+            fh.write('\t'.join([me.db, me.id, me.entry_name,
+                                te.db, te.id, te.entry_name]) + '\n')
+
+
+def get_ambigs_by_db(ambigs):
+    ambigs_by_db = defaultdict(list)
+    for term in ambigs:
+        ambigs_by_db[term.db].append(term)
+    return dict(ambigs_by_db)
 
 
 def get_mesh_mappings(ambigs):
     predicted_mappings = {}
-    for text, ambig in ambigs.items():
-        hgnc_entries = [a for a in ambig if a.db == 'HGNC']
-        mesh_entries = [a for a in ambig if a.db == 'MESH']
-        fplx_entries = [a for a in ambig if a.db == 'FPLX']
-        if len(mesh_entries) != 1:
+    for text, ambig_terms in ambigs.items():
+        ambigs_by_db = get_ambigs_by_db(ambig_terms)
+        if len(ambigs_by_db.get('MESH', [])) != 1:
             continue
-        me = mesh_entries[0]
+        me = ambigs_by_db['MESH'][0]
         if (mesh_client.mesh_isa(me.id, mesh_protein) or
                 mesh_client.mesh_isa(me.id, mesh_enzyme)):
             print('Considering %s' % me.id)
-            if len(fplx_entries) == 1:
-                key = (me.id, 'FPLX', fplx_entries[0].id)
-                predicted_mappings[key] = (me, fplx_entries[0])
-            elif len(hgnc_entries) == 1:
-                key = (me.id, 'HGNC', hgnc_entries[0].id)
-                predicted_mappings[key] = (me, hgnc_entries[0])
+            if len(ambigs_by_db.get('FPLX', [])) == 1:
+                key = (me.id, 'FPLX', ambigs_by_db['FPLX'][0].id)
+                predicted_mappings[key] = (me, ambigs_by_db['FPLX'][0])
+            elif len(ambigs_by_db.get('HGNC', [])) == 1:
+                key = (me.id, 'HGNC', ambigs_by_db['HGNC'][0].id)
+                predicted_mappings[key] = (me, ambigs_by_db['HGNC'][0])
+        else:
+            if len(ambigs_by_db.get('CHEBI', [])) == 1:
+                key = (me.id, 'CHEBI', ambigs_by_db['CHEBI'][0].id)
+                predicted_mappings[key] = (me, ambigs_by_db['CHEBI'][0])
     return predicted_mappings
 
 
 def find_ambiguities(terms):
-    ambig_entries = {}
+    ambig_entries = defaultdict(list)
     for term in terms:
         # We consider it an ambiguity if the same text entry appears
         # multiple times
-        key = term.text
-        if key in ambig_entries:
-            ambig_entries[key].append(term)
-        else:
-            ambig_entries[key] = [term]
+        ambig_entries[term.text].append(term)
     # It's only an ambiguity if there are two entries at least
     ambig_entries = {k: v for k, v in ambig_entries.items() if len(v) >= 2}
     return ambig_entries
 
 
-if __name__ == '__main__':
+def get_terms():
     terms = generate_mesh_terms(ignore_mappings=True) + \
         generate_hgnc_terms() + generate_famplex_terms() + \
-        generate_uniprot_terms(download=False)
+        generate_uniprot_terms(download=False) + generate_chebi_terms()
     terms = filter_out_duplicates(terms)
+    return terms
+
+
+if __name__ == '__main__':
+    terms = get_terms()
     ambigs = find_ambiguities(terms)
     mappings = get_mesh_mappings(ambigs)
     dump_mappings(mappings, os.path.join(resources, 'mesh_mappings.tsv'))

--- a/scripts/generate_mesh_mappings.py
+++ b/scripts/generate_mesh_mappings.py
@@ -2,7 +2,7 @@ import os
 from collections import defaultdict
 from gilda.generate_terms import generate_famplex_terms, generate_hgnc_terms, \
     generate_mesh_terms, generate_uniprot_terms, generate_chebi_terms, \
-    filter_out_duplicates
+    generate_go_terms, filter_out_duplicates
 from indra.databases import mesh_client
 
 
@@ -47,6 +47,9 @@ def get_mesh_mappings(ambigs):
             if len(ambigs_by_db.get('CHEBI', [])) == 1:
                 key = (me.id, 'CHEBI', ambigs_by_db['CHEBI'][0].id)
                 predicted_mappings[key] = (me, ambigs_by_db['CHEBI'][0])
+            elif len(ambigs_by_db.get('GO', [])) == 1:
+                key = (me.id, 'GO', ambigs_by_db['GO'][0].id)
+                predicted_mappings[key] = (me, ambigs_by_db['GO'][0])
     return predicted_mappings
 
 
@@ -64,7 +67,8 @@ def find_ambiguities(terms):
 def get_terms():
     terms = generate_mesh_terms(ignore_mappings=True) + \
         generate_hgnc_terms() + generate_famplex_terms() + \
-        generate_uniprot_terms(download=False) + generate_chebi_terms()
+        generate_uniprot_terms(download=False) + generate_chebi_terms() + \
+        generate_go_terms()
     terms = filter_out_duplicates(terms)
     return terms
 


### PR DESCRIPTION
This PR extends the script for finding mappings between MeSH and other resources (FPLX, HGNC, CHEBI, GO) based on lexical overlaps. Resolving these redundancies is important since without these mappings, if a MeSH entry and an equivalent entry from another name space have distinct synonyms, groundings would be inconsistent depending on which synonym is encountered.
Though the mappings seem to be good quality overall, there could be some false positives that may need to be manually removed before merging.