### PR TITLE
Improve redundancy resolution for EFO, HP, and DOID

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,7 +26,7 @@ author = 'Benjamin M. Gyori'
 # The short X.Y version
 version = '0.3'
 # The full version, including alpha/beta/rc tags
-release = '0.3.0'
+release = '0.3.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 import logging
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -158,7 +158,8 @@ def generate_mesh_terms(ignore_mappings=False):
         db_id = row[0]
         text_name = row[1]
         mapping = mesh_mappings.get(db_id)
-        if not ignore_mappings and mapping:
+        if not ignore_mappings and mapping and mapping[0] \
+                not in {'EFO', 'HP', 'DOID'}:
             db, db_id, name = mapping
             status = 'synonym'
         else:
@@ -391,7 +392,8 @@ def _generate_obo_terms(prefix):
                     # Here we need to check if we further map the MeSH ID to
                     # another namespace
                     mesh_mapping = mesh_mappings.get(mesh_id)
-                    db, db_id, name = mesh_mapping if mesh_mapping else \
+                    db, db_id, name = mesh_mapping if (mesh_mapping and \
+                            mesh_mapping[0] not in {'EFO', 'HP', 'DOID'}) else \
                         ('MESH', mesh_id, mesh_name)
         # Next we look at mappings to DOID
         # TODO: are we sure that the DOIDs that we get here (from e.g., EFO)

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -376,7 +376,11 @@ def _generate_obo_terms(prefix):
         # We first need to decide if we prioritize another name space
         xref_dict = {xr['namespace']: xr['id'] for xr in entry['xrefs']}
         # Handle MeSH mappings first
-        if 'MESH' in xref_dict or 'MSH' in xref_dict:
+        auto_mesh_mapping = mesh_mappings_reverse.get((db, db_id))
+        if auto_mesh_mapping:
+            db, db_id, name = ('MESH', auto_mesh_mapping[0],
+                               auto_mesh_mapping[1])
+        elif 'MESH' in xref_dict or 'MSH' in xref_dict:
             mesh_id = xref_dict.get('MESH') or xref_dict.get('MSH')
             # Since we currently only include regular MeSH terms (which start
             # with D), we only need to do the mapping if that's the case.
@@ -450,13 +454,15 @@ def _make_mesh_mappings():
     # Load MeSH ID/label mappings
     from .resources import MESH_MAPPINGS_PATH
     mesh_mappings = {}
+    mesh_mappings_reverse = {}
     for row in read_csv(MESH_MAPPINGS_PATH, delimiter='\t'):
         # We can skip row[2] which is the MeSH standard name for the entry
         mesh_mappings[row[1]] = row[3:]
-    return mesh_mappings
+        mesh_mappings_reverse[(row[3], row[4])] = [row[1], row[2]]
+    return mesh_mappings, mesh_mappings_reverse
 
 
-mesh_mappings = _make_mesh_mappings()
+mesh_mappings, mesh_mappings_reverse = _make_mesh_mappings()
 
 
 def filter_out_duplicates(terms):

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -9,7 +9,7 @@ from adeft import available_shortforms as available_adeft_models
 from .term import Term
 from .process import normalize, replace_dashes, replace_greek_uni, \
     replace_greek_latin, depluralize
-from .scorer import generate_match, score
+from .scorer import generate_match, score, score_namespace
 from .resources import get_gilda_models, get_grounding_terms
 
 
@@ -134,8 +134,8 @@ class Grounder(object):
             unique_scores = self.disambiguate(raw_str, unique_scores, context)
 
         # Then sort by decreasing score
-        unique_scores = sorted(unique_scores, key=lambda x: x.score,
-                               reverse=True)
+        rank_fun = lambda x: (x.score, score_namespace(x.term))
+        unique_scores = sorted(unique_scores, key=rank_fun, reverse=True)
 
         return unique_scores
 

--- a/gilda/resources/mesh_mappings.tsv
+++ b/gilda/resources/mesh_mappings.tsv
@@ -1,7 +1,15 @@
 MESH	D000001	Calcimycin	CHEBI	CHEBI:3305	Calcimycin
 MESH	D000002	Temefos	CHEBI	CHEBI:38954	temephos
+MESH	D000007	Abdominal Injuries	EFO	0009502	abdominal injury
+MESH	D000012	Abetalipoproteinemia	HP	HP:0001927	Acanthocytosis
 MESH	D000019	Abortifacient Agents	CHEBI	CHEBI:50691	abortifacient
+MESH	D000038	Abscess	HP	HP:0025615	Abscess
+MESH	D000050	Acanthocytes	HP	HP:0001927	Acanthocytosis
+MESH	D000058	Accidental Falls	HP	HP:0002527	Falls
+MESH	D000066450	Mouse Embryonic Stem Cells	EFO	0004038	mouse embryonic stem cell
 MESH	D000067128	Extracellular Vesicles	GO	GO:1903561	extracellular vesicle
+MESH	D000067208	Shellfish Hypersensitivity	DOID	DOID:0060495	shellfish allergy
+MESH	D000067329	Obesity, Metabolically Benign	EFO	0009382	metabolically healthy obesity
 MESH	D000067596	Interleukin-33	HGNC	16028	IL33
 MESH	D000067616	S100A12 Protein	HGNC	10489	S100A12
 MESH	D000067696	Ataxin-1	HGNC	10548	ATXN1
@@ -17,6 +25,7 @@ MESH	D000067778	ELAV-Like Protein 3	HGNC	3314	ELAVL3
 MESH	D000067779	ELAV-Like Protein 4	HGNC	3315	ELAVL4
 MESH	D000067780	ELAV-Like Protein 1	HGNC	3312	ELAVL1
 MESH	D000067856	Poly(ADP-ribose) Polymerase Inhibitors	CHEBI	CHEBI:62913	EC 2.4.2.30 (NAD(+) ADP-ribosyltransferase) inhibitor
+MESH	D000067877	Autism Spectrum Disorder	DOID	DOID:0060040	pervasive developmental disorder
 MESH	D000067956	Adenylyl Cyclase Inhibitors	CHEBI	CHEBI:90365	EC 4.6.1.1 (adenylate cyclase) inhibitor
 MESH	D000068180	Aripiprazole	CHEBI	CHEBI:31236	aripiprazole
 MESH	D000068256	Darbepoetin alfa	HGNC	4392	GNAS
@@ -51,6 +60,7 @@ MESH	D000068877	Imatinib Mesylate	CHEBI	CHEBI:31690	imatinib methanesulfonate
 MESH	D000068882	Paliperidone Palmitate	CHEBI	CHEBI:83807	paliperidone palmitate
 MESH	D000069056	Lurasidone Hydrochloride	CHEBI	CHEBI:70732	lurasidone hydrochloride
 MESH	D000069059	Atorvastatin	CHEBI	CHEBI:39548	atorvastatin
+MESH	D000069078	Seroconversion	EFO	0007851	seroconversion
 MESH	D000069283	Rituximab	CHEBI	CHEBI:64357	rituximab
 MESH	D000069286	Bortezomib	CHEBI	CHEBI:52717	bortezomib
 MESH	D000069287	Capecitabine	CHEBI	CHEBI:31348	capecitabine
@@ -88,7 +98,10 @@ MESH	D000069604	Dabigatran	CHEBI	CHEBI:70752	dabigatran
 MESH	D000069605	Olopatadine Hydrochloride	CHEBI	CHEBI:31933	Olopatadine hydrochloride
 MESH	D000069616	Simeprevir	CHEBI	CHEBI:134743	simeprevir
 MESH	D000070	Acebutolol	CHEBI	CHEBI:2379	acebutolol
+MESH	D000070589	Talipes Cavus	HP	HP:0001761	Pes cavus
+MESH	D000070636	Rotator Cuff Injuries	EFO	1001250	rotator cuff tear
 MESH	D000070778	Perilipin-1	HGNC	9076	PLIN1
+MESH	D000070779	Giant Cell Tumor of Tendon Sheath	DOID	DOID:314	tenosynovial giant cell tumor
 MESH	D000070780	Perilipin-2	HGNC	248	PLIN2
 MESH	D000070796	Perilipin-3	HGNC	16893	PLIN3
 MESH	D000070797	Perilipin-5	HGNC	33196	PLIN5
@@ -101,6 +114,7 @@ MESH	D000070820	Discoidin Domain Receptor 2	HGNC	2731	DDR2
 MESH	D000070957	MutL Protein Homolog 1	HGNC	7127	MLH1
 MESH	D000070976	Mismatch Repair Endonuclease PMS2	HGNC	9122	PMS2
 MESH	D000070998	ATP Binding Cassette Transporter, Subfamily G, Member 1	HGNC	73	ABCG1
+MESH	D000071017	Hyperekplexia	DOID	DOID:0060695	hyperekplexia
 MESH	D000071040	Axon Initial Segment	GO	GO:0043194	axon initial segment
 MESH	D000071058	Huntingtin Protein	HGNC	4851	HTT
 MESH	D000071063	Endoglin	HGNC	3349	ENG
@@ -138,6 +152,7 @@ MESH	D000071247	Uncoupling Protein 3	HGNC	12519	UCP3
 MESH	D000071248	Peroxisome Proliferator-Activated Receptor Gamma Coactivator 1-alpha	HGNC	9237	PPARGC1A
 MESH	D000071256	Uncoupling Protein 1	HGNC	12517	UCP1
 MESH	D000071316	Forkhead Box Protein O3	HGNC	3821	FOXO3
+MESH	D000071380	Fibromatosis, Plantar	DOID	DOID:8936	plantar fascial fibromatosis
 MESH	D000071396	Aldehyde Dehydrogenase, Mitochondrial	HGNC	404	ALDH2
 MESH	D000071417	Twist-Related Protein 2	HGNC	20670	TWIST2
 MESH	D000071425	Src Homology 2 Domain-Containing, Transforming Protein 1	HGNC	10840	SHC1
@@ -164,12 +179,16 @@ MESH	D000071502	AlkB Homolog 5, RNA Demethylase	HGNC	25996	ALKBH5
 MESH	D000071503	AlkB Homolog 8, tRNA Methyltransferase	HGNC	25189	ALKBH8
 MESH	D000071516	Alpha-Ketoglutarate-Dependent Dioxygenase FTO	HGNC	24678	FTO
 MESH	D000071560	beta-Arrestin 2	HGNC	710	ARR3
+MESH	D000071576	Crush Injuries	EFO	0009504	crush injury
 MESH	D000071617	Protein Deglycase DJ-1	HGNC	16369	PARK7
 MESH	D000071636	Protein Phosphatase 2C	HGNC	9279	PDP1
 MESH	D000071656	Receptor, Notch3	HGNC	7883	NOTCH3
 MESH	D000071657	Werner Syndrome Helicase	HGNC	12791	WRN
 MESH	D000071676	Zinc Finger Protein GLI1	HGNC	4317	GLI1
 MESH	D000071679	Glycogen Synthase Kinase 3 beta	HGNC	4617	GSK3B
+MESH	D000071698	Latent Autoimmune Diabetes in Adults	EFO	0009706	latent autoimmune diabetes in adults
+MESH	D000071699	Bilateral Vestibulopathy	HP	HP:0008568	Vestibular areflexia
+MESH	D000071700	Cone-Rod Dystrophies	DOID	DOID:0050572	cone-rod dystrophy
 MESH	D000071716	Regulatory Factor X1	HGNC	9982	RFX1
 MESH	D000071717	X-Box Binding Protein 1	HGNC	12801	XBP1
 MESH	D000071740	ORAI1 Protein	HGNC	25896	ORAI1
@@ -193,12 +212,14 @@ MESH	D000072019	Kelch-Like ECH-Associated Protein 1	HGNC	23177	KEAP1
 MESH	D000072040	Apolipoprotein A-V	HGNC	17288	APOA5
 MESH	D000072056	Transcription Factor HES-1	HGNC	5192	HES1
 MESH	D000072100	Jagged-1 Protein	HGNC	6188	JAG1
+MESH	D000072142	Pathologists	EFO	0009738	pathologist
 MESH	D000072159	Dynactin Complex	GO	GO:0005869	dynactin complex
 MESH	D000072197	ADAM10 Protein	HGNC	188	ADAM10
 MESH	D000072198	ADAM17 Protein	HGNC	195	ADAM17
 MESH	D000072199	ADAM12 Protein	HGNC	190	ADAM12
 MESH	D000072224	Bcl-2-Like Protein 11	HGNC	994	BCL2L11
 MESH	D000072278	Forkhead Box Protein M1	HGNC	3818	FOXM1
+MESH	D000072283	A549 Cells	EFO	0001086	A549
 MESH	D000072316	Dioxins and Dioxin-like Compounds	CHEBI	CHEBI:134045	polychlorinated dibenzodioxines and related compounds
 MESH	D000072317	Polychlorinated Dibenzodioxins	CHEBI	CHEBI:36682	polychlorinated dibenzodioxine
 MESH	D000072318	Dibenzofurans	CHEBI	CHEBI:38922	dibenzofurans
@@ -217,14 +238,21 @@ MESH	D000072597	Hepatitis A Virus Cellular Receptor 2	HGNC	18437	HAVCR2
 MESH	D000072598	Tumor Necrosis Factor alpha-Induced Protein 3	HGNC	11896	TNFAIP3
 MESH	D000072621	Peptidyl-Prolyl Cis-Trans Isomerase NIMA-Interacting 4	HGNC	8992	PIN4
 MESH	D000072622	Cyclophilin C	HGNC	9256	PPIC
+MESH	D000072637	Thyroid Epithelial Cells	EFO	0003076	thyrocyte
 MESH	D000072640	Interferon-Induced Helicase, IFIH1	HGNC	18873	IFIH1
+MESH	D000072657	ST Elevation Myocardial Infarction	EFO	0008585	ST Elevation Myocardial Infarction
+MESH	D000072658	Non-ST Elevated Myocardial Infarction	EFO	0008586	Non-ST Elevation Myocardial Infarction
+MESH	D000072660	Teratozoospermia	EFO	0002625	teratozoospermia
 MESH	D000072664	Provitamins	CHEBI	CHEBI:50188	provitamin
+MESH	D000072742	Invasive Fungal Infections	HP	HP:0020101	Invasive fungal infection
 MESH	D000072777	Host-Seeking Behavior	GO	GO:0032537	host-seeking behavior
 MESH	D000073	Acenaphthenes	CHEBI	CHEBI:22156	acenaphthenes
 MESH	D000073398	Demethylation	GO	GO:0070988	demethylation
 MESH	D000073399	DNA Demethylation	GO	GO:0080111	DNA demethylation
+MESH	D000073605	Spotted Fever Group Rickettsiosis	DOID	DOID:11104	spotted fever
 MESH	D000073739	Strobilurins	CHEBI	CHEBI:141153	quinone outside inhibitor
 MESH	D000073861	Apelin	HGNC	16665	APLN
+MESH	D000073872	Vascular Ring	HP	HP:0010775	Vascular ring
 MESH	D000073882	ATP Binding Cassette Transporter, Subfamily A, Member 4	HGNC	34	ABCA4
 MESH	D000073883	CX3C Chemokine Receptor 1	HGNC	2558	CX3CR1
 MESH	D000073939	Dysferlin	HGNC	3097	DYSF
@@ -233,6 +261,7 @@ MESH	D000073979	F-Box-WD Repeat-Containing Protein 7	HGNC	16712	FBXW7
 MESH	D000074	Acenocoumarol	CHEBI	CHEBI:53766	acenocoumarol
 MESH	D000074001	Intercellular Adhesion Molecule-3	HGNC	5346	ICAM3
 MESH	D000074008	MDS1 and EVI1 Complex Locus Protein	HGNC	3498	MECOM
+MESH	D000074009	Tubular Sweat Gland Adenomas	DOID	DOID:5445	syringocystadenoma papilliferum
 MESH	D000074010	Bone Marrow Stromal Antigen 2	HGNC	1119	BST2
 MESH	D000074011	Peptide Transporter 1	HGNC	10920	SLC15A1
 MESH	D000074019	T-Cell Intracellular Antigen-1	HGNC	11802	TIA1
@@ -251,11 +280,13 @@ MESH	D000074163	Serine Peptidase Inhibitor Kazal-Type 5	HGNC	15464	SPINK5
 MESH	D000074165	Zinc Finger E-box Binding Homeobox 2	HGNC	14881	ZEB2
 MESH	D000074181	Spastin	HGNC	11233	SPAST
 MESH	D000074261	Receptors, Enterotoxin	HGNC	4688	GUCY2C
+MESH	D000074270	Meconium Ileus	HP	HP:0004401	Meconium ileus
 MESH	D000074283	Endothelial Protein C Receptor	HGNC	9452	PROCR
 MESH	D000074287	TRPC6 Cation Channel	HGNC	12338	TRPC6
 MESH	D000074288	Discs Large Homolog 1 Protein	HGNC	2900	DLG1
 MESH	D000074289	High-Temperature Requirement A Serine Peptidase 1	HGNC	9476	HTRA1
 MESH	D000074301	CD52 Antigen	HGNC	1804	CD52
+MESH	D000074361	Sleep Latency	EFO	0005280	sleep latency
 MESH	D000074382	Greenhouse Gases	CHEBI	CHEBI:76413	greenhouse gas
 MESH	D000074405	Valosin Containing Protein	HGNC	12666	VCP
 MESH	D000074409	Carbonyl Reductase (NADPH)	HGNC	1548	CBR1
@@ -274,6 +305,7 @@ MESH	D000074624	NADPH Oxidase 1	HGNC	7889	NOX1
 MESH	D000074662	NADPH Oxidase 2	HGNC	2578	CYBB
 MESH	D000074663	NADPH Oxidase 4	HGNC	7891	NOX4
 MESH	D000074664	NADPH Oxidase 5	HGNC	14874	NOX5
+MESH	D000074742	Median Arcuate Ligament Syndrome	HP	HP:0012327	Celiac artery compression
 MESH	D000074749	Deubiquitinating Enzyme CYLD	HGNC	2584	CYLD
 MESH	D000074765	Dysbindin	HGNC	17328	DTNBP1
 MESH	D000074842	Forkhead Box Protein L2	HGNC	1092	FOXL2
@@ -286,11 +318,14 @@ MESH	D000075062	Pre-B-Cell Leukemia Transcription Factor 1	HGNC	8632	PBX1
 MESH	D000075064	Myeloid Ecotropic Viral Integration Site 1 Protein	HGNC	7000	MEIS1
 MESH	D000075065	Elongin	GO	GO:0070449	elongin complex
 MESH	D000075102	Organic Cation Transporter 2	HGNC	10966	SLC22A2
+MESH	D000075122	Smoldering Multiple Myeloma	DOID	DOID:9551	smoldering myeloma
 MESH	D000075142	RUNX1 Translocation Partner 1 Protein	HGNC	1535	RUNX1T1
 MESH	D000075163	Metallocenes	CHEBI	CHEBI:33963	metallocene
+MESH	D000075222	Essential Hypertension	EFO	1002032	primary hypertension
 MESH	D000075243	Apolipoproteins M	HGNC	13916	APOM
 MESH	D000075244	Apelin Receptors	HGNC	339	APLNR
 MESH	D000075302	Connexin 30	HGNC	4288	GJB6
+MESH	D000075322	Heavy Metal Poisoning	EFO	1001518	heavy metal poisoning
 MESH	D000075362	Leukocyte Immunoglobulin-like Receptor B1	HGNC	6605	LILRB1
 MESH	D000075366	Chemokine CCL18	HGNC	10616	CCL18
 MESH	D000075369	Anoctamin-1	HGNC	21625	ANO1
@@ -298,6 +333,7 @@ MESH	D000075370	Receptors for Activated C Kinase	HGNC	4399	RACK1
 MESH	D000075383	S100 Calcium Binding Protein A6	HGNC	10496	S100A6
 MESH	D000075388	Netrin-1	HGNC	8029	NTN1
 MESH	D000075389	DCC Receptor	HGNC	2701	DCC
+MESH	D000075529	Solitary Kidney	HP	HP:0000122	Unilateral renal agenesis
 MESH	D000075684	T-Lymphoma Invasion and Metastasis-inducing Protein 1	HGNC	11805	TIAM1
 MESH	D000075687	NEDD8 Protein	HGNC	7732	NEDD8
 MESH	D000075703	Zinc Transporter 8	HGNC	20303	SLC30A8
@@ -326,6 +362,7 @@ MESH	D000076223	Regulatory-Associated Protein of mTOR	HGNC	30287	RPTOR
 MESH	D000076225	Mechanistic Target of Rapamycin Complex 2	FPLX	mTORC2	mTORC2
 MESH	D000076242	MTOR Associated Protein, LST8 Homolog	HGNC	24825	MLST8
 MESH	D000076245	Heterogeneous Nuclear Ribonucleoprotein A1	HGNC	5031	HNRNPA1
+MESH	D000076385	Diverticular Diseases	EFO	0009959	diverticular disease
 MESH	D000077004	Tuberous Sclerosis Complex 1 Protein	HGNC	12362	TSC1
 MESH	D000077005	Tuberous Sclerosis Complex 2 Protein	HGNC	12363	TSC2
 MESH	D000077022	Survivin	HGNC	593	BIRC5
@@ -345,6 +382,7 @@ MESH	D000077157	Sorafenib	CHEBI	CHEBI:50924	sorafenib
 MESH	D000077185	Resveratrol	CHEBI	CHEBI:27881	resveratrol
 MESH	D000077190	Interferon alpha-2	HGNC	5423	IFNA2
 MESH	D000077191	Wortmannin	CHEBI	CHEBI:52289	wortmannin
+MESH	D000077195	Squamous Cell Carcinoma of Head and Neck	EFO	0000181	head and neck squamous cell carcinoma
 MESH	D000077204	Temozolomide	CHEBI	CHEBI:72564	temozolomide
 MESH	D000077205	Pioglitazone	CHEBI	CHEBI:8228	pioglitazone
 MESH	D000077206	Gabapentin	CHEBI	CHEBI:42797	gabapentin
@@ -366,7 +404,9 @@ MESH	D000077268	Pamidronate	CHEBI	CHEBI:7903	pamidronate
 MESH	D000077269	Lenalidomide	CHEBI	CHEBI:63791	lenalidomide
 MESH	D000077270	Exenatide	CHEBI	CHEBI:64073	exendin-4
 MESH	D000077271	Imiquimod	CHEBI	CHEBI:36704	imiquimod
+MESH	D000077273	Thyroid Cancer, Papillary	DOID	DOID:3969	thyroid gland papillary carcinoma
 MESH	D000077276	Lycopene	CHEBI	CHEBI:15948	lycopene
+MESH	D000077277	Esophageal Squamous Cell Carcinoma	EFO	0005922	esophageal squamous cell carcinoma
 MESH	D000077279	Protein Carbamylation	GO	GO:0046944	protein carbamoylation
 MESH	D000077286	Cetrimonium	CHEBI	CHEBI:39561	cetyltrimethylammonium ion
 MESH	D000077287	Levetiracetam	CHEBI	CHEBI:6437	levetiracetam
@@ -455,6 +495,7 @@ MESH	D000077610	Bexarotene	CHEBI	CHEBI:50859	bexarotene
 MESH	D000077612	Anidulafungin	CHEBI	CHEBI:55346	anidulafungin
 MESH	D000077613	Etoricoxib	CHEBI	CHEBI:6339	etoricoxib
 MESH	D000077704	Tirapazamine	CHEBI	CHEBI:78887	tirapazamine
+MESH	D000077711	Self-Neglect	HP	HP:0025479	Self-neglect
 MESH	D000077712	Telbivudine	CHEBI	CHEBI:63624	telbivudine
 MESH	D000077713	17 alpha-Hydroxyprogesterone Caproate	CHEBI	CHEBI:5812	Hydroxyprogesterone caproate
 MESH	D000077716	Afatinib	CHEBI	CHEBI:61390	afatinib
@@ -463,11 +504,13 @@ MESH	D000077726	Doripenem	CHEBI	CHEBI:135928	doripenem
 MESH	D000077728	Cilastatin, Imipenem Drug Combination	CHEBI	CHEBI:5880	Imipenem-cilastatin
 MESH	D000077731	Meropenem	CHEBI	CHEBI:43968	meropenem
 MESH	D000077732	Fidaxomicin	CHEBI	CHEBI:68590	fidaxomicin
+MESH	D000077733	Immunoglobulin G4-Related Disease	DOID	DOID:0080356	IgG4-related disease
 MESH	D000077734	Gatifloxacin	CHEBI	CHEBI:5280	gatifloxacin
 MESH	D000077735	Gemifloxacin	CHEBI	CHEBI:101853	gemifloxacin
 MESH	D000077740	Procalcitonin	HGNC	1437	CALCA
 MESH	D000077743	Diterpene Alkaloids	CHEBI	CHEBI:23847	diterpene alkaloid
 MESH	D000077764	Dronedarone	CHEBI	CHEBI:50659	dronedarone
+MESH	D000077765	Cone Dystrophy	DOID	DOID:0050795	cone dystrophy
 MESH	D000077767	Panobinostat	CHEBI	CHEBI:85990	panobinostat
 MESH	D000077768	Ciclopirox	CHEBI	CHEBI:453011	ciclopirox
 MESH	D000077769	Rilmenidine	CHEBI	CHEBI:8862	Rilmenidine
@@ -481,6 +524,7 @@ MESH	D000077867	Tolcapone	CHEBI	CHEBI:63630	tolcapone
 MESH	D000077868	Atrasentan	CHEBI	CHEBI:135810	atrasentan
 MESH	D000077922	Thiamethoxam	CHEBI	CHEBI:39185	thiamethoxam
 MESH	D000077924	Palonosetron	CHEBI	CHEBI:85161	palonosetron
+MESH	D000077982	Progression-Free Survival	EFO	0004920	progression free survival
 MESH	D000078102	Lumefantrine	CHEBI	CHEBI:156095	lumefantrine
 MESH	D000078142	Tazobactam	CHEBI	CHEBI:9421	tazobactam
 MESH	D000078183	Oxindoles	CHEBI	CHEBI:38459	oxindoles
@@ -530,13 +574,16 @@ MESH	D000117	Acetylglucosamine	CHEBI	CHEBI:28009	N-acetyl-beta-D-glucosamine
 MESH	D000119	Acetylmuramyl-Alanyl-Isoglutamine	CHEBI	CHEBI:59414	muramyl dipeptide
 MESH	D000120	Acecainide	CHEBI	CHEBI:60728	N-acetylprocainamide
 MESH	D000121	Acetylserotonin O-Methyltransferase	HGNC	750	ASMT
+MESH	D000126	Achlorhydria	HP	HP:0032448	Achlorhydria
 MESH	D000145	Acids, Aldehydic	CHEBI	CHEBI:26643	aldehydic acid
+MESH	D000151	Acinetobacter Infections	HP	HP:0032250	Acinetobacter infection
 MESH	D000156	Aconitic Acid	CHEBI	CHEBI:22211	aconitic acid
 MESH	D000157	Aconitine	CHEBI	CHEBI:2430	aconitine
 MESH	D000165	Acridine Orange	CHEBI	CHEBI:51739	acridine orange
 MESH	D000166	Acridines	CHEBI	CHEBI:22213	acridines
 MESH	D000167	Acriflavine	CHEBI	CHEBI:383703	3,6-diamino-10-methylacridinium chloride
 MESH	D000171	Acrolein	CHEBI	CHEBI:15368	acrolein
+MESH	D000172	Acromegaly	DOID	DOID:6255	growth hormone secreting pituitary adenoma
 MESH	D000175	Acronine	CHEBI	CHEBI:2437	acronycine
 MESH	D000176	Acrosin	HGNC	126	ACR
 MESH	D000178	Acrylamides	CHEBI	CHEBI:22216	acrylamides
@@ -545,6 +592,7 @@ MESH	D000185	Actinin	FPLX	ACTN	ACTN
 MESH	D000186	Actinium	CHEBI	CHEBI:33337	actinium atom
 MESH	D000198	Spectinomycin	CHEBI	CHEBI:9215	spectinomycin
 MESH	D000200	Action Potentials	GO	GO:0001508	action potential
+MESH	D000203	Activities of Daily Living	EFO	0008451	activities of daily living score measurement
 MESH	D000205	Actomyosin	GO	GO:0042641	actomyosin
 MESH	D000210	Acute-Phase Reaction	GO	GO:0006953	acute-phase response
 MESH	D000212	Acyclovir	CHEBI	CHEBI:2453	acyclovir
@@ -552,19 +600,23 @@ MESH	D000216	N-Acylneuraminate Cytidylyltransferase	HGNC	18290	CMAS
 MESH	D000218	Adamantane	CHEBI	CHEBI:38223	diamantane
 MESH	D000225	Adenine	CHEBI	CHEBI:16708	adenine
 MESH	D000227	Adenine Nucleotides	CHEBI	CHEBI:22256	adenosine phosphate
+MESH	D000236	Adenoma	DOID	DOID:6204	follicular adenoma
 MESH	D000241	Adenosine	CHEBI	CHEBI:16335	adenosine
 MESH	D000242	Cyclic AMP	CHEBI	CHEBI:17489	3',5'-cyclic AMP
 MESH	D000243	Adenosine Deaminase	HGNC	186	ADA
 MESH	D000245	Adenosine Diphosphate Glucose	CHEBI	CHEBI:15751	ADP alpha-D-glucoside
 MESH	D000246	Adenosine Diphosphate Ribose	CHEBI	CHEBI:16960	ADP-D-ribose
-MESH	D000249	Adenosine Monophosphate	CHEBI	CHEBI:16027	adenosine 5'-monophosphate
+MESH	D000249	Adenosine Monophosphate	EFO	0000244	adult midgut precursor
 MESH	D000250	Adenosine Phosphosulfate	CHEBI	CHEBI:17709	5'-adenylyl sulfate
 MESH	D000255	Adenosine Triphosphate	CHEBI	CHEBI:15422	ATP
 MESH	D000262	Adenylyl Cyclases	FPLX	ADCY	ADCY
 MESH	D000263	Adenylate Kinase	HGNC	361	AK1
 MESH	D000264	Adenylosuccinate Lyase	HGNC	291	ADSL
 MESH	D000266	Adenylyl Imidodiphosphate	CHEBI	CHEBI:47785	AMP-PNP
+MESH	D000275	Adjustment Disorders	DOID	DOID:507	adjustment disorder
 MESH	D000276	Adjuvants, Immunologic	CHEBI	CHEBI:50847	immunological adjuvant
+MESH	D000309	Adrenal Insufficiency	DOID	DOID:10493	adrenal cortical hypofunction
+MESH	D000312	Adrenal Hyperplasia, Congenital	DOID	DOID:0050811	congenital adrenal hyperplasia
 MESH	D000316	Adrenergic alpha-Agonists	CHEBI	CHEBI:35569	alpha-adrenergic agonist
 MESH	D000317	Adrenergic alpha-Antagonists	CHEBI	CHEBI:37890	alpha-adrenergic antagonist
 MESH	D000318	Adrenergic beta-Agonists	CHEBI	CHEBI:35522	beta-adrenergic agonist
@@ -573,7 +625,12 @@ MESH	D000322	Adrenergic Agonists	CHEBI	CHEBI:37886	adrenergic agonist
 MESH	D000325	Adrenodoxin	CHEBI	CHEBI:48962	adrenodoxin
 MESH	D000345	Affinity Labels	CHEBI	CHEBI:60788	affinity label
 MESH	D000348	Aflatoxins	CHEBI	CHEBI:22271	aflatoxin
+MESH	D000374	Aggression	GO	GO:0002118	aggressive behavior
 MESH	D000376	Agmatine	CHEBI	CHEBI:17431	agmatine
+MESH	D000377	Agnosia	DOID	DOID:0060150	astereognosia
+MESH	D000380	Agranulocytosis	HP	HP:0012234	Agranulocytosis
+MESH	D000381	Agraphia	DOID	DOID:0060223	agraphia
+MESH	D000387	Ainhum	HP	HP:0031009	Ainhum
 MESH	D000404	Ajmaline	CHEBI	CHEBI:28462	ajmaline
 MESH	D000409	Alanine	CHEBI	CHEBI:16449	alanine
 MESH	D000410	Alanine Transaminase	HGNC	4552	GPT
@@ -582,6 +639,7 @@ MESH	D000426	Alcohol Dehydrogenase	FPLX	ADH	ADH
 MESH	D000431	Ethanol	CHEBI	CHEBI:16236	ethanol
 MESH	D000432	Methanol	CHEBI	CHEBI:17790	methanol
 MESH	D000433	1-Propanol	CHEBI	CHEBI:28831	propan-1-ol
+MESH	D000437	Alcoholism	HP	HP:0030955	Alcoholism
 MESH	D000438	Alcohols	CHEBI	CHEBI:30879	alcohol
 MESH	D000443	Alcuronium	CHEBI	CHEBI:55313	alcuronium
 MESH	D000447	Aldehydes	CHEBI	CHEBI:17478	aldehyde
@@ -601,6 +659,7 @@ MESH	D000487	Allethrin	CHEBI	CHEBI:34572	allethrin
 MESH	D000493	Allopurinol	CHEBI	CHEBI:40279	allopurinol
 MESH	D000496	Alloxan	CHEBI	CHEBI:76451	alloxan
 MESH	D000500	Allylestrenol	CHEBI	CHEBI:31189	Allylestrenol
+MESH	D000505	Alopecia	DOID	DOID:0050801	androgenic alopecia
 MESH	D000509	alpha-Fetoproteins	HGNC	317	AFP
 MESH	D000514	alpha 1-Antichymotrypsin	HGNC	16	SERPINA3
 MESH	D000515	alpha 1-Antitrypsin	HGNC	8941	SERPINA1
@@ -615,12 +674,14 @@ MESH	D000526	Alprenolol	CHEBI	CHEBI:51211	alprenolol
 MESH	D000527	Alprostadil	CHEBI	CHEBI:15544	prostaglandin E1
 MESH	D000536	Aluminum Hydroxide	CHEBI	CHEBI:33130	aluminium hydroxide
 MESH	D000537	Aluminum Oxide	CHEBI	CHEBI:30187	aluminium oxide
+MESH	D000544	Alzheimer Disease	EFO	1001870	late-onset Alzheimers disease
 MESH	D000547	Amantadine	CHEBI	CHEBI:2618	amantadine
 MESH	D000549	Ambenonium Chloride	CHEBI	CHEBI:2628	ambenonium chloride
 MESH	D000551	Ambroxol	CHEBI	CHEBI:135590	ambroxol
 MESH	D000560	Amdinocillin	CHEBI	CHEBI:51208	mecillinam
 MESH	D000561	Amdinocillin Pivoxil	CHEBI	CHEBI:51210	pivmecillinam
 MESH	D000566	Amelogenesis	GO	GO:0097186	amelogenesis
+MESH	D000568	Amenorrhea	HP	HP:0000141	Amenorrhea
 MESH	D000576	Americium	CHEBI	CHEBI:33389	americium atom
 MESH	D000582	Amidophosphoribosyltransferase	HGNC	9238	PPAT
 MESH	D000583	Amikacin	CHEBI	CHEBI:2637	amikacin
@@ -648,6 +709,7 @@ MESH	D000640	Amitrole	CHEBI	CHEBI:40036	amitrole
 MESH	D000641	Ammonia	CHEBI	CHEBI:16134	ammonia
 MESH	D000644	Quaternary Ammonium Compounds	CHEBI	CHEBI:35273	quaternary ammonium salt
 MESH	D000645	Ammonium Sulfate	CHEBI	CHEBI:62946	ammonium sulfate
+MESH	D000650	Amnion	EFO	0003028	acute myeloblastic leukemia with maturation
 MESH	D000654	Amobarbital	CHEBI	CHEBI:2673	amobarbital
 MESH	D000655	Amodiaquine	CHEBI	CHEBI:2674	amodiaquine
 MESH	D000657	Amoxapine	CHEBI	CHEBI:2675	amoxapine
@@ -658,6 +720,7 @@ MESH	D000662	Amphetamines	CHEBI	CHEBI:35338	amphetamines
 MESH	D000666	Amphotericin B	CHEBI	CHEBI:2682	amphotericin B
 MESH	D000667	Ampicillin	CHEBI	CHEBI:28971	ampicillin
 MESH	D000670	Amprolium	CHEBI	CHEBI:85265	amprolium
+MESH	D000671	Amputation	EFO	0009632	amputation
 MESH	D000675	Ampyrone	CHEBI	CHEBI:59026	4-aminoantipyrine
 MESH	D000676	Amrinone	CHEBI	CHEBI:2686	amrinone
 MESH	D000677	Amsacrine	CHEBI	CHEBI:2687	amsacrine
@@ -667,15 +730,21 @@ MESH	D000683	Serum Amyloid P-Component	HGNC	584	APCS
 MESH	D000685	Serum Amyloid A Protein	CHEBI	CHEBI:138152	serum amyloid A
 MESH	D000687	Amylopectin	CHEBI	CHEBI:28057	amylopectin
 MESH	D000688	Amylose	CHEBI	CHEBI:28102	amylose
+MESH	D000690	Amyotrophic Lateral Sclerosis	DOID	DOID:0111246	amyotrophic lateral sclerosis-parkinsonism/dementia complex 1
 MESH	D000691	Anabasine	CHEBI	CHEBI:74	(S)-anabasine
+MESH	D000698	Analgesia	DOID	DOID:0060145	pain agnosia
 MESH	D000701	Analgesics, Opioid	CHEBI	CHEBI:35482	opioid analgesic
 MESH	D000705	Anaphase	GO	GO:0051322	anaphase
 MESH	D000728	Androgens	CHEBI	CHEBI:50113	androgen
 MESH	D000735	Androstenedione	CHEBI	CHEBI:16422	androst-4-ene-3,17-dione
 MESH	D000738	Androsterone	CHEBI	CHEBI:16032	androsterone
+MESH	D000743	Anemia, Hemolytic	DOID	DOID:583	hemolytic anemia
 MESH	D000777	Anesthetics	CHEBI	CHEBI:38867	anaesthetic
 MESH	D000779	Anesthetics, Local	CHEBI	CHEBI:36333	local anaesthetic
 MESH	D000781	Anethole Trithione	CHEBI	CHEBI:31221	Anetholtrithion
+MESH	D000783	Aneurysm	EFO	0009659	aneurysm
+MESH	D000793	Angioid Streaks	DOID	DOID:979	angioid streaks of choroid
+MESH	D000799	Angioedema	DOID	DOID:0060002	C1 inhibitor deficiency
 MESH	D000802	Angiotensin Amide	CHEBI	CHEBI:135950	angiotensinamide
 MESH	D000803	Angiotensin I	CHEBI	CHEBI:2718	Angiotensin I
 MESH	D000804	Angiotensin II	CHEBI	CHEBI:2719	Ile(5)-angiotensin II
@@ -685,6 +754,9 @@ MESH	D000808	Angiotensinogen	CHEBI	CHEBI:2720	Angiotensinogen
 MESH	D000809	Angiotensins	CHEBI	CHEBI:2719	Ile(5)-angiotensin II
 MESH	D000814	Aniline Compounds	CHEBI	CHEBI:22562	anilines
 MESH	D000841	Anisomycin	CHEBI	CHEBI:338412	(-)-anisomycin
+MESH	D000844	Ankylosis	HP	HP:0031013	Ankylosis
+MESH	D000848	Anodontia	DOID	DOID:0050591	tooth agenesis
+MESH	D000860	Hypoxia	EFO	0009444	hypoxia
 MESH	D000861	Anserine	CHEBI	CHEBI:18323	anserine
 MESH	D000863	Antacids	CHEBI	CHEBI:65265	antacid
 MESH	D000865	Antazoline	CHEBI	CHEBI:84115	antazoline
@@ -713,6 +785,7 @@ MESH	D000966	Antimony Potassium Tartrate	CHEBI	CHEBI:2761	dipotassium bis[mu-tar
 MESH	D000967	Antimony Sodium Gluconate	CHEBI	CHEBI:28148	sodium stibogluconate
 MESH	D000968	Antimycin A	CHEBI	CHEBI:2762	antimycin A
 MESH	D000970	Antineoplastic Agents	CHEBI	CHEBI:35610	antineoplastic agent
+MESH	D000974	Antibodies, Antinuclear	HP	HP:0003493	Antinuclear antibody positivity
 MESH	D000977	Antiparasitic Agents	CHEBI	CHEBI:35442	antiparasitic agent
 MESH	D000979	alpha-2-Antiplasmin	HGNC	9075	SERPINF2
 MESH	D000980	Antiplatyhelmintic Agents	CHEBI	CHEBI:35684	antiplatyhelmintic drug
@@ -724,6 +797,8 @@ MESH	D000990	Antithrombin III	HGNC	775	SERPINC1
 MESH	D000993	Antitreponemal Agents	CHEBI	CHEBI:36050	antitreponemal drug
 MESH	D000995	Antitubercular Agents	CHEBI	CHEBI:33231	antitubercular agent
 MESH	D000996	Antitussive Agents	CHEBI	CHEBI:51177	antitussive
+MESH	D001010	Anxiety, Separation	DOID	DOID:10685	separation anxiety disorder
+MESH	D001019	Aortic Rupture	HP	HP:0031649	Aortic rupture
 MESH	D001032	Apazone	CHEBI	CHEBI:38010	apazone
 MESH	D001052	Apoferritins	CHEBI	CHEBI:2784	Apoferritin
 MESH	D001053	Apolipoproteins	FPLX	Apolipoprotein	Apolipoprotein
@@ -731,6 +806,7 @@ MESH	D001054	Apolipoproteins A	FPLX	APOA	APOA
 MESH	D001057	Apolipoproteins E	HGNC	613	APOE
 MESH	D001058	Apomorphine	CHEBI	CHEBI:48538	apomorphine
 MESH	D001059	Apoproteins	CHEBI	CHEBI:13850	apoprotein
+MESH	D001072	Apraxias	DOID	DOID:0060135	apraxia
 MESH	D001073	Aprindine	CHEBI	CHEBI:135370	aprindine
 MESH	D001074	Propoxur	CHEBI	CHEBI:34938	propoxur
 MESH	D001086	Arabinofuranosyluracil	CHEBI	CHEBI:68346	arauridine
@@ -748,22 +824,33 @@ MESH	D001147	Arsanilic Acid	CHEBI	CHEBI:49477	arsanilic acid
 MESH	D001151	Arsenic	CHEBI	CHEBI:27563	arsenic atom
 MESH	D001152	Arsenicals	CHEBI	CHEBI:22632	arsenic molecular entity
 MESH	D001153	Arsphenamine	CHEBI	CHEBI:9016	arsphenamine
+MESH	D001165	Arteriovenous Malformations	DOID	DOID:11294	arteriovenous malformation
+MESH	D001176	Arthrogryposis	DOID	DOID:0050646	distal arthrogryposis
 MESH	D001194	Asbestos	CHEBI	CHEBI:46661	asbestos
+MESH	D001202	Ascitic Fluid	HP	HP:0030995	Peritoneal effusion
 MESH	D001215	Asparaginase	HGNC	20123	ASPG
 MESH	D001216	Asparagine	CHEBI	CHEBI:17196	L-asparagine
 MESH	D001218	Aspartame	CHEBI	CHEBI:2877	aspartame
 MESH	D001227	Aspartylglucosylaminase	HGNC	318	AGA
+MESH	D001237	Asphyxia	EFO	0009446	asphyxia
 MESH	D001241	Aspirin	CHEBI	CHEBI:15365	acetylsalicylic acid
 MESH	D001246	Astatine	CHEBI	CHEBI:30415	astatine atom
+MESH	D001247	Asthenia	HP	HP:0025406	Asthenia
+MESH	D001248	Asthenopia	HP	HP:0031590	Asthenopia
+MESH	D001249	Asthma	EFO	0009759	Chronic Obstructive Asthma
 MESH	D001252	Astringents	CHEBI	CHEBI:74783	astringent
+MESH	D001254	Astrocytoma	DOID	DOID:3078	grade III astrocytoma
 MESH	D001275	ATP Citrate (pro-S)-Lyase	HGNC	115	ACLY
 MESH	D001278	Atractyloside	CHEBI	CHEBI:2913	Atractyloside
 MESH	D001279	Atracurium	CHEBI	CHEBI:2914	atracurium
 MESH	D001280	Atrazine	CHEBI	CHEBI:15930	atrazine
+MESH	D001284	Atrophy	EFO	1000096	Atrophy
 MESH	D001285	Atropine	CHEBI	CHEBI:16684	atropine
 MESH	D001310	Auranofin	CHEBI	CHEBI:2922	auranofin
 MESH	D001312	Aurintricarboxylic Acid	CHEBI	CHEBI:87397	aurintricarboxylic acid
+MESH	D001327	Autoimmune Diseases	DOID	DOID:417	autoimmune hypersensitivity disease
 MESH	D001329	Autolysis	GO	GO:0001896	autolysis
+MESH	D001342	Autonomic Nervous System Diseases	DOID	DOID:11465	autonomic nervous system disease
 MESH	D001343	Autophagy	GO	GO:0006914	autophagy
 MESH	D001370	Axonal Transport	GO	GO:0098930	axonal transport
 MESH	D001374	Azacitidine	CHEBI	CHEBI:2038	5-azacytidine
@@ -781,6 +868,7 @@ MESH	D001388	Aziridines	CHEBI	CHEBI:22681	aziridines
 MESH	D001390	Azlocillin	CHEBI	CHEBI:2956	azlocillin
 MESH	D001391	Azo Compounds	CHEBI	CHEBI:37533	azo compound
 MESH	D001398	Aztreonam	CHEBI	CHEBI:161680	aztreonam
+MESH	D001405	Reflex, Babinski	HP	HP:0003487	Babinski sign
 MESH	D001414	Bacitracin	CHEBI	CHEBI:28669	bacitracin
 MESH	D001418	Baclofen	CHEBI	CHEBI:2972	baclofen
 MESH	D001429	Bacteriochlorophylls	CHEBI	CHEBI:38201	bacteriochlorophyll
@@ -790,6 +878,7 @@ MESH	D001457	Anion Exchange Protein 1, Erythrocyte	HGNC	11027	SLC4A1
 MESH	D001462	Barbital	CHEBI	CHEBI:31252	5,5-diethylbarbituric acid
 MESH	D001463	Barbiturates	CHEBI	CHEBI:22693	barbiturates
 MESH	D001466	Barium Sulfate	CHEBI	CHEBI:133326	barium sulfate
+MESH	D001471	Barrett Esophagus	EFO	0000478	esophageal adenocarcinoma
 MESH	D001485	Basement Membrane	GO	GO:0005604	basement membrane
 MESH	D001507	Beclomethasone	CHEBI	CHEBI:3001	beclomethasone
 MESH	D001519	Behavior	GO	GO:0007610	behavior
@@ -838,6 +927,7 @@ MESH	D001627	Bethanidine	CHEBI	CHEBI:37937	bethanidine
 MESH	D001629	Bezafibrate	CHEBI	CHEBI:47612	bezafibrate
 MESH	D001640	Bicuculline	CHEBI	CHEBI:3092	bicuculline
 MESH	D001645	Biguanides	CHEBI	CHEBI:53662	biguanides
+MESH	D001661	Biliary Tract Neoplasms	DOID	DOID:0050625	biliary tract benign neoplasm
 MESH	D001663	Bilirubin	CHEBI	CHEBI:16990	bilirubin IXalpha
 MESH	D001664	Biliverdine	CHEBI	CHEBI:17033	biliverdin
 MESH	D001704	Biopolymers	CHEBI	CHEBI:33694	biomacromolecule
@@ -850,12 +940,19 @@ MESH	D001728	Dicumarol	CHEBI	CHEBI:4513	dicoumarol
 MESH	D001729	Bismuth	CHEBI	CHEBI:33301	bismuth atom
 MESH	D001735	Bithionol	CHEBI	CHEBI:3131	bithionol
 MESH	D001737	Biuret	CHEBI	CHEBI:18138	biuret
+MESH	D001749	Urinary Bladder Neoplasms	DOID	DOID:4007	bladder carcinoma
 MESH	D001761	Bleomycin	CHEBI	CHEBI:3139	bleomycin A2
+MESH	D001766	Blindness	HP	HP:0000572	Visual loss
+MESH	D001772	Blood Cell Count	EFO	0004586	complete blood cell count
 MESH	D001775	Blood Circulation	GO	GO:0008015	blood circulation
 MESH	D001777	Blood Coagulation	GO	GO:0007596	blood coagulation
+MESH	D001782	Blood Donors	EFO	0009635	blood donor
+MESH	D001792	Blood Platelets	EFO	0009237	Estimated Platelets Measurement
+MESH	D001800	Blood Specimen Collection	EFO	0009121	blood draw
 MESH	D001802	Blood Substitutes	CHEBI	CHEBI:38849	blood substitute
 MESH	D001839	Bombesin	CHEBI	CHEBI:80229	Bombesin
 MESH	D001846	Bone Development	GO	GO:0060348	bone development
+MESH	D001859	Bone Neoplasms	EFO	1000350	Malignant Bone Neoplasm
 MESH	D001861	Bone Regeneration	GO	GO:1990523	bone regeneration
 MESH	D001862	Bone Resorption	GO	GO:0045453	bone resorption
 MESH	D001865	Bongkrekic Acid	CHEBI	CHEBI:77742	bongkrekic acid
@@ -867,7 +964,10 @@ MESH	D001894	Borohydrides	CHEBI	CHEBI:50986	tetrahydroborate salt
 MESH	D001895	Boron	CHEBI	CHEBI:27560	boron atom
 MESH	D001896	Boron Compounds	CHEBI	CHEBI:22916	boron molecular entity
 MESH	D001897	Boronic Acids	CHEBI	CHEBI:38269	boronic acids
+MESH	D001906	Botulism	DOID	DOID:0050352	foodborne botulism
+MESH	D001907	Boutonneuse Fever	DOID	DOID:0050035	African tick-bite fever
 MESH	D001920	Bradykinin	CHEBI	CHEBI:3165	bradykinin
+MESH	D001948	Brenner Tumor	EFO	1000112	Benign Ovarian Brenner Tumor
 MESH	D001950	Bretylium Tosylate	CHEBI	CHEBI:3173	bretylium tosylate
 MESH	D001952	Bridged-Ring Compounds	CHEBI	CHEBI:35990	bridged compound
 MESH	D001959	Bromates	CHEBI	CHEBI:22923	bromate salt
@@ -891,11 +991,13 @@ MESH	D002026	Buformin	CHEBI	CHEBI:3209	Buformin
 MESH	D002027	Bufotenin	CHEBI	CHEBI:3210	bufotenin
 MESH	D002034	Bumetanide	CHEBI	CHEBI:3213	bumetanide
 MESH	D002035	Bunaftine	CHEBI	CHEBI:135392	bunaftine
+MESH	D002037	Bundle-Branch Block	DOID	DOID:0111074	progressive familial heart block type IA
 MESH	D002040	Levobunolol	CHEBI	CHEBI:6438	levobunolol
 MESH	D002045	Bupivacaine	CHEBI	CHEBI:3215	bupivacaine
 MESH	D002046	Bupranolol	CHEBI	CHEBI:135123	bupranolol
 MESH	D002047	Buprenorphine	CHEBI	CHEBI:3216	buprenorphine
 MESH	D002049	Burimamide	CHEBI	CHEBI:3221	Burimamide
+MESH	D002062	Bursitis	HP	HP:0025232	Bursitis
 MESH	D002064	Buserelin	CHEBI	CHEBI:135907	buserelin
 MESH	D002065	Buspirone	CHEBI	CHEBI:3223	buspirone
 MESH	D002066	Busulfan	CHEBI	CHEBI:28901	busulfan
@@ -907,6 +1009,7 @@ MESH	D002084	Butylated Hydroxytoluene	CHEBI	CHEBI:34247	2,6-di-tert-butyl-4-meth
 MESH	D002085	Butylhydroxybutylnitrosamine	CHEBI	CHEBI:91275	N-butyl-N-(4-hydroxybutyl)nitrosamine
 MESH	D002091	Butyrylcholinesterase	HGNC	983	BCHE
 MESH	D002092	Butyrylthiocholine	CHEBI	CHEBI:41055	butyrylthiocholine
+MESH	D002095	Byssinosis	DOID	DOID:12118	pulmonary hemosiderosis
 MESH	D002096	C-Peptide	CHEBI	CHEBI:80332	C-peptide
 MESH	D002097	C-Reactive Protein	HGNC	2367	CRP
 MESH	D002101	Cacodylic Acid	CHEBI	CHEBI:48765	dimethylarsinic acid
@@ -915,6 +1018,7 @@ MESH	D002104	Cadmium	CHEBI	CHEBI:22977	cadmium atom
 MESH	D002108	Ceruletide	CHEBI	CHEBI:59219	ceruletide
 MESH	D002110	Caffeine	CHEBI	CHEBI:27732	caffeine
 MESH	D002112	Calcifediol	CHEBI	CHEBI:17933	calcidiol
+MESH	D002114	Calcinosis	GO	GO:0030282	bone mineralization
 MESH	D002116	Calcitonin	HGNC	1437	CALCA
 MESH	D002117	Calcitriol	CHEBI	CHEBI:17823	calcitriol
 MESH	D002118	Calcium	CHEBI	CHEBI:22984	calcium atom
@@ -938,6 +1042,7 @@ MESH	D002187	Cannabinol	CHEBI	CHEBI:3360	Cannabinol
 MESH	D002191	Canrenoic Acid	CHEBI	CHEBI:50156	canrenoic acid
 MESH	D002192	Canrenone	CHEBI	CHEBI:135445	canrenone
 MESH	D002193	Cantharidin	CHEBI	CHEBI:64213	cantharidin
+MESH	D002198	Capillary Fragility	HP	HP:0025017	Capillary fragility
 MESH	D002207	Capreomycin	CHEBI	CHEBI:3371	capreomycin
 MESH	D002209	Caprolactam	CHEBI	CHEBI:28579	epsilon-caprolactam
 MESH	D002211	Capsaicin	CHEBI	CHEBI:3374	capsaicin
@@ -966,12 +1071,18 @@ MESH	D002260	Carboprost	CHEBI	CHEBI:3403	carboprost
 MESH	D002261	Carboxin	CHEBI	CHEBI:3405	carboxin
 MESH	D002264	Carboxylic Acids	CHEBI	CHEBI:33575	carboxylic acid
 MESH	D002265	Carboxylic Ester Hydrolases	FPLX	Carboxylesterase	Carboxylesterase
+MESH	D002270	Carbuncle	HP	HP:0020084	Carbuncle
 MESH	D002271	Carbutamide	CHEBI	CHEBI:135118	carbutamide
 MESH	D002272	Carcinoembryonic Antigen	HGNC	1817	CEACAM5
 MESH	D002273	Carcinogens	CHEBI	CHEBI:50903	carcinogenic agent
+MESH	D002277	Carcinoma	DOID	DOID:4015	spindle cell carcinoma
+MESH	D002282	Adenocarcinoma, Bronchiolo-Alveolar	EFO	1001941	bronchioloalveolar carcinoma
+MESH	D002285	Carcinoma, Intraductal, Noninfiltrating	DOID	DOID:0060074	ductal carcinoma in situ
+MESH	D002294	Carcinoma, Squamous Cell	DOID	DOID:3151	skin squamous cell carcinoma
 MESH	D002298	Cardenolides	CHEBI	CHEBI:74634	cardenolides
 MESH	D002301	Cardiac Glycosides	CHEBI	CHEBI:83970	cardiac glycoside
 MESH	D002308	Cardiolipins	CHEBI	CHEBI:28494	cardiolipin
+MESH	D002312	Cardiomyopathy, Hypertrophic	HP	HP:0001670	Asymmetric septal hypertrophy
 MESH	D002317	Cardiovascular Agents	CHEBI	CHEBI:35554	cardiovascular drug
 MESH	D002323	Carfecillin	CHEBI	CHEBI:3414	carfecillin
 MESH	D002328	Carisoprodol	CHEBI	CHEBI:3419	carisoprodol
@@ -980,11 +1091,14 @@ MESH	D002330	Carmustine	CHEBI	CHEBI:3423	carmustine
 MESH	D002332	Carnitine O-Acetyltransferase	HGNC	2342	CRAT
 MESH	D002336	Carnosine	CHEBI	CHEBI:15727	carnosine
 MESH	D002338	Carotenoids	CHEBI	CHEBI:23044	carotenoid
+MESH	D002340	Carotid Artery Diseases	HP	HP:3000041	Abnormality of external carotid artery
+MESH	D002349	Carpal Tunnel Syndrome	HP	HP:0012185	Constrictive median neuropathy
 MESH	D002351	Carrageenan	CHEBI	CHEBI:3435	carrageenan
 MESH	D002354	Carteolol	CHEBI	CHEBI:3437	carteolol
 MESH	D002360	Carubicin	CHEBI	CHEBI:31359	carminomycin
 MESH	D002368	Castor Oil	CHEBI	CHEBI:140618	castor oil
 MESH	D002374	Catalase	HGNC	1516	CAT
+MESH	D002375	Catalepsy	EFO	0009845	catalepsy
 MESH	D002392	Catechin	CHEBI	CHEBI:15600	(+)-catechin
 MESH	D002394	Catechol O-Methyltransferase	HGNC	2228	COMT
 MESH	D002395	Catecholamines	CHEBI	CHEBI:33567	catecholamine
@@ -1015,8 +1129,10 @@ MESH	D002473	Cell Wall	GO	GO:0005618	cell wall
 MESH	D002475	Cellobiose	CHEBI	CHEBI:17057	cellobiose
 MESH	D002479	Inclusion Bodies	GO	GO:0016234	inclusion body
 MESH	D002482	Cellulose	CHEBI	CHEBI:18246	(1->4)-beta-D-glucan
+MESH	D002487	Centers for Disease Control and Prevention (U.S.)	EFO	0006820	complicated disease course
 MESH	D002491	Central Nervous System Agents	CHEBI	CHEBI:35470	central nervous system drug
 MESH	D002492	Central Nervous System Depressants	CHEBI	CHEBI:35488	central nervous system depressant
+MESH	D002499	Centrifugation, Density Gradient	EFO	0009112	density gradient centrifugation
 MESH	D002502	Centrioles	GO	GO:0005814	centriole
 MESH	D002504	Meclofenoxate	CHEBI	CHEBI:6712	Meclofenoxate
 MESH	D002505	Cephacetrile	CHEBI	CHEBI:135437	cefacetrile
@@ -1029,19 +1145,29 @@ MESH	D002513	Cephamycins	CHEBI	CHEBI:55429	cephamycin
 MESH	D002514	Cephapirin	CHEBI	CHEBI:554446	cephapirin
 MESH	D002515	Cephradine	CHEBI	CHEBI:3547	cephradine
 MESH	D002518	Ceramides	CHEBI	CHEBI:17761	ceramide
+MESH	D002529	Cerebellar Nuclei	HP	HP:0003687	Centrally nucleated skeletal muscle fibers
+MESH	D002532	Intracranial Aneurysm	HP	HP:0031773	Posterior communicating artery aneurysm
+MESH	D002546	Ischemic Attack, Transient	EFO	1000758	punctate palmoplantar keratoderma type III
+MESH	D002547	Cerebral Palsy	DOID	DOID:11656	cicatricial pemphigoid
 MESH	D002553	Cerebroside-Sulfatase	HGNC	713	ARSA
 MESH	D002554	Cerebrosides	CHEBI	CHEBI:23079	cerebroside
 MESH	D002569	Cerulenin	CHEBI	CHEBI:171741	cerulenin
 MESH	D002570	Ceruloplasmin	HGNC	2295	CP
+MESH	D002578	Uterine Cervical Dysplasia	HP	HP:0032131	Cervical dysplasia
+MESH	D002585	Cesarean Section	EFO	0009636	cesarean section
 MESH	D002594	Cetylpyridinium	CHEBI	CHEBI:32914	cetylpyridinium
 MESH	D002599	Chalcone	CHEBI	CHEBI:27618	chalcone
 MESH	D002606	Charcoal	CHEBI	CHEBI:91090	charcoal
+MESH	D002607	Charcot-Marie-Tooth Disease	DOID	DOID:0110152	Charcot-Marie-Tooth disease type 1B
 MESH	D002614	Chelating Agents	CHEBI	CHEBI:38161	chelator
 MESH	D002629	Chemosterilants	CHEBI	CHEBI:23092	chemosterilant
 MESH	D002633	Chemotaxis	GO	GO:0006935	chemotaxis
 MESH	D002634	Chemotaxis, Leukocyte	GO	GO:0030595	leukocyte chemotaxis
 MESH	D002635	Chenodeoxycholic Acid	CHEBI	CHEBI:16755	chenodeoxycholic acid
+MESH	D002647	Chilblains	HP	HP:0009710	Chilblains
+MESH	D002659	Child Development Disorders, Pervasive	DOID	DOID:0060040	pervasive developmental disorder
 MESH	D002686	Chitin	CHEBI	CHEBI:17029	chitin
+MESH	D002690	Chlamydia Infections	DOID	DOID:11263	chlamydia
 MESH	D002698	Chloralose	CHEBI	CHEBI:81902	Chloralose
 MESH	D002699	Chlorambucil	CHEBI	CHEBI:28830	chlorambucil
 MESH	D002701	Chloramphenicol	CHEBI	CHEBI:17698	chloramphenicol
@@ -1081,9 +1207,11 @@ MESH	D002750	Chlorquinaldol	CHEBI	CHEBI:74500	chlorquinaldol
 MESH	D002751	Chlortetracycline	CHEBI	CHEBI:27644	chlortetracycline
 MESH	D002752	Chlorthalidone	CHEBI	CHEBI:3654	chlorthalidone
 MESH	D002753	Chlorzoxazone	CHEBI	CHEBI:3655	chlorzoxazone
+MESH	D002754	Choanal Atresia	HP	HP:0004496	Posterior choanal atresia
 MESH	D002762	Cholecalciferol	CHEBI	CHEBI:28940	calciol
 MESH	D002766	Cholecystokinin	HGNC	1569	CCK
 MESH	D002777	Cholestanols	CHEBI	CHEBI:50420	bile alcohol
+MESH	D002780	Cholestasis, Intrahepatic	DOID	DOID:0070227	intrahepatic cholestasis of pregnancy
 MESH	D002784	Cholesterol	CHEBI	CHEBI:16113	cholesterol
 MESH	D002786	Cholesterol Side-Chain Cleavage Enzyme	HGNC	2590	CYP11A1
 MESH	D002788	Cholesterol Esters	CHEBI	CHEBI:17002	cholesteryl ester
@@ -1098,7 +1226,11 @@ MESH	D002802	Cholinesterases	HGNC	983	BCHE
 MESH	D002807	Chondroitin	CHEBI	CHEBI:16137	chondroitin D-glucuronate
 MESH	D002809	Chondroitin Sulfates	CHEBI	CHEBI:37397	chondroitin sulfate
 MESH	D002811	Chondroitinsulfatases	HGNC	4122	GALNS
+MESH	D002819	Chorea	DOID	DOID:12859	choreatic disease
+MESH	D002821	Chorioamnionitis	DOID	DOID:0050697	chorioamnionitis
+MESH	D002822	Choriocarcinoma	DOID	DOID:5551	choriocarcinoma of the testis
 MESH	D002823	Chorion	GO	GO:0042600	chorion
+MESH	D002836	Hemophilia B	EFO	0009154	hemophilia b leyden
 MESH	D002837	Chromaffin Granules	GO	GO:0042583	chromaffin granule
 MESH	D002843	Chromatin	GO	GO:0000785	chromatin
 MESH	D002857	Chromium	CHEBI	CHEBI:28073	chromium atom
@@ -1106,9 +1238,13 @@ MESH	D002863	Chromogenic Compounds	CHEBI	CHEBI:75050	chromogenic compound
 MESH	D002865	Chromomycins	CHEBI	CHEBI:51233	chromomycin
 MESH	D002866	Chromonar	CHEBI	CHEBI:135525	carbocromen
 MESH	D002867	Chromones	CHEBI	CHEBI:23238	chromones
+MESH	D002869	Chromosome Aberrations	EFO	0000336	chromosomal aberration
 MESH	D002875	Chromosomes	GO	GO:0005694	chromosome
+MESH	D002908	Chronic Disease	EFO	0009714	chronic disease
 MESH	D002914	Chylomicrons	GO	GO:0042627	chylomicron
+MESH	D002921	Cicatrix	EFO	0006346	severe cutaneous adverse reaction
 MESH	D002922	Ciguatoxins	CHEBI	CHEBI:61275	ciguatoxin
+MESH	D002925	Ciliary Motility Disorders	DOID	DOID:0060340	ciliopathy
 MESH	D002927	Cimetidine	CHEBI	CHEBI:3699	cimetidine
 MESH	D002930	Cinchona Alkaloids	CHEBI	CHEBI:51323	cinchona alkaloid
 MESH	D002934	Cinnamates	CHEBI	CHEBI:36091	cinnamates
@@ -1122,6 +1258,7 @@ MESH	D002951	Citrates	CHEBI	CHEBI:50744	citrate salt
 MESH	D002952	Citric Acid Cycle	GO	GO:0006099	tricarboxylic acid cycle
 MESH	D002955	Leucovorin	CHEBI	CHEBI:15640	5-formyltetrahydrofolic acid
 MESH	D002966	Clathrin	FPLX	Clathrin	Clathrin
+MESH	D002971	Cleft Lip	HP	HP:0410030	Cleft lip
 MESH	D002974	Clemastine	CHEBI	CHEBI:3738	clemastine
 MESH	D002981	Clindamycin	CHEBI	CHEBI:3745	clindamycin
 MESH	D002990	Clobetasol	CHEBI	CHEBI:205919	clobetasol
@@ -1140,7 +1277,9 @@ MESH	D003023	Cloxacillin	CHEBI	CHEBI:49566	cloxacillin
 MESH	D003024	Clozapine	CHEBI	CHEBI:3766	clozapine
 MESH	D003038	Cobamides	CHEBI	CHEBI:23341	cobamides
 MESH	D003042	Cocaine	CHEBI	CHEBI:27958	cocaine
+MESH	D003047	Coccidioidomycosis	HP	HP:0032249	Coccidioidomycosis
 MESH	D003049	Coccidiostats	CHEBI	CHEBI:35818	coccidiostat
+MESH	D003054	Cochlear Implants	EFO	0009728	cochlear implant
 MESH	D003061	Codeine	CHEBI	CHEBI:16714	codeine
 MESH	D003065	Coenzyme A	CHEBI	CHEBI:15346	coenzyme A
 MESH	D003067	Coenzymes	CHEBI	CHEBI:23354	coenzyme
@@ -1152,6 +1291,7 @@ MESH	D003091	Colistin	CHEBI	CHEBI:37943	colistin
 MESH	D003094	Collagen	CHEBI	CHEBI:3815	Collagen
 MESH	D003101	Collodion	CHEBI	CHEBI:53325	nitrocellulose
 MESH	D003115	Colony-Stimulating Factors	HGNC	2434	CSF2
+MESH	D003141	Communicable Diseases	DOID	DOID:0050117	disease by infectious agent
 MESH	D003167	Complement Activation	GO	GO:0006956	complement activation
 MESH	D003173	Complement C1s	HGNC	1247	C1S
 MESH	D003175	Complement C2	HGNC	1248	C2
@@ -1162,15 +1302,25 @@ MESH	D003184	Complement C7	HGNC	1346	C7
 MESH	D003186	Complement C9	HGNC	1358	C9
 MESH	D003189	p-Methoxy-N-methylphenethylamine	CHEBI	CHEBI:75143	N,O-dimethyltyramine
 MESH	D003216	Conditioning, Operant	GO	GO:0035106	operant conditioning
+MESH	D003218	Condylomata Acuminata	HP	HP:0032301	Genital warts
 MESH	D003224	Congo Red	CHEBI	CHEBI:34653	Congo Red
+MESH	D003229	Conjunctival Diseases	EFO	1000203	Conjunctival Disorder
+MESH	D003231	Conjunctivitis	DOID	DOID:11213	acute contagious conjunctivitis
+MESH	D003251	Constriction, Pathologic	EFO	0006818	stricture
+MESH	D003253	Consultants	EFO	0001732	consultant
 MESH	D003260	Contact Inhibition	GO	GO:0060242	contact inhibition
+MESH	D003267	Contraception	EFO	0009520	contraception
 MESH	D003276	Contraceptives, Oral	CHEBI	CHEBI:49325	oral contraceptive
 MESH	D003287	Contrast Media	CHEBI	CHEBI:37338	radioopaque medium
+MESH	D003289	Convalescence	EFO	0009630	convalescence
 MESH	D003300	Copper	CHEBI	CHEBI:28694	copper atom
 MESH	D003304	Coproporphyrinogen Oxidase	HGNC	2321	CPOX
 MESH	D003305	Coproporphyrinogens	CHEBI	CHEBI:15438	coproporphyrinogen
 MESH	D003307	Copulation	GO	GO:0007620	copulation
+MESH	D003310	Cor Triatriatum	HP	HP:0010774	Cor triatriatum
 MESH	D003311	Cord Factors	CHEBI	CHEBI:82624	trehalose 6,6'-dimycolate
+MESH	D003323	Coronary Aneurysm	HP	HP:0030882	Coronary artery aneurysm
+MESH	D003329	Coronary Vasospasm	HP	HP:0025497	Coronary artery spasm
 MESH	D003341	Luteolysis	GO	GO:0001554	luteolysis
 MESH	D003345	Corticosterone	CHEBI	CHEBI:16827	corticosterone
 MESH	D003346	Corticotropin-Releasing Hormone	HGNC	2355	CRH
@@ -1183,11 +1333,14 @@ MESH	D003372	Coumaphos	CHEBI	CHEBI:3903	coumaphos
 MESH	D003373	Coumaric Acids	CHEBI	CHEBI:24689	hydroxycinnamic acid
 MESH	D003374	Coumarins	CHEBI	CHEBI:23403	coumarins
 MESH	D003375	Coumestrol	CHEBI	CHEBI:3908	coumestrol
+MESH	D003397	Craniopharyngioma	EFO	1000447	Papillary Craniopharyngioma
+MESH	D003398	Craniosynostoses	EFO	0008511	metopic craniosynostosis
 MESH	D003401	Creatine	CHEBI	CHEBI:16919	creatine
 MESH	D003402	Creatine Kinase	FPLX	Creatine_kinase	Creatine_kinase
 MESH	D003404	Creatinine	CHEBI	CHEBI:16737	creatinine
 MESH	D003408	Cresols	CHEBI	CHEBI:25399	cresol
 MESH	D003425	Flurogestone Acetate	CHEBI	CHEBI:79932	Flurogestone acetate
+MESH	D003430	Cross-Sectional Studies	EFO	0001428	cross sectional design
 MESH	D003474	Curcumin	CHEBI	CHEBI:3962	curcumin
 MESH	D003484	Cyanamide	CHEBI	CHEBI:16698	cyanamide
 MESH	D003485	Cyanates	CHEBI	CHEBI:23420	cyanates
@@ -1220,6 +1373,7 @@ MESH	D003544	Cysteic Acid	CHEBI	CHEBI:21260	cysteic acid
 MESH	D003545	Cysteine	CHEBI	CHEBI:15356	cysteine
 MESH	D003548	Cysteinyldopa	CHEBI	CHEBI:81392	Cysteinyldopa
 MESH	D003553	Cystine	CHEBI	CHEBI:17376	cystine
+MESH	D003557	Phyllodes Tumor	DOID	DOID:3016	breast malignant phyllodes tumor
 MESH	D003561	Cytarabine	CHEBI	CHEBI:28680	cytarabine
 MESH	D003562	Cytidine	CHEBI	CHEBI:17562	cytidine
 MESH	D003563	Cyclic CMP	CHEBI	CHEBI:17065	3',5'-cyclic CMP
@@ -1248,13 +1402,17 @@ MESH	D003623	Dark Adaptation	GO	GO:1990603	dark adaptation
 MESH	D003630	Daunorubicin	CHEBI	CHEBI:41977	daunorubicin
 MESH	D003632	Dichlorodiphenyldichloroethane	CHEBI	CHEBI:27841	DDD
 MESH	D003634	DDT	CHEBI	CHEBI:16130	DDT
+MESH	D003635	De Lange Syndrome	DOID	DOID:0080505	Cornelia de Lange syndrome 1
 MESH	D003642	Deanol	CHEBI	CHEBI:271436	N,N-dimethylethanolamine
 MESH	D003647	Debrisoquin	CHEBI	CHEBI:34665	debrisoquin
+MESH	D003655	Decerebrate State	HP	HP:0025013	Decerebrate rigidity
+MESH	D003668	Pressure Ulcer	DOID	DOID:8717	decubitus ulcer
 MESH	D003671	DEET	CHEBI	CHEBI:7071	N,N-diethyl-m-toluamide
 MESH	D003672	Defecation	GO	GO:0030421	defecation
 MESH	D003676	Deferoxamine	CHEBI	CHEBI:4356	desferrioxamine B
 MESH	D003685	Dehydrocholic Acid	CHEBI	CHEBI:31459	3,7,12-trioxo-5beta-cholanic acid
 MESH	D003687	Dehydroepiandrosterone	CHEBI	CHEBI:28689	dehydroepiandrosterone
+MESH	D003693	Delirium	HP	HP:0031258	Delirium
 MESH	D003703	Demecolcine	CHEBI	CHEBI:4393	(-)-demecolcine
 MESH	D003707	Demeclocycline	CHEBI	CHEBI:4392	demeclocycline
 MESH	D003708	Nordazepam	CHEBI	CHEBI:111762	nordazepam
@@ -1277,9 +1435,14 @@ MESH	D003854	Deoxyribonucleotides	CHEBI	CHEBI:4431	deoxyribonucleotide
 MESH	D003855	Deoxyribose	CHEBI	CHEBI:28816	2-deoxy-D-ribose
 MESH	D003856	Deoxyuracil Nucleotides	CHEBI	CHEBI:23641	deoxyuridine phosphate
 MESH	D003857	Deoxyuridine	CHEBI	CHEBI:16450	2'-deoxyuridine
+MESH	D003865	Depressive Disorder, Major	DOID	DOID:1470	major depressive disorder
 MESH	D003868	Dequalinium	CHEBI	CHEBI:41872	dequalinium
 MESH	D003871	Dermatan Sulfate	CHEBI	CHEBI:18376	dermatan sulfate
+MESH	D003872	Dermatitis	EFO	1000636	inflammatory skin disease
+MESH	D003876	Dermatitis, Atopic	DOID	DOID:6204	follicular adenoma
+MESH	D003877	Dermatitis, Contact	HP	HP:0032282	Contact dermatitis
 MESH	D003879	Dermatologic Agents	CHEBI	CHEBI:50177	dermatologic drug
+MESH	D003884	Dermoid Cyst	DOID	DOID:5117	dermoid cyst of ovary
 MESH	D003891	Desipramine	CHEBI	CHEBI:47781	desipramine
 MESH	D003892	Deslanoside	CHEBI	CHEBI:31468	deslanoside
 MESH	D003893	Desmin	HGNC	2770	DES
@@ -1301,12 +1464,15 @@ MESH	D003915	Dextromethorphan	CHEBI	CHEBI:4470	dextromethorphan
 MESH	D003916	Dextromoramide	CHEBI	CHEBI:74274	dextromoramide
 MESH	D003917	Dextrorphan	CHEBI	CHEBI:29133	dextrorphan
 MESH	D003918	Dextrothyroxine	CHEBI	CHEBI:30659	D-thyroxine
+MESH	D003924	Diabetes Mellitus, Type 2	DOID	DOID:0050524	maturity-onset diabetes of the young
+MESH	D003925	Diabetic Angiopathies	DOID	DOID:10182	diabetic peripheral angiopathy
 MESH	D003931	Diacetyl	CHEBI	CHEBI:16583	butane-2,3-dione
 MESH	D003932	Heroin	CHEBI	CHEBI:27808	heroin
 MESH	D003958	Diamide	CHEBI	CHEBI:48958	1,1'-azobis(N,N-dimethylformamide)
 MESH	D003959	Diamines	CHEBI	CHEBI:23666	diamine
 MESH	D003960	Diaminopimelic Acid	CHEBI	CHEBI:23673	2,6-diaminopimelic acid
 MESH	D003962	Dianisidine	CHEBI	CHEBI:82321	3,3'-Dimethoxybenzidine
+MESH	D003969	Vipoma	EFO	1000445	Pancreatic Vipoma
 MESH	D003973	Diatrizoate	CHEBI	CHEBI:53691	amidotrizoic acid
 MESH	D003974	Diatrizoate Meglumine	CHEBI	CHEBI:31812	meglumine amidotrizoate
 MESH	D003975	Diazepam	CHEBI	CHEBI:49575	diazepam
@@ -1417,6 +1583,7 @@ MESH	D004258	DNA Polymerase III	FPLX	DNA_polymerase_delta	DNA_polymerase_delta
 MESH	D004260	DNA Repair	GO	GO:0006281	DNA repair
 MESH	D004261	DNA Replication	GO	GO:0006260	DNA replication
 MESH	D004264	DNA Topoisomerases, Type I	HGNC	11986	TOP1
+MESH	D004272	DNA, Mitochondrial	EFO	0008480	mitochondrial DNA
 MESH	D004280	Dobutamine	CHEBI	CHEBI:4670	dobutamine
 MESH	D004281	Docosahexaenoic Acids	CHEBI	CHEBI:36005	docosahexaenoic acid
 MESH	D004286	Dolichol	CHEBI	CHEBI:16091	dolichol
@@ -1432,6 +1599,8 @@ MESH	D004318	Doxycycline	CHEBI	CHEBI:50845	doxycycline
 MESH	D004319	Doxylamine	CHEBI	CHEBI:51380	doxylamine
 MESH	D004327	Drinking Behavior	GO	GO:0042756	drinking behavior
 MESH	D004329	Droperidol	CHEBI	CHEBI:4717	droperidol
+MESH	D004342	Drug Hypersensitivity	DOID	DOID:0060500	drug allergy
+MESH	D004347	Drug Interactions	EFO	0009878	drug interaction
 MESH	D004364	Pharmaceutical Preparations	CHEBI	CHEBI:52217	pharmaceutical
 MESH	D004369	Pentetic Acid	CHEBI	CHEBI:35739	pentetic acid
 MESH	D004376	Galactitol	CHEBI	CHEBI:16813	galactitol
@@ -1439,13 +1608,20 @@ MESH	D004390	Chlorpyrifos	CHEBI	CHEBI:34631	chlorpyrifos
 MESH	D004394	Dydrogesterone	CHEBI	CHEBI:31527	dydrogesterone
 MESH	D004397	Fonofos	CHEBI	CHEBI:38689	fonofos
 MESH	D004400	Dyphylline	CHEBI	CHEBI:4728	dyphylline
+MESH	D004407	Dysgerminoma	DOID	DOID:5511	dysgerminoma of ovary
+MESH	D004408	Dysgeusia	HP	HP:0031249	Parageusia
+MESH	D004410	Dyslexia	DOID	DOID:13365	reading disorder
+MESH	D004415	Dyspepsia	HP	HP:0410281	Dyspepsia
 MESH	D004419	Dysprosium	CHEBI	CHEBI:33377	dysprosium atom
+MESH	D004438	Ecchymosis	HP	HP:0031364	Ecchymosis
 MESH	D004440	Ecdysone	CHEBI	CHEBI:16688	ecdysone
 MESH	D004441	Ecdysterone	CHEBI	CHEBI:16587	20-hydroxyecdysone
 MESH	D004448	Echinomycin	CHEBI	CHEBI:80052	Quinomycin A
 MESH	D004455	Echolocation	GO	GO:0050959	echolocation
 MESH	D004456	Echothiophate Iodide	CHEBI	CHEBI:59849	ecothiopate iodide
 MESH	D004464	Econazole	CHEBI	CHEBI:4754	econazole
+MESH	D004473	Ecthyma	DOID	DOID:11907	ecthyma
+MESH	D004487	Edema	EFO	0009373	edema
 MESH	D004491	Edrophonium	CHEBI	CHEBI:251408	edrophonium
 MESH	D004533	Egtazic Acid	CHEBI	CHEBI:30740	ethylene glycol bis(2-aminoethyl)tetraacetic acid
 MESH	D004540	Einsteinium	CHEBI	CHEBI:33393	einsteinium atom
@@ -1453,15 +1629,20 @@ MESH	D004549	Elastin	HGNC	3327	ELN
 MESH	D004600	Eledoisin	CHEBI	CHEBI:135903	eledoisin
 MESH	D004602	Elements	CHEBI	CHEBI:33250	atom
 MESH	D004610	Ellagic Acid	CHEBI	CHEBI:4775	ellagic acid
+MESH	D004620	Embolism, Fat	HP	HP:0032008	Pulmonary fat embolism
+MESH	D004628	Embryonic Structures	EFO	0000795	animal developmental tissue
 MESH	D004629	Emepronium	CHEBI	CHEBI:135169	emepronium
 MESH	D004640	Emetine	CHEBI	CHEBI:4781	emetine
 MESH	D004642	Emodin	CHEBI	CHEBI:42223	emodin
 MESH	D004656	Enalapril	CHEBI	CHEBI:4784	enalapril
 MESH	D004659	Enbucrilate	CHEBI	CHEBI:134778	enbucrilate
+MESH	D004688	Encopresis	HP	HP:0040183	Encopresis
 MESH	D004705	Endocytosis	GO	GO:0006897	endocytosis
+MESH	D004716	Endometritis	HP	HP:0025636	Endometritis
 MESH	D004721	Endoplasmic Reticulum	GO	GO:0005783	endoplasmic reticulum
 MESH	D004726	Endosulfan	CHEBI	CHEBI:4791	endosulfan
 MESH	D004732	Endrin	CHEBI	CHEBI:81526	Endrin
+MESH	D004734	Energy Metabolism	EFO	0005109	energy expenditure
 MESH	D004737	Enflurane	CHEBI	CHEBI:4792	enflurane
 MESH	D004743	Enkephalin, Leucine	CHEBI	CHEBI:80263	Leu-enkephalin
 MESH	D004744	Enkephalin, Methionine	CHEBI	CHEBI:6618	MET-enkephalin
@@ -1471,12 +1652,15 @@ MESH	D004776	Enviomycin	CHEBI	CHEBI:135872	enviomycin
 MESH	D004791	Enzyme Inhibitors	CHEBI	CHEBI:23924	enzyme inhibitor
 MESH	D004793	Enzyme Reactivators	CHEBI	CHEBI:50242	enzyme reactivator
 MESH	D004801	Eosine Yellowish-(YS)	CHEBI	CHEBI:52053	eosin YS dye
+MESH	D004803	Eosinophilic Granuloma	HP	HP:0032253	Eosinophilic granuloma
 MESH	D004809	Ephedrine	CHEBI	CHEBI:15407	(-)-ephedrine
 MESH	D004811	Epichlorohydrin	CHEBI	CHEBI:37144	epichlorohydrin
+MESH	D004814	Epidermal Cyst	EFO	1000243	Epidermal Inclusion Cyst
 MESH	D004815	Epidermal Growth Factor	HGNC	3229	EGF
 MESH	D004836	Epimestrol	CHEBI	CHEBI:34738	Epimestrol
 MESH	D004837	Epinephrine	CHEBI	CHEBI:28918	(R)-adrenaline
 MESH	D004840	Epirizole	CHEBI	CHEBI:31545	Epirizole
+MESH	D004842	Epispadias	HP	HP:0000039	Epispadias
 MESH	D004855	Equilenin	CHEBI	CHEBI:34739	equilenin
 MESH	D004857	Equilin	CHEBI	CHEBI:42309	equilin
 MESH	D004874	Ergonovine	CHEBI	CHEBI:4822	ergometrine
@@ -1485,14 +1669,19 @@ MESH	D004876	Ergot Alkaloids	CHEBI	CHEBI:23943	ergot alkaloid
 MESH	D004877	Ergoloid Mesylates	CHEBI	CHEBI:34706	ergoloid mesylate
 MESH	D004878	Ergotamine	CHEBI	CHEBI:64318	ergotamine
 MESH	D004883	Erucic Acids	CHEBI	CHEBI:36031	docosenoic acid
+MESH	D004894	Erythrasma	DOID	DOID:4131	erythrasma
 MESH	D004896	Erythritol	CHEBI	CHEBI:17113	erythritol
 MESH	D004897	Erythrityl Tetranitrate	CHEBI	CHEBI:60072	erythrityl tetranitrate
 MESH	D004903	Erythrocyte Aggregation	GO	GO:0034117	erythrocyte aggregation
+MESH	D004915	Leukemia, Erythroblastic, Acute	EFO	1001955	erythroleukemia
+MESH	D004916	Erythromelalgia	HP	HP:0032147	Erythromelalgia
 MESH	D004917	Erythromycin	CHEBI	CHEBI:42355	erythromycin A
 MESH	D004921	Erythropoietin	HGNC	3415	EPO
 MESH	D004923	Erythrosine	CHEBI	CHEBI:61000	erythrosin B
 MESH	D004928	Escin	CHEBI	CHEBI:2500	Aescin
 MESH	D004929	Esculin	CHEBI	CHEBI:4853	esculin
+MESH	D004932	Esophageal and Gastric Varices	DOID	DOID:112	esophageal varix
+MESH	D004948	Esotropia	HP	HP:0020045	Esodeviation
 MESH	D004949	Estazolam	CHEBI	CHEBI:4858	estazolam
 MESH	D004953	Estetrol	CHEBI	CHEBI:142773	estetrol
 MESH	D004956	Estivation	GO	GO:0042751	estivation
@@ -1516,6 +1705,7 @@ MESH	D004999	Amifostine	CHEBI	CHEBI:2636	amifostine
 MESH	D005000	Ethionamide	CHEBI	CHEBI:4885	ethionamide
 MESH	D005001	Ethionine	CHEBI	CHEBI:4886	L-ethionine
 MESH	D005003	Ethisterone	CHEBI	CHEBI:34749	ethisterone
+MESH	D005006	Ethnic Groups	EFO	0001799	ethnic group
 MESH	D005013	Ethosuximide	CHEBI	CHEBI:4887	ethosuximide
 MESH	D005015	Ethoxyquin	CHEBI	CHEBI:77323	ethoxyquin
 MESH	D005016	Ethoxzolamide	CHEBI	CHEBI:101096	ethoxzolamide
@@ -1536,27 +1726,39 @@ MESH	D005047	Etoposide	CHEBI	CHEBI:4911	etoposide
 MESH	D005048	Etorphine	CHEBI	CHEBI:4912	etorphine
 MESH	D005050	Etretinate	CHEBI	CHEBI:4913	etretinate
 MESH	D005054	Eugenol	CHEBI	CHEBI:4917	eugenol
+MESH	D005058	Eunuchism	HP	HP:0008720	Primary testicular failure
+MESH	D005059	Euphoria	HP	HP:0031844	Euphoria
 MESH	D005063	Europium	CHEBI	CHEBI:32999	europium atom
 MESH	D005070	Evans Blue	CHEBI	CHEBI:82467	Evans blue
 MESH	D005089	Exocytosis	GO	GO:0006887	exocytosis
+MESH	D005097	Exostoses, Multiple Hereditary	DOID	DOID:206	hereditary multiple exostoses
+MESH	D005099	Exotropia	HP	HP:0020049	Exodeviation
 MESH	D005100	Expectorants	CHEBI	CHEBI:77035	expectorant
 MESH	D005109	Extracellular Matrix	GO	GO:0031012	extracellular matrix
 MESH	D005110	Extracellular Space	GO	GO:0005615	extracellular space
+MESH	D005131	Eye Injuries	EFO	0009485	eye injury
+MESH	D005157	Facial Pain	EFO	0009625	facial pain
 MESH	D005164	Factor IX	HGNC	3551	F9
 MESH	D005167	Factor VII	HGNC	3544	F7
 MESH	D005170	Factor X	CHEBI	CHEBI:4964	Factor X
 MESH	D005172	Factor XI	HGNC	3529	F11
 MESH	D005174	Factor XII	HGNC	3530	F12
 MESH	D005182	Flavin-Adenine Dinucleotide	CHEBI	CHEBI:16238	FAD
+MESH	D005183	Failure to Thrive	HP	HP:0001508	Failure to thrive
+MESH	D005185	Fallopian Tube Neoplasms	DOID	DOID:1963	fallopian tube carcinoma
+MESH	D005195	Family Relations	EFO	0004424	family relationship
 MESH	D005204	Farnesol	CHEBI	CHEBI:28600	farnesol
+MESH	D005221	Fatigue	EFO	0009641	malaise
 MESH	D005227	Fatty Acids	CHEBI	CHEBI:35366	fatty acid
 MESH	D005228	Fatty Acids, Essential	CHEBI	CHEBI:59549	essential fatty acid
 MESH	D005229	Fatty Acids, Monounsaturated	CHEBI	CHEBI:25413	monounsaturated fatty acid
 MESH	D005231	Fatty Acids, Unsaturated	CHEBI	CHEBI:27208	unsaturated fatty acid
 MESH	D005232	Fatty Acids, Volatile	CHEBI	CHEBI:26666	short-chain fatty acid
 MESH	D005233	Fatty Alcohols	CHEBI	CHEBI:24026	fatty alcohol
+MESH	D005234	Fatty Liver	EFO	0008527	steatosis
 MESH	D005247	Feeding Behavior	GO	GO:0007631	feeding behavior
 MESH	D005259	Felypressin	CHEBI	CHEBI:60564	felypressin
+MESH	D005264	Femoral Fractures	HP	HP:0031846	Femur fracture
 MESH	D005273	Fenbendazole	CHEBI	CHEBI:77092	fenbendazole
 MESH	D005277	Fenfluramine	CHEBI	CHEBI:5000	fenfluramine
 MESH	D005278	Fenitrothion	CHEBI	CHEBI:34757	fenitrothion
@@ -1575,14 +1777,23 @@ MESH	D005294	Ferrochelatase	HGNC	3647	FECH
 MESH	D005295	Ferrocyanides	CHEBI	CHEBI:36294	hexacyanoferrate(4-) salt
 MESH	D005306	Fertilization	GO	GO:0009566	fertilization
 MESH	D005308	Fertilizers	CHEBI	CHEBI:33287	fertilizer
+MESH	D005316	Fetal Distress	HP	HP:0025116	Fetal distress
+MESH	D005319	Fetal Hemoglobin	EFO	0004576	fetal hemoglobin measurement
+MESH	D005320	Fetal Macrosomia	HP	HP:0001520	Large for gestational age
 MESH	D005337	Fibrin	CHEBI	CHEBI:5054	Fibrin
 MESH	D005340	Fibrinogen	FPLX	Fibrinogen	Fibrinogen
 MESH	D005342	Fibrinolysis	GO	GO:0042730	fibrinolysis
 MESH	D005345	Fibrinopeptide B	CHEBI	CHEBI:5057	Fibrinopeptide B
+MESH	D005348	Fibrocystic Breast Disease	DOID	DOID:5998	microglandular adenosis
+MESH	D005351	Fibromatosis, Gingival	DOID	DOID:0060466	gingival fibromatosis
 MESH	D005353	Fibronectins	HGNC	3778	FN1
+MESH	D005354	Fibrosarcoma	EFO	1000255	Fibroblastic Neoplasm
+MESH	D005355	Fibrosis	EFO	0006890	fibrosis
 MESH	D005363	Ficusin	CHEBI	CHEBI:27616	psoralen
 MESH	D005372	Filipin	CHEBI	CHEBI:83267	filipin III
 MESH	D005411	Flame Retardants	CHEBI	CHEBI:79314	flame retardant
+MESH	D005413	Flatfoot	HP	HP:0004684	Talipes valgus
+MESH	D005414	Flatulence	EFO	0009669	flatulence
 MESH	D005415	Flavins	CHEBI	CHEBI:30527	flavin
 MESH	D005420	Flavoproteins	CHEBI	CHEBI:5086	flavoprotein
 MESH	D005421	Flavoring Agents	CHEBI	CHEBI:35617	flavouring agent
@@ -1616,11 +1827,15 @@ MESH	D005478	Flurandrenolone	CHEBI	CHEBI:5127	Flurandrenolide
 MESH	D005479	Flurazepam	CHEBI	CHEBI:5128	flurazepam
 MESH	D005480	Flurbiprofen	CHEBI	CHEBI:5130	flurbiprofen
 MESH	D005481	Flurothyl	CHEBI	CHEBI:134824	flurotyl
+MESH	D005483	Flushing	HP	HP:0031284	Flushing
 MESH	D005485	Flutamide	CHEBI	CHEBI:5132	flutamide
 MESH	D005486	Flavin Mononucleotide	HGNC	3768	FMN1
 MESH	D005492	Folic Acid	CHEBI	CHEBI:27470	folic acid
+MESH	D005499	Folliculitis	HP	HP:0025084	Folliculitis
 MESH	D005503	Food Additives	CHEBI	CHEBI:64047	food additive
+MESH	D005512	Food Hypersensitivity	HP	HP:0012537	Food intolerance
 MESH	D005520	Food Preservatives	CHEBI	CHEBI:65255	food preservative
+MESH	D005547	Foreign Bodies	EFO	0009525	foreign body
 MESH	D005557	Formaldehyde	CHEBI	CHEBI:16842	formaldehyde
 MESH	D005558	Arylformamidase	HGNC	20910	AFMID
 MESH	D005559	Formamides	CHEBI	CHEBI:24079	formamides
@@ -1631,8 +1846,11 @@ MESH	D005574	Formate-Tetrahydrofolate Ligase	HGNC	21055	MTHFD1L
 MESH	D005576	Colforsin	CHEBI	CHEBI:42471	forskolin
 MESH	D005578	Fosfomycin	CHEBI	CHEBI:28915	fosfomycin
 MESH	D005579	Fossil Fuels	CHEBI	CHEBI:35230	fossil fuel
+MESH	D005599	Fractures, Ununited	EFO	0009707	fractures, ununited
 MESH	D005601	Framycetin	CHEBI	CHEBI:7508	framycetin
 MESH	D005605	Francium	CHEBI	CHEBI:33323	francium atom
+MESH	D005621	Friedreich Ataxia	DOID	DOID:0111218	Friedreich ataxia 1
+MESH	D005627	Frostbite	EFO	0009527	frostbite
 MESH	D005630	Fructans	CHEBI	CHEBI:28796	fructan
 MESH	D005632	Fructose	CHEBI	CHEBI:28757	fructose
 MESH	D005634	Fructose-Bisphosphate Aldolase	FPLX	ALDO	ALDO
@@ -1641,6 +1859,7 @@ MESH	D005641	Tegafur	CHEBI	CHEBI:32188	Tegafur
 MESH	D005643	Fucose	CHEBI	CHEBI:33984	fucose
 MESH	D005647	Fucosyltransferases	FPLX	FUT	FUT
 MESH	D005649	Fumarate Hydratase	HGNC	3700	FH
+MESH	D005660	Funnel Chest	HP	HP:0000767	Pectus excavatum
 MESH	D005661	Furagin	CHEBI	CHEBI:131714	furagin
 MESH	D005662	Furaldehyde	CHEBI	CHEBI:34768	furfural
 MESH	D005664	Furazolidone	CHEBI	CHEBI:5195	furazolidone
@@ -1661,6 +1880,7 @@ MESH	D005697	Galactosides	CHEBI	CHEBI:24163	galactoside
 MESH	D005698	Galactosylceramidase	HGNC	4115	GALC
 MESH	D005699	Galactosylceramides	CHEBI	CHEBI:36498	galactosylceramide
 MESH	D005702	Galantamine	CHEBI	CHEBI:42944	galanthamine
+MESH	D005706	Gallbladder Neoplasms	DOID	DOID:3121	gallbladder cancer
 MESH	D005708	Gallium	CHEBI	CHEBI:49631	gallium atom
 MESH	D005711	Gallopamil	CHEBI	CHEBI:34772	Gallopamil
 MESH	D005721	Glutamate-Cysteine Ligase	HGNC	4311	GCLC
@@ -1670,7 +1890,9 @@ MESH	D005746	Gastric Emptying	GO	GO:0035483	gastric emptying
 MESH	D005749	Gastric Inhibitory Polypeptide	CHEBI	CHEBI:80165	Glucose-dependent insulinotropic peptide
 MESH	D005752	Gastric Mucins	HGNC	7515	MUC5AC
 MESH	D005755	Gastrins	CHEBI	CHEBI:75436	gastrin
+MESH	D005756	Gastritis	HP	HP:0005231	Chronic gastritis
 MESH	D005765	Gastrointestinal Agents	CHEBI	CHEBI:55324	gastrointestinal drug
+MESH	D005776	Gaucher Disease	DOID	DOID:0110957	Gaucher's disease type I
 MESH	D005778	Gefarnate	CHEBI	CHEBI:31646	Gefarnate
 MESH	D005780	Gelatin	CHEBI	CHEBI:5291	gelatin
 MESH	D005785	Gene Conversion	GO	GO:0035822	gene conversion
@@ -1686,10 +1908,12 @@ MESH	D005897	Glafenine	CHEBI	CHEBI:31653	glafenine
 MESH	D005900	Glaucarubin	CHEBI	CHEBI:5370	Glaucarubin
 MESH	D005905	Glyburide	CHEBI	CHEBI:5441	glyburide
 MESH	D005907	Gliclazide	CHEBI	CHEBI:31654	gliclazide
+MESH	D005910	Glioma	DOID	DOID:0060108	brain glioma
 MESH	D005912	Gliotoxin	CHEBI	CHEBI:5385	gliotoxin
 MESH	D005913	Glipizide	CHEBI	CHEBI:5384	glipizide
 MESH	D005914	Globins	CHEBI	CHEBI:5386	globin
 MESH	D005915	Globosides	CHEBI	CHEBI:61360	globoside
+MESH	D005929	Glossitis, Benign Migratory	HP	HP:0025252	Geographic tongue
 MESH	D005934	Glucagon	HGNC	4191	GCG
 MESH	D005936	Glucans	CHEBI	CHEBI:37163	glucan
 MESH	D005937	Glucaric Acid	CHEBI	CHEBI:17301	glucaric acid
@@ -1755,6 +1979,8 @@ MESH	D006063	Chorionic Gonadotropin	CHEBI	CHEBI:81570	Chorionic gonadotropin
 MESH	D006072	Gossypol	CHEBI	CHEBI:28584	gossypol
 MESH	D006074	Gout Suppressants	CHEBI	CHEBI:35845	gout suppressant
 MESH	D006096	Gramicidin	CHEBI	CHEBI:5530	gramicidin S
+MESH	D006099	Granuloma	HP	HP:0032252	Granuloma
+MESH	D006111	Graves Disease	DOID	DOID:10719	toxic diffuse goiter
 MESH	D006118	Griseofulvin	CHEBI	CHEBI:27779	griseofulvin
 MESH	D006139	Guaiacol	CHEBI	CHEBI:28591	guaiacol
 MESH	D006140	Guaifenesin	CHEBI	CHEBI:5551	Guaifenesin
@@ -1781,26 +2007,53 @@ MESH	D006213	Hallucinogens	CHEBI	CHEBI:35499	hallucinogen
 MESH	D006219	Halogens	CHEBI	CHEBI:24473	halogen
 MESH	D006220	Haloperidol	CHEBI	CHEBI:5613	haloperidol
 MESH	D006221	Halothane	CHEBI	CHEBI:5615	halothane
+MESH	D006223	Hamartoma Syndrome, Multiple	HP	HP:0500009	Dysplastic gangliocytoma of the cerebellum
 MESH	D006241	Haptens	CHEBI	CHEBI:59174	hapten
 MESH	D006242	Haptoglobins	HGNC	5141	HP
 MESH	D006246	Harmaline	CHEBI	CHEBI:28172	harmaline
 MESH	D006247	Harmine	CHEBI	CHEBI:28121	harmine
+MESH	D006255	Rhinitis, Allergic, Seasonal	DOID	DOID:0060497	pollen allergy
+MESH	D006258	Head and Neck Neoplasms	DOID	DOID:11934	head and neck cancer
+MESH	D006259	Craniocerebral Trauma	EFO	0009505	head injury
+MESH	D006304	Health Status	HP	HP:0032319	Health status
+MESH	D006330	Heart Defects, Congenital	HP	HP:0030680	Abnormality of cardiovascular system morphology
+MESH	D006333	Heart Failure	DOID	DOID:6000	congestive heart failure
+MESH	D006335	Heart Injuries	EFO	0009506	heart injury
+MESH	D006366	Heinz Bodies	HP	HP:0020082	Heinz bodies
 MESH	D006371	Helium	CHEBI	CHEBI:30217	helium atom
+MESH	D006391	Hemangioma	HP	HP:0032060	Epithelioid hemangioma
+MESH	D006394	Hemangiosarcoma	EFO	0003967	vascular sarcoma
+MESH	D006399	Hematocolpos	HP	HP:0031923	Hematocolpos
 MESH	D006401	Hematologic Agents	CHEBI	CHEBI:50248	hematologic agent
+MESH	D006411	Hematopoiesis, Extramedullary	HP	HP:0001978	Extramedullary hematopoiesis
 MESH	D006419	Heme Oxygenase (Decyclizing)	FPLX	HMOX	HMOX
 MESH	D006420	Hemeproteins	CHEBI	CHEBI:35137	hemoprotein
 MESH	D006427	Hemin	CHEBI	CHEBI:50385	hemin
+MESH	D006429	Hemiplegia	DOID	DOID:10967	spastic hemiplegia
+MESH	D006441	Hemoglobin A	EFO	0009208	Hemoglobin A Measurement
+MESH	D006443	Hemoglobin A2	EFO	0005845	hemoglobin A2 measurement
+MESH	D006444	Hemoglobin C	HP	HP:0032146	HbC hemoglobin
+MESH	D006447	Hemoglobin H	HP	HP:0011903	HbH hemoglobin
+MESH	D006451	Hemoglobin, Sickle	EFO	0009223	Hemoglobin S Measurement
 MESH	D006454	Hemoglobins	CHEBI	CHEBI:5656	deoxyhemoglobin
+MESH	D006461	Hemolysis	EFO	0009473	hemolysis
 MESH	D006466	Hemopexin	HGNC	5171	HPX
+MESH	D006473	Postpartum Hemorrhage	EFO	0009579	postpartum hemorrhage
+MESH	D006474	Hemorrhagic Disorders	HP	HP:0001892	Abnormal bleeding
+MESH	D006480	Hemorrhagic Fever with Renal Syndrome	DOID	DOID:0050200	Korean hemorrhagic fever
 MESH	D006487	Hemostasis	GO	GO:0007599	hemostasis
 MESH	D006492	Hempa	CHEBI	CHEBI:24565	hexamethylphosphoric triamide
 MESH	D006493	Heparin	CHEBI	CHEBI:28304	heparin
 MESH	D006497	Heparitin Sulfate	CHEBI	CHEBI:28815	heparan sulfate
+MESH	D006519	Hepatitis, Alcoholic	DOID	DOID:12351	alcoholic hepatitis
+MESH	D006521	Hepatitis, Chronic	EFO	0008496	chronic hepatitis
 MESH	D006531	HEPES	CHEBI	CHEBI:46756	HEPES
 MESH	D006533	Heptachlor	CHEBI	CHEBI:34785	heptachlor
 MESH	D006534	Heptachlor Epoxide	CHEBI	CHEBI:34786	Heptachlor epoxide
 MESH	D006539	Heptoses	CHEBI	CHEBI:33905	heptose
 MESH	D006540	Herbicides	CHEBI	CHEBI:24527	herbicide
+MESH	D006554	Hernia, Umbilical	HP	HP:0001537	Umbilical hernia
+MESH	D006561	Herpes Simplex	DOID	DOID:8566	herpes simplex
 MESH	D006570	Heterochromatin	GO	GO:0000792	heterochromatin
 MESH	D006571	Heterocyclic Compounds	CHEBI	CHEBI:5686	heterocyclic compound
 MESH	D006581	Hexachlorobenzene	CHEBI	CHEBI:5692	hexachlorobenzene
@@ -1817,7 +2070,10 @@ MESH	D006599	UDPglucose-Hexose-1-Phosphate Uridylyltransferase	HGNC	4135	GALT
 MESH	D006601	Hexoses	CHEBI	CHEBI:18133	hexose
 MESH	D006603	Hexuronic Acids	CHEBI	CHEBI:24592	hexuronic acid
 MESH	D006605	Hibernation	GO	GO:0042750	hibernation
+MESH	D006607	Adenoma, Sweat Gland	DOID	DOID:5445	syringocystadenoma papilliferum
+MESH	D006616	Hip Contracture	HP	HP:0003273	Hip contracture
 MESH	D006626	Hippurates	CHEBI	CHEBI:132966	hippurate
+MESH	D006627	Hirschsprung Disease	HP	HP:0005241	Total intestinal aganglionosis
 MESH	D006631	Amine Oxidase (Copper-Containing)	HGNC	80	AOC1
 MESH	D006632	Histamine	CHEBI	CHEBI:18295	histamine
 MESH	D006633	Histamine Antagonists	CHEBI	CHEBI:37956	histamine antagonist
@@ -1825,9 +2081,11 @@ MESH	D006634	Histamine H1 Antagonists	CHEBI	CHEBI:37955	H1-receptor antagonist
 MESH	D006635	Histamine H2 Antagonists	CHEBI	CHEBI:37961	H2-receptor antagonist
 MESH	D006638	Histidine Ammonia-Lyase	HGNC	4806	HAL
 MESH	D006639	Histidine	CHEBI	CHEBI:27570	histidine
+MESH	D006646	Histiocytosis, Langerhans-Cell	DOID	DOID:2571	Langerhans-cell histiocytosis
 MESH	D006655	Histone Deacetylases	FPLX	HDAC	HDAC
 MESH	D006657	Histones	FPLX	Histone	Histone
 MESH	D006684	HLA-DR Antigens	FPLX	HLA_DR	HLA_DR
+MESH	D006689	Hodgkin Disease	DOID	DOID:8654	Hodgkin's lymphoma, mixed cellularity
 MESH	D006690	Bisbenzimidazole	CHEBI	CHEBI:52082	pibenzimol
 MESH	D006695	Holmium	CHEBI	CHEBI:49648	holmium atom
 MESH	D006697	Holothurin	CHEBI	CHEBI:80869	Holothurin
@@ -1835,18 +2093,23 @@ MESH	D006709	Homoarginine	CHEBI	CHEBI:27747	L-homoarginine
 MESH	D006710	Homocysteine	CHEBI	CHEBI:17230	homocysteine
 MESH	D006711	Homocystine	CHEBI	CHEBI:17485	homocystine
 MESH	D006714	Homoserine	CHEBI	CHEBI:15699	L-homoserine
+MESH	D006716	Homosexuality	EFO	0008485	homosexuality
 MESH	D006719	Homovanillic Acid	CHEBI	CHEBI:545959	homovanillic acid
 MESH	D006727	Hormone Antagonists	CHEBI	CHEBI:49020	hormone antagonist
 MESH	D006728	Hormones	CHEBI	CHEBI:24621	hormone
+MESH	D006791	Hostility	HP	HP:0031473	Hostility
+MESH	D006819	Hyaline Membrane Disease	HP	HP:0002643	Neonatal respiratory distress
 MESH	D006826	Hycanthone	CHEBI	CHEBI:52768	hycanthone
 MESH	D006830	Hydralazine	CHEBI	CHEBI:5775	hydralazine
 MESH	D006834	Hydrazines	CHEBI	CHEBI:24631	hydrazines
 MESH	D006835	Hydrazones	CHEBI	CHEBI:38532	hydrazone
+MESH	D006837	Hydroa Vacciniforme	HP	HP:0032381	Hydroa vacciniforme
 MESH	D006838	Hydrocarbons	CHEBI	CHEBI:24632	hydrocarbon
 MESH	D006841	Hydrocarbons, Aromatic	CHEBI	CHEBI:33658	arene
 MESH	D006842	Hydrocarbons, Brominated	CHEBI	CHEBI:22926	bromohydrocarbon
 MESH	D006844	Hydrocarbons, Cyclic	CHEBI	CHEBI:33663	cyclic hydrocarbon
 MESH	D006846	Hydrocarbons, Halogenated	CHEBI	CHEBI:24472	halohydrocarbon
+MESH	D006848	Testicular Hydrocele	DOID	DOID:9912	hydrocele
 MESH	D006851	Hydrochloric Acid	CHEBI	CHEBI:17883	hydrogen chloride
 MESH	D006852	Hydrochlorothiazide	CHEBI	CHEBI:5778	hydrochlorothiazide
 MESH	D006853	Hydrocodone	CHEBI	CHEBI:5779	hydrocodone
@@ -1856,6 +2119,7 @@ MESH	D006857	Hydroflumethiazide	CHEBI	CHEBI:5784	hydroflumethiazide
 MESH	D006858	Hydrofluoric Acid	CHEBI	CHEBI:29228	hydrogen fluoride
 MESH	D006859	Hydrogen	CHEBI	CHEBI:18276	dihydrogen
 MESH	D006861	Hydrogen Peroxide	CHEBI	CHEBI:35923	hydroperoxide
+MESH	D006871	Hydrophthalmos	DOID	DOID:11211	buphthalmos
 MESH	D006873	Hydroquinones	CHEBI	CHEBI:24646	hydroquinones
 MESH	D006877	Hydroxamic Acids	CHEBI	CHEBI:24650	hydroxamic acid
 MESH	D006878	Hydroxides	CHEBI	CHEBI:24651	hydroxides
@@ -1875,12 +2139,22 @@ MESH	D006916	5-Hydroxytryptophan	CHEBI	CHEBI:28171	5-hydroxytryptophan
 MESH	D006918	Hydroxyurea	CHEBI	CHEBI:44423	hydroxyurea
 MESH	D006919	Hydroxyzine	CHEBI	CHEBI:5818	hydroxyzine
 MESH	D006921	Hygromycin B	CHEBI	CHEBI:16976	hygromycin B
+MESH	D006930	Hyperalgesia	HP	HP:0031005	Hyperalgesia
+MESH	D006932	Hyperbilirubinemia	HP	HP:0002904	Hyperbilirubinemia
 MESH	D006967	Hypersensitivity	GO	GO:0002524	hypersensitivity
 MESH	D006968	Hypersensitivity, Delayed	GO	GO:0001806	type IV hypersensitivity
 MESH	D006969	Hypersensitivity, Immediate	GO	GO:0016068	type I hypersensitivity
+MESH	D006973	Hypertension	HP	HP:0032263	Increased blood pressure
 MESH	D006993	Hypnotics and Sedatives	CHEBI	CHEBI:35717	sedative
 MESH	D006997	Hypochlorous Acid	CHEBI	CHEBI:24757	hypochlorous acid
 MESH	D007004	Hypoglycemic Agents	CHEBI	CHEBI:35526	hypoglycemic agent
+MESH	D007007	Hypohidrosis	DOID	DOID:11156	anhidrosis
+MESH	D007008	Hypokalemia	DOID	DOID:4500	hypokalemia
+MESH	D007012	Hypopharyngeal Neoplasms	EFO	0002938	hypopharyngeal carcinoma
+MESH	D007014	Hypophosphatasia	DOID	DOID:0110915	childhood hypophosphatasia
+MESH	D007018	Hypopituitarism	DOID	DOID:9410	panhypopituitarism
+MESH	D007021	Hypospadias	HP	HP:0000047	Hypospadias
+MESH	D007024	Hypotension, Orthostatic	EFO	0005252	orthostatic hypotension
 MESH	D007041	Hypoxanthine Phosphoribosyltransferase	HGNC	5157	HPRT1
 MESH	D007050	Ibogaine	CHEBI	CHEBI:5852	Ibogaine
 MESH	D007051	Ibotenic Acid	CHEBI	CHEBI:5854	Ibotenic acid
@@ -1889,13 +2163,20 @@ MESH	D007064	L-Iditol 2-Dehydrogenase	HGNC	11184	SORD
 MESH	D007065	Idoxuridine	CHEBI	CHEBI:147675	5-iodo-2'-deoxyuridine
 MESH	D007067	Iduronic Acid	CHEBI	CHEBI:24769	iduronic acid
 MESH	D007069	Ifosfamide	CHEBI	CHEBI:5864	ifosfamide
+MESH	D007074	Immunoglobulin G	EFO	0005030	anti-IgG
+MESH	D007078	Ileal Neoplasms	DOID	DOID:10153	ileum cancer
 MESH	D007093	Imidazoles	CHEBI	CHEBI:24780	imidazoles
 MESH	D007095	Imidocarb	CHEBI	CHEBI:51804	imidocarb
 MESH	D007098	Imino Acids	CHEBI	CHEBI:48377	imidic acid
 MESH	D007099	Imipramine	CHEBI	CHEBI:47499	imipramine
 MESH	D007105	Immune Complex Diseases	GO	GO:0001802	type III hypersensitivity
 MESH	D007113	Immunity, Innate	GO	GO:0045087	innate immune response
+MESH	D007154	Immune System Diseases	DOID	DOID:2914	immune system disease
+MESH	D007161	Immunoproliferative Small Intestinal Disease	DOID	DOID:0060126	alpha chain disease
 MESH	D007166	Immunosuppressive Agents	CHEBI	CHEBI:35705	immunosuppressive agent
+MESH	D007169	Impetigo	DOID	DOID:8504	impetigo
+MESH	D007172	Erectile Dysfunction	DOID	DOID:1875	impotence
+MESH	D007177	Inappropriate ADH Syndrome	HP	HP:0031218	Inappropriate antidiuretic hormone secretion
 MESH	D007190	Indapamide	CHEBI	CHEBI:5893	indapamide
 MESH	D007191	Indazoles	CHEBI	CHEBI:38769	indazoles
 MESH	D007203	Indigo Carmine	CHEBI	CHEBI:31695	indigo carmine
@@ -1907,7 +2188,9 @@ MESH	D007213	Indomethacin	CHEBI	CHEBI:49662	indometacin
 MESH	D007215	Indophenol	CHEBI	CHEBI:50428	indophenol
 MESH	D007216	Indoprofen	CHEBI	CHEBI:76162	indoprofen
 MESH	D007217	Indoramin	CHEBI	CHEBI:135470	indoramin
+MESH	D007231	Infant, Newborn	EFO	0001372	neonate
 MESH	D007249	Inflammation	GO	GO:0006954	inflammatory response
+MESH	D007251	Influenza, Human	DOID	DOID:8469	influenza
 MESH	D007265	Inhibins	FPLX	Inhibin	Inhibin
 MESH	D007288	Inosine	CHEBI	CHEBI:17596	inosine
 MESH	D007289	Cyclic IMP	CHEBI	CHEBI:27541	3',5'-cyclic IMP
@@ -1919,6 +2202,7 @@ MESH	D007295	Inositol Phosphates	CHEBI	CHEBI:24846	inositol phosphate
 MESH	D007302	Insect Repellents	CHEBI	CHEBI:71692	insect repellent
 MESH	D007306	Insecticides	CHEBI	CHEBI:24852	insecticide
 MESH	D007314	Insemination	GO	GO:0007320	insemination
+MESH	D007319	Sleep Initiation and Maintenance Disorders	DOID	DOID:0111141	delayed sleep phase syndrome
 MESH	D007328	Insulin	HGNC	6081	INS
 MESH	D007334	Insulin-Like Growth Factor I	HGNC	5464	IGF1
 MESH	D007335	Insulin-Like Growth Factor II	HGNC	5466	IGF2
@@ -1962,6 +2246,7 @@ MESH	D007502	Iron Chelating Agents	CHEBI	CHEBI:38157	iron chelator
 MESH	D007506	Iron-Sulfur Proteins	CHEBI	CHEBI:35135	iron-sulfur protein
 MESH	D007510	Isatin	CHEBI	CHEBI:27539	isatin
 MESH	D007513	Isethionic Acid	CHEBI	CHEBI:1157	isethionic acid
+MESH	D007516	Adenoma, Islet Cell	DOID	DOID:1799	islet cell tumor
 MESH	D007524	Isodesmosine	CHEBI	CHEBI:64366	isodesmosine
 MESH	D007528	Isoetharine	CHEBI	CHEBI:6005	Isoetharine
 MESH	D007529	Isoflavones	CHEBI	CHEBI:38757	isoflavones
@@ -1969,6 +2254,7 @@ MESH	D007530	Isoflurane	CHEBI	CHEBI:6015	isoflurane
 MESH	D007531	Isoflurophate	CHEBI	CHEBI:17941	diisopropyl fluorophosphate
 MESH	D007532	Isoleucine	CHEBI	CHEBI:17191	L-isoleucine
 MESH	D007534	Isomaltose	CHEBI	CHEBI:28189	isomaltose
+MESH	D007536	Isomerism	HP	HP:0031853	Isomerism
 MESH	D007538	Isoniazid	CHEBI	CHEBI:6030	isoniazide
 MESH	D007541	Isopentenyladenosine	CHEBI	CHEBI:62881	N(6)-(Delta(2)-isopentenyl)adenosine
 MESH	D007544	Isopropyl Thiogalactoside	CHEBI	CHEBI:61448	isopropyl beta-D-thiogalactopyranoside
@@ -1977,6 +2263,10 @@ MESH	D007546	Isoquinolines	CHEBI	CHEBI:24922	isoquinolines
 MESH	D007547	Isosorbide	CHEBI	CHEBI:6060	Isosorbide
 MESH	D007555	Isoxazoles	CHEBI	CHEBI:55373	isoxazoles
 MESH	D007559	Ivermectin	CHEBI	CHEBI:6078	ivermectin
+MESH	D007571	Jaw Diseases	EFO	0009468	jaw disease
+MESH	D007572	Jaw Fractures	EFO	0009612	jaw fracture
+MESH	D007588	Job Satisfaction	EFO	0009723	job satisfaction measurement
+MESH	D007589	Job Syndrome	DOID	DOID:0080545	hyper IgE syndrome
 MESH	D007605	Juvenile Hormones	CHEBI	CHEBI:24851	insect growth regulator
 MESH	D007608	Kainic Acid	CHEBI	CHEBI:31746	kainic acid
 MESH	D007609	Kallidin	CHEBI	CHEBI:6102	Kallidin
@@ -1984,6 +2274,8 @@ MESH	D007610	Kallikreins	FPLX	KLK	KLK
 MESH	D007612	Kanamycin	CHEBI	CHEBI:6104	kanamycin
 MESH	D007631	Chlordecone	CHEBI	CHEBI:16548	chlordecone
 MESH	D007632	Keratan Sulfate	CHEBI	CHEBI:60924	keratan sulfate
+MESH	D007636	Keratoacanthoma	HP	HP:0031525	Keratoacanthoma
+MESH	D007645	Keratoderma, Palmoplantar	DOID	DOID:3390	palmoplantar keratosis
 MESH	D007649	Ketamine	CHEBI	CHEBI:6121	ketamine
 MESH	D007650	Ketanserin	CHEBI	CHEBI:6123	ketanserin
 MESH	D007654	Ketoconazole	CHEBI	CHEBI:47519	ketoconazole
@@ -1992,16 +2284,23 @@ MESH	D007657	Ketone Bodies	CHEBI	CHEBI:73693	ketone body
 MESH	D007659	Ketones	CHEBI	CHEBI:17087	ketone
 MESH	D007660	Ketoprofen	CHEBI	CHEBI:6128	ketoprofen
 MESH	D007661	Ketoses	CHEBI	CHEBI:24978	ketose
+MESH	D007662	Ketosis	HP	HP:0001993	Ketoacidosis
 MESH	D007664	Ketosteroids	CHEBI	CHEBI:35789	oxo steroid
 MESH	D007665	Ketotifen	CHEBI	CHEBI:92511	ketotifen
 MESH	D007666	Khellin	CHEBI	CHEBI:6133	khellin
+MESH	D007680	Kidney Neoplasms	DOID	DOID:4451	renal carcinoma
+MESH	D007690	Polycystic Kidney Diseases	EFO	0008620	Polycystic Kidney Disease
 MESH	D007692	Diatomaceous Earth	CHEBI	CHEBI:82661	diatomaceous earth
 MESH	D007698	Kinesis	GO	GO:0042465	kinesis
 MESH	D007701	Kinetin	CHEBI	CHEBI:27407	kinetin
 MESH	D007703	Peptidyl-Dipeptidase A	HGNC	2707	ACE
+MESH	D007713	Klinefelter Syndrome	DOID	DOID:0090070	hypogonadotropic hypogonadism
+MESH	D007718	Knee Injuries	EFO	0009507	knee injury
 MESH	D007735	Kynuramine	CHEBI	CHEBI:73472	kynuramine
 MESH	D007737	Kynurenine	CHEBI	CHEBI:28683	kynurenine
 MESH	D007741	Labetalol	CHEBI	CHEBI:6343	labetalol
+MESH	D007762	Labyrinthitis	DOID	DOID:3930	otitis interna
+MESH	D007766	Lacrimal Apparatus Diseases	DOID	DOID:1400	lacrimal apparatus disease
 MESH	D007769	Lactams	CHEBI	CHEBI:24995	lactam
 MESH	D007773	Lactates	CHEBI	CHEBI:24997	lactate salt
 MESH	D007774	Lactation	GO	GO:0007595	lactation
@@ -2009,44 +2308,60 @@ MESH	D007781	Lactoferrin	HGNC	6720	LTF
 MESH	D007783	Lactones	CHEBI	CHEBI:25000	lactone
 MESH	D007784	Lactoperoxidase	HGNC	6678	LPO
 MESH	D007785	Lactose	CHEBI	CHEBI:36219	alpha-lactose
+MESH	D007787	Lactose Intolerance	DOID	DOID:10604	lactose intolerance
 MESH	D007790	Lactosylceramides	CHEBI	CHEBI:17950	beta-D-galactosyl-(1->4)-beta-D-glucosyl-(1<->1)-N-acylsphingosine
 MESH	D007791	Lactoylglutathione Lyase	HGNC	4323	GLO1
 MESH	D007792	Lactulose	CHEBI	CHEBI:6359	lactulose
+MESH	D007805	Language Development Disorders	DOID	DOID:0060244	specific language impairment
 MESH	D007810	Lanosterol	CHEBI	CHEBI:16521	lanosterol
 MESH	D007811	Lanthanum	CHEBI	CHEBI:33336	lanthanum atom
+MESH	D007822	Laryngeal Neoplasms	HP	HP:0012118	Laryngeal carcinoma
+MESH	D007826	Laryngismus	HP	HP:0025425	Laryngospasm
+MESH	D007839	Functional Laterality	EFO	0009902	handedness
 MESH	D007851	Dodecanol	CHEBI	CHEBI:28878	dodecan-1-ol
 MESH	D007852	Lawrencium	CHEBI	CHEBI:33397	lawrencium atom
 MESH	D007854	Lead	CHEBI	CHEBI:27889	lead(0)
 MESH	D007858	Learning	GO	GO:0007612	learning
+MESH	D007865	Leeches	DOID	DOID:11079	leech infestation
+MESH	D007869	Leg Injuries	EFO	0009508	leg injury
 MESH	D007874	Leghemoglobin	CHEBI	CHEBI:35144	leghemoglobin
 MESH	D007930	Leucine	CHEBI	CHEBI:15603	L-leucine
 MESH	D007931	Leucyl Aminopeptidase	HGNC	18449	LAP3
+MESH	D007937	Leukapheresis	EFO	0009126	leukapheresis
+MESH	D007938	Leukemia	DOID	DOID:1036	chronic leukemia
+MESH	D007952	Leukemia, Plasma Cell	DOID	DOID:0070212	hereditary lymphedema I
 MESH	D007975	Leukotriene B4	CHEBI	CHEBI:15647	leukotriene B4
 MESH	D007977	Levallorphan	CHEBI	CHEBI:6431	Levallorphan
 MESH	D007978	Levamisole	CHEBI	CHEBI:6432	levamisole
+MESH	D007979	Levocardia	HP	HP:0031592	Situs inversus with levocardia
 MESH	D007980	Levodopa	CHEBI	CHEBI:15765	L-dopa
 MESH	D007981	Levorphanol	CHEBI	CHEBI:6444	Levorphanol
 MESH	D007986	Luteinizing Hormone	CHEBI	CHEBI:81568	Luteinizing hormone
 MESH	D008012	Lidocaine	CHEBI	CHEBI:6456	lidocaine
+MESH	D008018	Life Cycle Stages	EFO	0000399	developmental stage
 MESH	D008024	Ligands	CHEBI	CHEBI:52214	ligand
 MESH	D008034	Lincomycin	CHEBI	CHEBI:6472	lincomycin
 MESH	D008042	Linolenic Acids	CHEBI	CHEBI:25048	linolenic acid
 MESH	D008044	Linuron	CHEBI	CHEBI:6482	linuron
 MESH	D008049	Lipase	HGNC	1863	CES1
 MESH	D008054	Lipid Peroxides	CHEBI	CHEBI:61051	lipid hydroperoxide
+MESH	D008068	Lipomatosis	DOID	DOID:14116	multiple symmetric lipomatosis
+MESH	D008069	Lipomatosis, Multiple Symmetrical	DOID	DOID:14116	multiple symmetric lipomatosis
 MESH	D008070	Lipopolysaccharides	CHEBI	CHEBI:16412	lipopolysaccharide
+MESH	D008072	Hyperlipoproteinemia Type I	HP	HP:0012238	Increased circulating chylomicron concentration
 MESH	D008074	Lipoproteins	CHEBI	CHEBI:6495	lipoprotein
 MESH	D008076	Cholesterol, HDL	CHEBI	CHEBI:47775	high-density lipoprotein cholesterol
-MESH	D008077	Lipoproteins, LDL	CHEBI	CHEBI:39026	low-density lipoprotein
 MESH	D008078	Cholesterol, LDL	CHEBI	CHEBI:47774	low-density lipoprotein cholesterol
 MESH	D008079	Lipoproteins, VLDL	CHEBI	CHEBI:39027	very-low-density lipoprotein
 MESH	D008083	beta-Lipotropin	CHEBI	CHEBI:80247	beta-Lipotropin
 MESH	D008090	Lisuride	CHEBI	CHEBI:51164	lisuride
 MESH	D008094	Lithium	CHEBI	CHEBI:30145	lithium atom
 MESH	D008095	Lithocholic Acid	CHEBI	CHEBI:81253	isolithocholic acid
+MESH	D008105	Liver Cirrhosis, Biliary	EFO	0004267	biliary liver cirrhosis
+MESH	D008113	Liver Neoplasms	DOID	DOID:916	liver benign neoplasm
 MESH	D008115	Liver Regeneration	GO	GO:0097421	liver regeneration
 MESH	D008120	Lobeline	CHEBI	CHEBI:48723	(-)-lobeline
-MESH	D008124	Locomotion	GO	GO:0040011	locomotion
+MESH	D008124	Locomotion	GO	GO:0003774	motor activity
 MESH	D008127	Lofepramine	CHEBI	CHEBI:47782	lofepramine
 MESH	D008130	Lomustine	CHEBI	CHEBI:6520	lomustine
 MESH	D008139	Loperamide	CHEBI	CHEBI:6532	loperamide
@@ -2054,9 +2369,14 @@ MESH	D008148	Lovastatin	CHEBI	CHEBI:40303	lovastatin
 MESH	D008152	Loxapine	CHEBI	CHEBI:50841	loxapine
 MESH	D008154	Lucanthone	CHEBI	CHEBI:51052	lucanthone
 MESH	D008155	Lucensomycin	CHEBI	CHEBI:135874	lucimycin
+MESH	D008178	Lupus Erythematosus, Cutaneous	DOID	DOID:0050169	cutaneous lupus erythematosus
+MESH	D008180	Lupus Erythematosus, Systemic	DOID	DOID:8857	lupus erythematosus
 MESH	D008187	Lutetium	CHEBI	CHEBI:33382	lutetium atom
 MESH	D008194	Lymecycline	CHEBI	CHEBI:59040	lymecycline
+MESH	D008200	Lymphangiectasis	HP	HP:0031842	Lymphangiectasis
 MESH	D008213	Lymphocyte Activation	GO	GO:0046649	lymphocyte activation
+MESH	D008228	Lymphoma, Non-Hodgkin	DOID	DOID:8538	reticulosarcoma
+MESH	D008232	Lymphoproliferative Disorders	EFO	1000228	EBV-Positive T-Cell Lymphoproliferative Disorder of Childhood
 MESH	D008233	Lymphotoxin-alpha	HGNC	6709	LTA
 MESH	D008234	Lynestrenol	CHEBI	CHEBI:31790	Lynestrenol
 MESH	D008236	Lypressin	CHEBI	CHEBI:6603	Lypressin
@@ -2069,12 +2389,15 @@ MESH	D008246	Lysophospholipids	CHEBI	CHEBI:16961	monoacylglycerol phosphate
 MESH	D008247	Lysosomes	GO	GO:0005764	lysosome
 MESH	D008249	Protein-Lysine 6-Oxidase	HGNC	6664	LOX
 MESH	D008250	Lysine-tRNA Ligase	HGNC	6215	KARS1
+MESH	D008258	Waldenstrom Macroglobulinemia	DOID	DOID:9080	macroglobulinemia
 MESH	D008262	Macrophage Activation	GO	GO:0042116	macrophage activation
+MESH	D008268	Macular Degeneration	DOID	DOID:4448	macular degeneration
 MESH	D008272	Mafenide	CHEBI	CHEBI:6633	Mafenide
 MESH	D008274	Magnesium	CHEBI	CHEBI:25107	magnesium atom
 MESH	D008276	Magnesium Hydroxide	CHEBI	CHEBI:6637	magnesium dihydroxide
 MESH	D008277	Magnesium Oxide	CHEBI	CHEBI:31794	magnesium oxide
 MESH	D008278	Magnesium Sulfate	CHEBI	CHEBI:32599	magnesium sulfate
+MESH	D008286	Malabsorption Syndromes	HP	HP:0002024	Malabsorption
 MESH	D008291	Malate Dehydrogenase	HGNC	8923	PHGDH
 MESH	D008292	Malate Synthase	HGNC	18355	CLYBL
 MESH	D008293	Malates	CHEBI	CHEBI:25115	malate
@@ -2082,6 +2405,7 @@ MESH	D008294	Malathion	CHEBI	CHEBI:6651	malathion
 MESH	D008298	Maleates	CHEBI	CHEBI:132951	maleate
 MESH	D008300	Maleic Hydrazide	CHEBI	CHEBI:81771	Maleic hydrazide
 MESH	D008301	Maleimides	CHEBI	CHEBI:55417	maleimides
+MESH	D008309	Mallory-Weiss Syndrome	HP	HP:0032062	Mallory-Weiss tear
 MESH	D008314	Malonates	CHEBI	CHEBI:38083	malonate ester
 MESH	D008315	Malondialdehyde	CHEBI	CHEBI:566274	malonaldehyde
 MESH	D008316	Malonyl Coenzyme A	CHEBI	CHEBI:15531	malonyl-CoA
@@ -2095,7 +2419,9 @@ MESH	D008359	Mannose-6-Phosphate Isomerase	HGNC	7216	MPI
 MESH	D008362	Mannosides	CHEBI	CHEBI:25169	mannoside
 MESH	D008376	Maprotiline	CHEBI	CHEBI:6690	Maprotiline
 MESH	D008409	Mastication	GO	GO:0071626	mastication
+MESH	D008415	Mastocytosis	EFO	0006453	MCAS
 MESH	D008425	Maternal Behavior	GO	GO:0042711	maternal behavior
+MESH	D008451	Maximal Voluntary Ventilation	EFO	0008431	maximal voluntary ventilation
 MESH	D008453	Maytansine	CHEBI	CHEBI:6701	maytansine
 MESH	D008454	Mazindol	CHEBI	CHEBI:6702	Mazindol
 MESH	D008456	2-Methyl-4-chlorophenoxyacetic Acid	CHEBI	CHEBI:50099	(4-chloro-2-methylphenoxy)acetic acid
@@ -2105,14 +2431,17 @@ MESH	D008466	Mechlorethamine	CHEBI	CHEBI:28925	mechlorethamine
 MESH	D008468	Meclizine	CHEBI	CHEBI:6709	Meclizine
 MESH	D008469	Meclofenamic Acid	CHEBI	CHEBI:6710	meclofenamic acid
 MESH	D008472	Medazepam	CHEBI	CHEBI:31807	Medazepam
+MESH	D008478	Mediastinal Emphysema	HP	HP:0025421	Pneumomediastinum
 MESH	D008520	Medigoxin	CHEBI	CHEBI:135885	metildigoxin
 MESH	D008524	Medrogestone	CHEBI	CHEBI:135446	medrogestone
 MESH	D008525	Medroxyprogesterone	CHEBI	CHEBI:6715	medroxyprogesterone
+MESH	D008527	Medulloblastoma	DOID	DOID:0060104	cerebellar medulloblastoma
 MESH	D008528	Mefenamic Acid	CHEBI	CHEBI:6717	mefenamic acid
 MESH	D008529	Mefruside	CHEBI	CHEBI:31809	Mefruside
 MESH	D008535	Megestrol	CHEBI	CHEBI:6722	megestrol
 MESH	D008536	Meglumine	CHEBI	CHEBI:59732	N-methylglucamine
 MESH	D008543	Melanins	CHEBI	CHEBI:89634	Melanin
+MESH	D008548	Melanosis	HP	HP:0025272	Melasma
 MESH	D008549	Melarsoprol	CHEBI	CHEBI:6729	Melarsoprol
 MESH	D008550	Melatonin	CHEBI	CHEBI:16796	melatonin
 MESH	D008552	Melengestrol Acetate	CHEBI	CHEBI:34831	Melengestrol acetate
@@ -2122,8 +2451,10 @@ MESH	D008558	Melphalan	CHEBI	CHEBI:28876	melphalan
 MESH	D008559	Memantine	CHEBI	CHEBI:64312	memantine
 MESH	D008561	Membrane Fusion	GO	GO:0061025	membrane fusion
 MESH	D008566	Membranes	GO	GO:0016020	membrane
+MESH	D008569	Memory Disorders	EFO	0001072	memory impairment
 MESH	D008572	Menarche	GO	GO:0042696	menarche
 MESH	D008573	Mendelevium	CHEBI	CHEBI:33395	mendelevium atom
+MESH	D008580	Meningism	HP	HP:0031179	Nuchal rigidity
 MESH	D008593	Menopause	GO	GO:0042697	menopause
 MESH	D008597	Menstrual Cycle	GO	GO:0044850	menstrual cycle
 MESH	D008598	Menstruation	GO	GO:0042703	menstruation
@@ -2143,6 +2474,7 @@ MESH	D008628	Mercury	CHEBI	CHEBI:16170	mercury(0)
 MESH	D008635	Mescaline	CHEBI	CHEBI:28346	mescaline
 MESH	D008652	Mesoporphyrins	CHEBI	CHEBI:59559	mesoporphyrins
 MESH	D008653	Mesoridazine	CHEBI	CHEBI:6780	mesoridazine
+MESH	D008654	Mesothelioma	HP	HP:0100001	Malignant mesothelioma
 MESH	D008655	Mesterolone	CHEBI	CHEBI:135293	mesterolone
 MESH	D008656	Mestranol	CHEBI	CHEBI:6784	mestranol
 MESH	D008660	Metabolism	GO	GO:0008152	metabolic process
@@ -2235,11 +2567,13 @@ MESH	D008802	Mezlocillin	CHEBI	CHEBI:6919	mezlocillin
 MESH	D008803	Mianserin	CHEBI	CHEBI:51137	mianserin
 MESH	D008825	Miconazole	CHEBI	CHEBI:6923	miconazole
 MESH	D008830	Microbodies	GO	GO:0042579	microbody
+MESH	D008831	Microcephaly	HP	HP:0000252	Microcephaly
 MESH	D008841	Actin Cytoskeleton	GO	GO:0015629	actin cytoskeleton
 MESH	D008870	Microtubules	GO	GO:0005874	microtubule
 MESH	D008871	Microvilli	GO	GO:0005902	microvillus
 MESH	D008874	Midazolam	CHEBI	CHEBI:6931	midazolam
 MESH	D008879	Midodrine	CHEBI	CHEBI:6933	midodrine
+MESH	D008883	Miliaria	DOID	DOID:11153	miliaria rubra
 MESH	D008901	Mineralocorticoids	CHEBI	CHEBI:25354	mineralocorticoid
 MESH	D008903	Minerals	CHEBI	CHEBI:46662	mineral
 MESH	D008911	Minocycline	CHEBI	CHEBI:50694	minocycline
@@ -2267,27 +2601,43 @@ MESH	D009005	Monosaccharides	CHEBI	CHEBI:35381	monosaccharide
 MESH	D009012	Mopidamol	CHEBI	CHEBI:135682	mopidamol
 MESH	D009020	Morphine	CHEBI	CHEBI:17303	morphine
 MESH	D009025	Morpholines	CHEBI	CHEBI:38785	morpholines
+MESH	D009026	Mortality	EFO	0004352	mortality
 MESH	D009037	Motilin	CHEBI	CHEBI:80269	Motilin
+MESH	D009041	Motion Sickness	EFO	0006928	motion sickness
 MESH	D009043	Motor Activity	GO	GO:0003774	motor activity
+MESH	D009062	Mouth Neoplasms	DOID	DOID:8618	oral cavity cancer
 MESH	D009070	Moxalactam	CHEBI	CHEBI:599928	moxalactam
 MESH	D009074	Melanocyte-Stimulating Hormones	CHEBI	CHEBI:16768	mycothiol
+MESH	D009081	Mucolipidoses	DOID	DOID:0080488	mucolipidosis
+MESH	D009101	Multiple Myeloma	DOID	DOID:0070004	myeloid neoplasm
+MESH	D009110	Munchausen Syndrome	DOID	DOID:1766	factitious disorder
 MESH	D009112	Muramic Acids	CHEBI	CHEBI:25432	muramic acids
 MESH	D009113	Muramidase	HGNC	6740	LYZ
 MESH	D009116	Muscarine	CHEBI	CHEBI:7034	Muscarine
 MESH	D009118	Muscimol	CHEBI	CHEBI:7035	muscimol
 MESH	D009119	Muscle Contraction	GO	GO:0006936	muscle contraction
-MESH	D009133	Muscular Atrophy	GO	GO:0014889	muscle atrophy
+MESH	D009120	Muscle Cramp	EFO	0009846	muscle cramp
+MESH	D009123	Muscle Hypotonia	HP	HP:0001290	Generalized hypotonia
+MESH	D009130	Muscle, Smooth	EFO	0000889	smooth muscle
+MESH	D009134	Muscular Atrophy, Spinal	HP	HP:0009067	Progressive spinal muscular atrophy
+MESH	D009135	Muscular Diseases	DOID	DOID:0080000	muscular disease
 MESH	D009151	Mustard Gas	CHEBI	CHEBI:25434	bis(2-chloroethyl) sulfide
 MESH	D009156	Muzolimine	CHEBI	CHEBI:135124	muzolimine
+MESH	D009164	Mycobacterium Infections	EFO	0009429	Mycobacterium infection
+MESH	D009165	Mycobacterium Infections, Nontuberculous	HP	HP:0006532	Recurrent pneumonia
 MESH	D009171	Mycolic Acids	CHEBI	CHEBI:25438	mycolic acid
 MESH	D009173	Mycophenolic Acid	CHEBI	CHEBI:168396	mycophenolic acid
+MESH	D009182	Mycosis Fungoides	EFO	0004169	methyl filtration
 MESH	D009183	Mycotoxins	CHEBI	CHEBI:25442	mycotoxin
 MESH	D009184	Mydriatics	CHEBI	CHEBI:50513	mydriatic agent
 MESH	D009186	Myelin Sheath	GO	GO:0043209	myelin sheath
 MESH	D009195	Peroxidase	CHEBI	CHEBI:8027	Peroxidase
+MESH	D009196	Myeloproliferative Disorders	DOID	DOID:2226	myeloproliferative neoplasm
+MESH	D009202	Cardiomyopathies	DOID	DOID:3978	extrinsic cardiomyopathy
 MESH	D009210	Myofibrils	GO	GO:0030016	myofibril
 MESH	D009211	Myoglobin	HGNC	6915	MB
 MESH	D009219	Myosin-Light-Chain Kinase	HGNC	7590	MYLK
+MESH	D009220	Myositis	EFO	0000557	juvenile dermatomyositis
 MESH	D009238	N-Acetylmuramoyl-L-alanine Amidase	HGNC	30013	PGLYRP2
 MESH	D009240	N-Formylmethionine Leucyl-Phenylalanine	CHEBI	CHEBI:53490	N-formyl-L-methionyl-L-leucyl-L-phenylalanine
 MESH	D009241	Ipratropium	CHEBI	CHEBI:5956	ipratropium
@@ -2312,23 +2662,37 @@ MESH	D009281	Naphthalenes	CHEBI	CHEBI:25477	naphthalenes
 MESH	D009284	Naphthols	CHEBI	CHEBI:25392	naphthols
 MESH	D009285	Naphthoquinones	CHEBI	CHEBI:25481	naphthoquinone
 MESH	D009288	Naproxen	CHEBI	CHEBI:7476	naproxen
+MESH	D009290	Narcolepsy	EFO	0005855	narcolepsy without cataplexy
 MESH	D009292	Narcotic Antagonists	CHEBI	CHEBI:60605	opioid receptor antagonist
 MESH	D009294	Narcotics	CHEBI	CHEBI:35482	opioid analgesic
+MESH	D009303	Nasopharyngeal Neoplasms	EFO	1000058	nasopharyngeal squamous cell carcinoma
 MESH	D009327	4-Chloro-7-nitrobenzofurazan	CHEBI	CHEBI:78878	4-chloro-7-nitrobenzofurazan
 MESH	D009336	Necrosis	GO	GO:0070265	necrotic cell death
 MESH	D009340	Nefopam	CHEBI	CHEBI:88316	nefopam
+MESH	D009341	Negativism	HP	HP:0410291	Negativism
 MESH	D009354	Neodymium	CHEBI	CHEBI:33372	neodymium atom
 MESH	D009355	Neomycin	CHEBI	CHEBI:7507	neomycin
 MESH	D009356	Neon	CHEBI	CHEBI:33310	neon atom
+MESH	D009373	Neoplasms, Germ Cell and Embryonal	DOID	DOID:688	embryonal cancer
+MESH	D009375	Neoplasms, Glandular and Epithelial	HP	HP:0031492	Epithelial neoplasm
 MESH	D009388	Neostigmine	CHEBI	CHEBI:7514	neostigmine
+MESH	D009404	Nephrotic Syndrome	DOID	DOID:0080390	nephrotic syndrome type 1
 MESH	D009405	Neptunium	CHEBI	CHEBI:33387	neptunium atom
 MESH	D009428	Netilmicin	CHEBI	CHEBI:7528	netilmycin
+MESH	D009436	Neural Tube Defects	DOID	DOID:0080074	neural tube defect
+MESH	D009437	Neuralgia	EFO	0005762	neuropathic pain
 MESH	D009438	Neuraminic Acids	CHEBI	CHEBI:25508	neuraminic acids
+MESH	D009443	Neuritis	HP	HP:0031002	Neuritis
+MESH	D009456	Neurofibromatosis 1	DOID	DOID:0111253	neurofibromatosis 1
+MESH	D009463	Neuroma	EFO	0009619	neuroma
 MESH	D009469	Neuromuscular Junction	GO	GO:0031594	neuromuscular junction
+MESH	D009477	Hereditary Sensory and Autonomic Neuropathies	HP	HP:0000763	Sensory neuropathy
 MESH	D009478	Neuropeptide Y	CHEBI	CHEBI:80201	Neuropeptide Y
 MESH	D009496	Neurotensin	CHEBI	CHEBI:7542	neurotensin
 MESH	D009498	Neurotoxins	CHEBI	CHEBI:50910	neurotoxin
 MESH	D009499	Neutral Red	CHEBI	CHEBI:86370	neutral red
+MESH	D009503	Neutropenia	HP	HP:0001875	Neutropenia
+MESH	D009504	Neutrophils	EFO	0009252	Segmented Neutrophils to Neutrophils Ratio Measurement
 MESH	D009525	Niacin	CHEBI	CHEBI:15940	nicotinic acid
 MESH	D009528	Nicarbazin	CHEBI	CHEBI:81725	Nicarbazin
 MESH	D009529	Nicardipine	CHEBI	CHEBI:7550	Nicardipine
@@ -2374,6 +2738,7 @@ MESH	D009609	Nitrous Oxide	CHEBI	CHEBI:17045	dinitrogen oxide
 MESH	D009610	Nitrovin	CHEBI	CHEBI:82516	Nitrovin
 MESH	D009614	Nobelium	CHEBI	CHEBI:33396	nobelium
 MESH	D009627	Nomifensine	CHEBI	CHEBI:116225	nomifensine
+MESH	D009634	Noonan Syndrome	DOID	DOID:0060578	Noonan syndrome 1
 MESH	D009637	Masoprocol	CHEBI	CHEBI:73468	masoprocol
 MESH	D009638	Norepinephrine	CHEBI	CHEBI:18357	(R)-noradrenaline
 MESH	D009639	Norethandrolone	CHEBI	CHEBI:135282	norethandrolone
@@ -2399,17 +2764,26 @@ MESH	D009712	Nucleotides, Cyclic	CHEBI	CHEBI:23447	cyclic nucleotide
 MESH	D009761	Nystatin	CHEBI	CHEBI:7660	nystatin
 MESH	D009762	o-Aminoazotoluene	CHEBI	CHEBI:82285	ortho-Aminoazotoluene
 MESH	D009764	o-Phthalaldehyde	CHEBI	CHEBI:70851	phthalaldehyde
+MESH	D009798	Ocular Hypertension	HP	HP:0007906	Ocular hypertension
 MESH	D009805	Odontogenesis	GO	GO:0042476	odontogenesis
 MESH	D009822	Oils, Volatile	CHEBI	CHEBI:83630	essential oil
 MESH	D009827	Oleandomycin	CHEBI	CHEBI:16869	oleandomycin
 MESH	D009828	Oleanolic Acid	CHEBI	CHEBI:37659	oleanolic acid
+MESH	D009837	Oligodendroglioma	DOID	DOID:7912	mixed oligodendroglioma-astrocytoma
 MESH	D009840	Oligomycins	CHEBI	CHEBI:25675	oligomycin
 MESH	D009841	Oligonucleotides	CHEBI	CHEBI:7754	oligonucleotide
 MESH	D009842	Oligopeptides	CHEBI	CHEBI:25676	oligopeptide
 MESH	D009844	Oligosaccharides	CHEBI	CHEBI:50699	oligosaccharide
+MESH	D009845	Oligospermia	DOID	DOID:0070311	oligoasthenoteratozoospermia
 MESH	D009848	Olivomycins	CHEBI	CHEBI:52515	olivomycin
 MESH	D009853	Omeprazole	CHEBI	CHEBI:7772	omeprazole
 MESH	D009866	Oogenesis	GO	GO:0048477	oogenesis
+MESH	D009869	Oophoritis	HP	HP:0031259	Oophoritis
+MESH	D009878	Ophthalmia Neonatorum	DOID	DOID:9699	ophthalmia neonatorum
+MESH	D009886	Ophthalmoplegia	HP	HP:0007824	Total ophthalmoplegia
+MESH	D009894	Opportunistic Infections	HP	HP:0031690	Opportunistic infection
+MESH	D009902	Optic Neuritis	DOID	DOID:14155	acute retrobulbar neuritis
+MESH	D009917	Orbital Fractures	EFO	0009611	orbital fracture
 MESH	D009921	Metaproterenol	CHEBI	CHEBI:82719	orciprenaline
 MESH	D009941	Organomercury Compounds	CHEBI	CHEBI:25706	organomercury compound
 MESH	D009942	Organometallic Compounds	CHEBI	CHEBI:25707	organometallic compound
@@ -2423,10 +2797,19 @@ MESH	D009952	Ornithine	CHEBI	CHEBI:18257	ornithine
 MESH	D009953	Ornithine-Oxo-Acid Transaminase	HGNC	8091	OAT
 MESH	D009954	Ornithine Carbamoyltransferase	HGNC	8512	OTC
 MESH	D009955	Ornithine Decarboxylase	HGNC	8109	ODC1
+MESH	D009959	Oropharyngeal Neoplasms	DOID	DOID:8557	oropharynx cancer
 MESH	D009966	Orphenadrine	CHEBI	CHEBI:7789	orphenadrine
 MESH	D009993	Osmium Tetroxide	CHEBI	CHEBI:88215	osmium tetroxide
+MESH	D010001	Osteitis Deformans	DOID	DOID:3443	mammary Paget's disease
+MESH	D010009	Osteochondrodysplasias	DOID	DOID:0080362	spondyloepiphyseal dysplasia tarda
 MESH	D010012	Osteogenesis	GO	GO:0001503	ossification
+MESH	D010018	Osteomalacia	HP	HP:0002749	Osteomalacia
+MESH	D010020	Osteonecrosis	DOID	DOID:0080008	ischemic bone disease
+MESH	D010032	Otitis Externa	DOID	DOID:9463	otitis externa
+MESH	D010034	Otitis Media with Effusion	HP	HP:0031353	Otitis media with effusion
 MESH	D010042	Ouabain	CHEBI	CHEBI:472805	ouabain
+MESH	D010048	Ovarian Cysts	DOID	DOID:3269	ovarian cystadenoma
+MESH	D010051	Ovarian Neoplasms	DOID	DOID:4001	ovarian carcinoma
 MESH	D010058	Oviposition	GO	GO:0018991	oviposition
 MESH	D010060	Ovulation	GO	GO:0030728	ovulation
 MESH	D010064	Embryo Implantation	GO	GO:0007566	embryo implantation
@@ -2460,10 +2843,15 @@ MESH	D010130	p-Aminohippuric Acid	CHEBI	CHEBI:104011	p-aminohippuric acid
 MESH	D010131	Aminosalicylic Acid	CHEBI	CHEBI:27565	4-aminosalicylic acid
 MESH	D010132	p-Azobenzenearsonate	CHEBI	CHEBI:53554	4,4'-azodibenzenearsonic acid
 MESH	D010135	p-Fluorophenylalanine	CHEBI	CHEBI:84060	4-fluorophenylalanine
+MESH	D010138	Pacemaker, Artificial	EFO	0009719	artificial cardiac pacemaker
+MESH	D010144	Paget's Disease, Mammary	DOID	DOID:3443	mammary Paget's disease
+MESH	D010157	Palatal Neoplasms	EFO	1000051	reproductive system neoplasm
 MESH	D010165	Palladium	CHEBI	CHEBI:33363	palladium
 MESH	D010170	Palmitoyl-CoA Hydrolase	HGNC	932	BAAT
 MESH	D010171	Palmitoyl Coenzyme A	CHEBI	CHEBI:15525	palmitoyl-CoA
 MESH	D010172	Palmitoylcarnitine	CHEBI	CHEBI:17490	O-palmitoyl-L-carnitine
+MESH	D010178	Pancoast Syndrome	DOID	DOID:4876	trachea carcinoma
+MESH	D010182	Pancreatic Diseases	DOID	DOID:26	pancreas disease
 MESH	D010191	Pancreatic Polypeptide	CHEBI	CHEBI:80329	Pancreatic polypeptide
 MESH	D010196	Pancreatic Elastase	FPLX	ELA	ELA
 MESH	D010197	Pancuronium	CHEBI	CHEBI:7907	pancuronium
@@ -2473,17 +2861,24 @@ MESH	D010208	Papaverine	CHEBI	CHEBI:28241	papaverine
 MESH	D010226	Parabens	CHEBI	CHEBI:85122	paraben
 MESH	D010242	Paraldehyde	CHEBI	CHEBI:27909	paraldehyde
 MESH	D010248	Paramethasone	CHEBI	CHEBI:7922	Paramethasone
+MESH	D010255	Paranasal Sinus Neoplasms	EFO	1000454	Paranasal Sinus Adenoid Cystic Carcinoma
 MESH	D010261	Paraoxon	CHEBI	CHEBI:27827	paraoxon
 MESH	D010269	Paraquat	CHEBI	CHEBI:34905	paraquat
+MESH	D010272	Parasitic Diseases	DOID	DOID:1398	parasitic infectious disease
 MESH	D010276	Parasympatholytics	CHEBI	CHEBI:50370	parasympatholytic
 MESH	D010278	Parathion	CHEBI	CHEBI:27928	parathion
 MESH	D010281	Parathyroid Hormone	HGNC	9606	PTH
+MESH	D010282	Parathyroid Neoplasms	DOID	DOID:1540	parathyroid carcinoma
 MESH	D010293	Pargyline	CHEBI	CHEBI:7930	Pargyline
 MESH	D010303	Paromomycin	CHEBI	CHEBI:7934	paromomycin
+MESH	D010323	Passive Cutaneous Anaphylaxis	DOID	DOID:0050639	primary cutaneous amyloidosis
 MESH	D010332	Paternal Behavior	GO	GO:0042712	paternal behavior
 MESH	D010365	Patulin	CHEBI	CHEBI:74926	patulin
 MESH	D010368	Pectins	CHEBI	CHEBI:17309	pectin
+MESH	D010383	Pellagra	EFO	0008570	Vitamin B3 deficiency
 MESH	D010389	Pemoline	CHEBI	CHEBI:7953	pemoline
+MESH	D010390	Pemphigoid, Benign Mucous Membrane	DOID	DOID:11656	cicatricial pemphigoid
+MESH	D010392	Pemphigus	DOID	DOID:0060851	pemphigus vulgaris
 MESH	D010394	Penbutolol	CHEBI	CHEBI:7954	penbutolol
 MESH	D010396	Penicillamine	CHEBI	CHEBI:7959	D-penicillamine
 MESH	D010397	Penicillanic Acid	CHEBI	CHEBI:37806	penicillanic acid
@@ -2493,7 +2888,9 @@ MESH	D010401	Penicillin G Benzathine	CHEBI	CHEBI:51352	benzylpenicillin benzathi
 MESH	D010402	Penicillin G Procaine	CHEBI	CHEBI:52154	benzylpenicillin procaine
 MESH	D010404	Penicillin V	CHEBI	CHEBI:27446	phenoxymethylpenicillin
 MESH	D010406	Penicillins	CHEBI	CHEBI:17334	penicillin
+MESH	D010409	Penile Diseases	DOID	DOID:1529	penile disease
 MESH	D010410	Penile Erection	GO	GO:0043084	penile erection
+MESH	D010411	Penile Induration	EFO	1000466	Penile Fibromatosis
 MESH	D010416	Pentachlorophenol	CHEBI	CHEBI:17642	pentachlorophenol
 MESH	D010417	Pentaerythritol Tetranitrate	CHEBI	CHEBI:25879	pentaerythritol tetranitrate
 MESH	D010418	Pentagastrin	CHEBI	CHEBI:31974	Pentagastrin
@@ -2515,14 +2912,20 @@ MESH	D010464	Perazine	CHEBI	CHEBI:59118	perazine
 MESH	D010476	Perfume	CHEBI	CHEBI:48318	fragrance
 MESH	D010479	Pergolide	CHEBI	CHEBI:63617	pergolide
 MESH	D010480	Perhexiline	CHEBI	CHEBI:35553	perhexiline
+MESH	D010482	Periapical Abscess	HP	HP:0030757	Tooth abscess
 MESH	D010504	Periodic Acid	CHEBI	CHEBI:29149	periodic acid
+MESH	D010523	Peripheral Nervous System Diseases	DOID	DOID:870	neuropathy
 MESH	D010528	Peristalsis	GO	GO:0030432	peristalsis
+MESH	D010534	Peritoneal Neoplasms	DOID	DOID:1725	peritoneum cancer
 MESH	D010546	Perphenazine	CHEBI	CHEBI:8028	perphenazine
+MESH	D010554	Personality Disorders	DOID	DOID:1510	personality disorder
 MESH	D010569	Perylene	CHEBI	CHEBI:29861	perylene
 MESH	D010574	Pesticide Synergists	CHEBI	CHEBI:25943	pesticide synergist
 MESH	D010575	Pesticides	CHEBI	CHEBI:25944	pesticide
+MESH	D010580	Peutz-Jeghers Syndrome	EFO	1000470	Peutz-Jeghers Polyp
 MESH	D010587	Phagocytosis	GO	GO:0006909	phagocytosis
 MESH	D010590	Phalloidine	CHEBI	CHEBI:8040	phalloidin
+MESH	D010612	Pharyngitis	HP	HP:0025439	Pharyngitis
 MESH	D010615	Phenacetin	CHEBI	CHEBI:8050	phenacetin
 MESH	D010616	Phenanthrenes	CHEBI	CHEBI:25961	phenanthrenes
 MESH	D010617	Phenanthridines	CHEBI	CHEBI:51245	phenanthridines
@@ -2560,8 +2963,10 @@ MESH	D010664	Phenylmethylsulfonyl Fluoride	CHEBI	CHEBI:8102	phenylmethanesulfony
 MESH	D010665	Phenylpropanolamine	CHEBI	CHEBI:8104	phenylpropanolamine
 MESH	D010670	Phenylthiourea	CHEBI	CHEBI:46261	N-phenylthiourea
 MESH	D010672	Phenytoin	CHEBI	CHEBI:8107	phenytoin
+MESH	D010673	Pheochromocytoma	DOID	DOID:0050892	adrenal gland pheochromocytoma
 MESH	D010674	Pheophytins	CHEBI	CHEBI:8108	pheophytin
 MESH	D010675	Pheromones	CHEBI	CHEBI:26013	pheromone
+MESH	D010688	Phimosis	HP	HP:0001741	Phimosis
 MESH	D010692	Phleomycins	CHEBI	CHEBI:75044	phleomycin
 MESH	D010693	Phloretin	CHEBI	CHEBI:17276	phloretin
 MESH	D010694	Lactase-Phlorizin Hydrolase	HGNC	6530	LCT
@@ -2607,6 +3012,7 @@ MESH	D010846	Picloram	CHEBI	CHEBI:34922	picloram
 MESH	D010852	Picrotoxin	CHEBI	CHEBI:134126	picrotoxin
 MESH	D010853	Picryl Chloride	CHEBI	CHEBI:53053	1-chloro-2,4,6-trinitrobenzene
 MESH	D010858	Pigmentation	GO	GO:0043473	pigmentation
+MESH	D010859	Pigmentation Disorders	EFO	1000395	Nevus of Ito
 MESH	D010862	Pilocarpine	CHEBI	CHEBI:8207	(+)-pilocarpine
 MESH	D010866	Natamycin	CHEBI	CHEBI:7488	Natamycin
 MESH	D010868	Pimozide	CHEBI	CHEBI:8212	pimozide
@@ -2624,9 +3030,12 @@ MESH	D010890	Pirenzepine	CHEBI	CHEBI:8247	pirenzepine
 MESH	D010892	Pirinitramide	CHEBI	CHEBI:135699	piritramide
 MESH	D010893	Piromidic Acid	CHEBI	CHEBI:32019	piromidic acid
 MESH	D010894	Piroxicam	CHEBI	CHEBI:8249	piroxicam
+MESH	D010900	Pituitary Diseases	DOID	DOID:53	pituitary gland disease
+MESH	D010911	Pituitary Neoplasms	DOID	DOID:1785	pituitary cancer
 MESH	D010917	Pivampicillin	CHEBI	CHEBI:8255	pivampicillin
 MESH	D010918	Pizotyline	CHEBI	CHEBI:50212	pizotifen
 MESH	D010928	Placental Lactogen	CHEBI	CHEBI:81588	Placental lactogen
+MESH	D010950	Plasma Cells	EFO	0009239	Mature Plasma Cell Count
 MESH	D010958	Plasminogen	HGNC	9071	PLG
 MESH	D010968	Plasticizers	CHEBI	CHEBI:79056	plasticiser
 MESH	D010971	Plastoquinone	CHEBI	CHEBI:17757	plastoquinone
@@ -2634,8 +3043,14 @@ MESH	D010972	Platelet Activating Factor	CHEBI	CHEBI:52450	2-O-acetyl-1-O-octadec
 MESH	D010974	Platelet Aggregation	GO	GO:0070527	platelet aggregation
 MESH	D010975	Platelet Aggregation Inhibitors	CHEBI	CHEBI:50427	platelet aggregation inhibitor
 MESH	D010984	Platinum	CHEBI	CHEBI:33400	platinum(0)
+MESH	D010996	Pleural Effusion	EFO	0009637	pleural effusion
+MESH	D010997	Pleural Neoplasms	DOID	DOID:5158	pleural cancer
 MESH	D011005	Plutonium	CHEBI	CHEBI:33388	plutonium atom
+MESH	D011014	Pneumonia	EFO	1001991	pneumonitis
+MESH	D011018	Pneumonia, Pneumococcal	DOID	DOID:0040084	Streptococcus pneumonia
+MESH	D011020	Pneumonia, Pneumocystis	HP	HP:0020102	Pneumocystis jirovecii pneumonia
 MESH	D011034	Podophyllotoxin	CHEBI	CHEBI:50305	podophyllotoxin
+MESH	D011041	Poisoning	EFO	0009574	intoxication
 MESH	D011042	Poisons	CHEBI	CHEBI:64909	poison
 MESH	D011059	Polonium	CHEBI	CHEBI:33313	polonium atom
 MESH	D011062	Polynucleotide Adenylyltransferase	HGNC	25532	MTPAP
@@ -2660,6 +3075,7 @@ MESH	D011108	Polymers	CHEBI	CHEBI:60027	polymer
 MESH	D011113	Polymyxins	CHEBI	CHEBI:59062	polymyxin
 MESH	D011119	Polynucleotides	CHEBI	CHEBI:15986	polynucleotide
 MESH	D011122	Polyphosphates	CHEBI	CHEBI:26197	polyphosphates
+MESH	D011125	Adenomatous Polyposis Coli	EFO	0009296	mutyh-associated polyposis
 MESH	D011126	Polypropylenes	CHEBI	CHEBI:53550	poly(propylene)
 MESH	D011132	Polyribosomes	GO	GO:0005844	polysome
 MESH	D011134	Polysaccharides	CHEBI	CHEBI:18154	polysaccharide
@@ -2668,6 +3084,7 @@ MESH	D011138	Polytetrafluoroethylene	CHEBI	CHEBI:53251	poly(tetrafluoroethylene)
 MESH	D011139	Polythiazide	CHEBI	CHEBI:8327	Polythiazide
 MESH	D011142	Polyvinyl Alcohol	CHEBI	CHEBI:17246	poly(vinyl alcohol) macromolecule
 MESH	D011143	Polyvinyl Chloride	CHEBI	CHEBI:53243	poly(vinyl chloride)
+MESH	D011151	Popliteal Cyst	HP	HP:0032072	Popliteal synovial cyst
 MESH	D011162	Porphobilinogen	CHEBI	CHEBI:17381	porphobilinogen
 MESH	D011163	Hydroxymethylbilane Synthase	HGNC	4982	HMBS
 MESH	D011165	Porphyrinogens	CHEBI	CHEBI:36321	porphyrinogens
@@ -2689,8 +3106,11 @@ MESH	D011235	Predatory Behavior	GO	GO:0002120	predatory behavior
 MESH	D011238	Prednimustine	CHEBI	CHEBI:82524	Prednimustine
 MESH	D011239	Prednisolone	CHEBI	CHEBI:8378	prednisolone
 MESH	D011241	Prednisone	CHEBI	CHEBI:8382	prednisone
+MESH	D011258	Pregnancy Tests	EFO	0009643	pregnancy test
 MESH	D011266	Pregnancy-Associated Plasma Protein-A	HGNC	8602	PAPPA
 MESH	D011268	Pregnancy-Specific beta 1-Glycoproteins	HGNC	9514	PSG1
+MESH	D011271	Pregnancy, Ectopic	HP	HP:0031456	Ectopic pregnancy
+MESH	D011273	Pregnancy, Prolonged	EFO	0009681	post term pregnancy
 MESH	D011276	Pregnanediol	CHEBI	CHEBI:8387	Pregnanediol
 MESH	D011279	Pregnanetriol	CHEBI	CHEBI:34464	5beta-Pregnane-3alpha,17alpha,20alpha-triol
 MESH	D011284	Pregnenolone	CHEBI	CHEBI:16581	pregnenolone
@@ -2716,6 +3136,7 @@ MESH	D011353	Prodigiosin	CHEBI	CHEBI:82758	prodigiosin
 MESH	D011355	Prodrugs	CHEBI	CHEBI:50266	prodrug
 MESH	D011359	Proestrus	GO	GO:0060208	proestrus
 MESH	D011370	Proflavine	CHEBI	CHEBI:8452	3,6-diaminoacridine
+MESH	D011371	Progeria	EFO	0005909	HGADFN167
 MESH	D011374	Progesterone	CHEBI	CHEBI:17026	progesterone
 MESH	D011377	Proglumide	CHEBI	CHEBI:32058	proglumide
 MESH	D011388	Prolactin	HGNC	9445	PRL
@@ -2755,6 +3176,8 @@ MESH	D011460	Prostaglandins F	CHEBI	CHEBI:26340	prostaglandins F
 MESH	D011462	Prostaglandins G	CHEBI	CHEBI:26343	prostaglandins G
 MESH	D011463	Prostaglandins H	CHEBI	CHEBI:26344	prostaglandins H
 MESH	D011464	Epoprostenol	CHEBI	CHEBI:15552	prostaglandin I2
+MESH	D011470	Prostatic Hyperplasia	DOID	DOID:11132	prostatic hypertrophy
+MESH	D011471	Prostatic Neoplasms	DOID	DOID:2526	prostate adenocarcinoma
 MESH	D011478	Protactinium	CHEBI	CHEBI:33386	protactinium atom
 MESH	D011485	Protein Binding	GO	GO:0005515	protein binding
 MESH	D011486	Protein C	HGNC	9367	PRH2
@@ -2770,15 +3193,21 @@ MESH	D011516	Prothrombin	HGNC	3535	F2
 MESH	D011521	Protochlorophyllide	CHEBI	CHEBI:16673	protochlorophyllide
 MESH	D011524	Protoporphyrins	CHEBI	CHEBI:26361	protoporphyrins
 MESH	D011530	Protriptyline	CHEBI	CHEBI:8597	protriptyline
+MESH	D011539	Pruritus Vulvae	HP	HP:0032004	Pruritus vulvae
 MESH	D011554	Pseudopodia	GO	GO:0031143	pseudopodium
 MESH	D011560	Pseudouridine	CHEBI	CHEBI:17802	pseudouridine
 MESH	D011562	Psilocybin	CHEBI	CHEBI:8614	psilocybin
 MESH	D011564	Furocoumarins	CHEBI	CHEBI:24128	furanocoumarin
+MESH	D011595	Psychomotor Agitation	HP	HP:0000711	Restlessness
 MESH	D011609	Psychosine	CHEBI	CHEBI:16874	psychosine
+MESH	D011618	Psychotic Disorders	DOID	DOID:2468	psychotic disorder
 MESH	D011619	Psychotropic Drugs	CHEBI	CHEBI:35471	psychotropic drug
 MESH	D011621	Pteridines	CHEBI	CHEBI:26373	pteridines
 MESH	D011622	Pterins	CHEBI	CHEBI:26375	pterins
 MESH	D011623	gamma-Glutamyl Hydrolase	HGNC	4248	GGH
+MESH	D011625	Pterygium	DOID	DOID:10526	conjunctival pterygium
+MESH	D011653	Pulmonary Diffusing Capacity	EFO	0009369	diffusing capacity of the lung for carbon monoxide
+MESH	D011657	Pulmonary Eosinophilia	HP	HP:0032071	Pulmonary eosinophilic infiltration
 MESH	D011683	Purine-Nucleoside Phosphorylase	HGNC	7892	PNP
 MESH	D011684	Purine Nucleosides	CHEBI	CHEBI:26394	purine nucleoside
 MESH	D011685	Purine Nucleotides	CHEBI	CHEBI:26395	purine nucleotide
@@ -2842,9 +3271,12 @@ MESH	D011809	Quinones	CHEBI	CHEBI:36141	quinone
 MESH	D011810	Quinoxalines	CHEBI	CHEBI:38771	quinoxaline derivative
 MESH	D011812	Quinuclidines	CHEBI	CHEBI:26518	quinuclidines
 MESH	D011814	Quipazine	CHEBI	CHEBI:93368	2-(1-piperazinyl)quinoline
+MESH	D011818	Rabies	HP	HP:0032505	Hydrophobia
 MESH	D011838	Radiation-Sensitizing Agents	CHEBI	CHEBI:132992	radiosensitizing agent
 MESH	D011887	Raffinose	CHEBI	CHEBI:16634	raffinose
 MESH	D011899	Ranitidine	CHEBI	CHEBI:8776	ranitidine
+MESH	D011900	Ranula	DOID	DOID:12904	mucocele of salivary gland
+MESH	D011906	Rat-Bite Fever	DOID	DOID:13238	Haverhill fever
 MESH	D011929	Razoxane	CHEBI	CHEBI:50225	razoxane
 MESH	D011954	Receptors, Dopamine	FPLX	DRD	DRD
 MESH	D011959	Receptors, Estradiol	HGNC	3467	ESR1
@@ -2862,21 +3294,36 @@ MESH	D011988	Receptors, Thyroid Hormone	FPLX	THR	THR
 MESH	D011989	Receptors, Thyrotropin	HGNC	12373	TSHR
 MESH	D011990	Receptors, Transferrin	HGNC	11763	TFRC
 MESH	D011992	Endosomes	GO	GO:0005768	endosome
+MESH	D012021	Reflex, Abnormal	HP	HP:0031826	Abnormal reflex
 MESH	D012038	Regeneration	GO	GO:0031099	regeneration
+MESH	D012046	Rehabilitation	EFO	0009581	rehabilitation
 MESH	D012076	Renal Agents	CHEBI	CHEBI:35846	renal agent
 MESH	D012083	Renin	HGNC	9958	REN
 MESH	D012098	Reproduction	GO	GO:0000003	reproduction
 MESH	D012100	Reproduction, Asexual	GO	GO:0019954	asexual reproduction
+MESH	D012108	Research Personnel	EFO	0001739	investigator
 MESH	D012110	Reserpine	CHEBI	CHEBI:28487	reserpine
 MESH	D012118	Resorcinols	CHEBI	CHEBI:33572	resorcinols
+MESH	D012130	Respiratory Hypersensitivity	EFO	0005414	airway hyperresponsiveness
+MESH	D012131	Respiratory Insufficiency	DOID	DOID:11162	respiratory failure
+MESH	D012135	Respiratory Sounds	EFO	0009715	wheezing
+MESH	D012140	Respiratory Tract Diseases	DOID	DOID:1579	respiratory system disease
 MESH	D012155	Reticulin	CHEBI	CHEBI:24750	5'-hydroxystreptomycin
 MESH	D012172	Retinaldehyde	CHEBI	CHEBI:17898	all-trans-retinal
+MESH	D012173	Retinitis	HP	HP:0032118	Retinitis
+MESH	D012175	Retinoblastoma	EFO	0000393	Robertsonian translocation
 MESH	D012176	Retinoids	CHEBI	CHEBI:26537	retinoid
+MESH	D012178	Retinopathy of Prematurity	HP	HP:0500049	Retinopathy of prematurity
+MESH	D012192	Retroviridae Infections	DOID	DOID:6171	uterine carcinosarcoma
 MESH	D012210	Rhamnose	CHEBI	CHEBI:26546	rhamnose
 MESH	D012211	Rhenium	CHEBI	CHEBI:49882	rhenium atom
+MESH	D012214	Rheumatic Heart Disease	DOID	DOID:0050827	rheumatic heart disease
+MESH	D012220	Rhinitis	HP	HP:0031417	Rhinorrhea
+MESH	D012221	Rhinitis, Allergic, Perennial	DOID	DOID:4481	allergic rhinitis
 MESH	D012236	Rhodanine	CHEBI	CHEBI:8830	rhodanine
 MESH	D012238	Rhodium	CHEBI	CHEBI:33359	rhodium atom
 MESH	D012243	Rhodopsin	HGNC	10012	RHO
+MESH	D012253	Rib Fractures	EFO	0009620	rib fracture
 MESH	D012254	Ribavirin	CHEBI	CHEBI:63580	ribavirin
 MESH	D012255	Ribitol	CHEBI	CHEBI:15963	ribitol
 MESH	D012256	Riboflavin	CHEBI	CHEBI:17015	riboflavin
@@ -2888,6 +3335,7 @@ MESH	D012276	Ricin	CHEBI	CHEBI:8852	Ricin
 MESH	D012293	Rifampin	CHEBI	CHEBI:28077	rifampicin
 MESH	D012294	Rifamycins	CHEBI	CHEBI:26580	rifamycins
 MESH	D012299	Rimantadine	CHEBI	CHEBI:49886	rimantadine
+MESH	D012309	Risk-Taking	HP	HP:0031472	Risk taking
 MESH	D012310	Ristocetin	CHEBI	CHEBI:85129	ristocetin
 MESH	D012312	Ritodrine	CHEBI	CHEBI:8872	Ritodrine
 MESH	D012313	RNA	CHEBI	CHEBI:33697	ribonucleic acid
@@ -2919,6 +3367,7 @@ MESH	D012363	RNA, Transfer, Thr	CHEBI	CHEBI:29180	tRNA(Thr)
 MESH	D012364	RNA, Transfer, Trp	CHEBI	CHEBI:29181	tRNA(Trp)
 MESH	D012365	RNA, Transfer, Tyr	CHEBI	CHEBI:29182	tRNA(Tyr)
 MESH	D012366	RNA, Transfer, Val	CHEBI	CHEBI:29183	tRNA(Val)
+MESH	D012373	Rocky Mountain Spotted Fever	DOID	DOID:0050052	Rocky Mountain spotted fever
 MESH	D012374	Rod Cell Outer Segment	GO	GO:0120200	rod photoreceptor outer segment
 MESH	D012378	Rodenticides	CHEBI	CHEBI:33288	rodenticide
 MESH	D012382	Rolitetracycline	CHEBI	CHEBI:63334	rolitetracycline
@@ -2940,12 +3389,18 @@ MESH	D012457	Salicylamides	CHEBI	CHEBI:53443	salicylamides
 MESH	D012458	Salicylanilides	CHEBI	CHEBI:53468	salicylanilides
 MESH	D012459	Salicylates	CHEBI	CHEBI:26596	salicylates
 MESH	D012460	Sulfasalazine	CHEBI	CHEBI:9334	sulfasalazine
+MESH	D012466	Salivary Gland Diseases	DOID	DOID:10854	salivary gland disease
+MESH	D012468	Salivary Gland Neoplasms	EFO	1000384	Mixed Tumor of the Salivary Gland
+MESH	D012480	Salmonella Infections	DOID	DOID:0060859	salmonellosis
 MESH	D012493	Samarium	CHEBI	CHEBI:33374	samarium atom
 MESH	D012500	Santonin	CHEBI	CHEBI:26604	santonin
 MESH	D012502	Sapogenins	CHEBI	CHEBI:26606	sapogenin
 MESH	D012503	Saponins	CHEBI	CHEBI:26605	saponin
 MESH	D012504	Saralasin	CHEBI	CHEBI:135894	saralasin
 MESH	D012508	Sarcolemma	GO	GO:0042383	sarcolemma
+MESH	D012509	Sarcoma	DOID	DOID:1115	sarcoma
+MESH	D012515	Mast-Cell Sarcoma	DOID	DOID:0060815	Miles-Carpenter syndrome
+MESH	D012516	Osteosarcoma	DOID	DOID:3376	bone osteosarcoma
 MESH	D012518	Sarcomeres	GO	GO:0030017	sarcomere
 MESH	D012519	Sarcoplasmic Reticulum	GO	GO:0016529	sarcoplasmic reticulum
 MESH	D012521	Sarcosine	CHEBI	CHEBI:15611	sarcosine
@@ -2953,9 +3408,11 @@ MESH	D012530	Saxitoxin	CHEBI	CHEBI:34970	saxitoxin
 MESH	D012538	Scandium	CHEBI	CHEBI:33330	scandium atom
 MESH	D012545	Schiff Bases	CHEBI	CHEBI:50229	Schiff base
 MESH	D012556	Schistosomicides	CHEBI	CHEBI:38941	schistosomicide drug
+MESH	D012559	Schizophrenia	DOID	DOID:5418	schizoaffective disorder
 MESH	D012566	Sizofiran	CHEBI	CHEBI:50653	schizophyllan
 MESH	D012601	Scopolamine	CHEBI	CHEBI:16794	scopolamine
 MESH	D012603	Scopoletin	CHEBI	CHEBI:17488	scopoletin
+MESH	D012625	Sebaceous Gland Diseases	DOID	DOID:9098	sebaceous gland disease
 MESH	D012631	Secobarbital	CHEBI	CHEBI:9073	secobarbital
 MESH	D012632	Secosteroids	CHEBI	CHEBI:35788	seco-steroid
 MESH	D012633	Secretin	HGNC	10607	SCT
@@ -2967,16 +3424,25 @@ MESH	D012664	Semicarbazones	CHEBI	CHEBI:87210	semicarbazone
 MESH	D012673	Semustine	CHEBI	CHEBI:6863	semustine
 MESH	D012685	Sepharose	CHEBI	CHEBI:2511	agarose
 MESH	D012694	Serine	CHEBI	CHEBI:17115	L-serine
+MESH	D012700	Serositis	HP	HP:0045073	Serositis
 MESH	D012701	Serotonin	CHEBI	CHEBI:28790	serotonin
 MESH	D012702	Serotonin Antagonists	CHEBI	CHEBI:48279	serotonergic antagonist
 MESH	D012709	Serum Albumin	HGNC	399	ALB
 MESH	D012717	Sesquiterpenes	CHEBI	CHEBI:35189	sesquiterpene
 MESH	D012721	Carbaryl	CHEBI	CHEBI:3390	carbaryl
+MESH	D012727	Sex Characteristics	EFO	0005951	sexual dimorphism
 MESH	D012728	Sex Chromatin	GO	GO:0001739	sex chromatin
 MESH	D012730	Sex Chromosomes	GO	GO:0000803	sex chromosome
 MESH	D012733	Sex Differentiation	GO	GO:0007548	sex differentiation
+MESH	D012734	Disorders of Sex Development	DOID	DOID:3765	pseudohermaphroditism
 MESH	D012738	Sex Hormone-Binding Globulin	HGNC	10839	SHBG
 MESH	D012739	Gonadal Steroid Hormones	CHEBI	CHEBI:50112	sex hormone
+MESH	D012768	Shivering	HP	HP:0025144	Shivering
+MESH	D012769	Shock	HP	HP:0031273	Shock
+MESH	D012772	Shock, Septic	EFO	0006834	septic shock
+MESH	D012784	Shoulder Fractures	EFO	0009621	shoulder fracture
+MESH	D012793	Sialadenitis	HP	HP:0031281	Sialadenitis
+MESH	D012804	Sick Sinus Syndrome	DOID	DOID:0050824	sinoatrial node disease
 MESH	D012821	Silanes	CHEBI	CHEBI:37172	silanes
 MESH	D012822	Silicon Dioxide	CHEBI	CHEBI:30563	silicon dioxide
 MESH	D012824	Silicic Acid	CHEBI	CHEBI:26675	silicic acid
@@ -2990,6 +3456,9 @@ MESH	D012839	Simazine	CHEBI	CHEBI:27496	simazine
 MESH	D012844	Sincalide	CHEBI	CHEBI:135946	sincalide
 MESH	D012853	Sisomicin	CHEBI	CHEBI:9169	sisomycin
 MESH	D012862	Skatole	CHEBI	CHEBI:9171	skatole
+MESH	D012878	Skin Neoplasms	DOID	DOID:8923	skin melanoma
+MESH	D012893	Sleep Wake Disorders	DOID	DOID:535	sleep disorder
+MESH	D012913	Snoring	HP	HP:0025267	Snoring
 MESH	D012919	Social Behavior	GO	GO:0035176	social behavior
 MESH	D012964	Sodium	CHEBI	CHEBI:52634	sodium-23 atom
 MESH	D012965	Sodium Chloride	CHEBI	CHEBI:26710	sodium chloride
@@ -3003,18 +3472,22 @@ MESH	D012974	Sodium Iodide	CHEBI	CHEBI:33167	sodium iodide
 MESH	D012977	Sodium Nitrite	CHEBI	CHEBI:78870	sodium nitrite
 MESH	D012980	Sodium Salicylate	CHEBI	CHEBI:9180	Sodium salicylate
 MESH	D012981	Sodium Tetradecyl Sulfate	CHEBI	CHEBI:75273	sodium tetradecyl sulfate
+MESH	D012983	Soft Tissue Neoplasms	EFO	1000541	Soft Tissue Neoplasm
 MESH	D012992	Solanine	CHEBI	CHEBI:9188	solanine
 MESH	D012997	Solvents	CHEBI	CHEBI:46787	solvent
 MESH	D012999	Soman	CHEBI	CHEBI:9195	Soman
 MESH	D013004	Somatostatin	CHEBI	CHEBI:64628	somatostatin
 MESH	D013006	Growth Hormone	HGNC	4261	GH1
 MESH	D013007	Growth Hormone-Releasing Hormone	HGNC	4265	GHRH
+MESH	D013009	Somnambulism	HP	HP:0025236	Somnambulism
 MESH	D013011	Sorbic Acid	CHEBI	CHEBI:35962	sorbic acid
 MESH	D013012	Sorbitol	CHEBI	CHEBI:30911	glucitol
 MESH	D013013	Sorbose	CHEBI	CHEBI:27922	sorbose
 MESH	D013014	SOS Response (Genetics)	GO	GO:0009432	SOS response
 MESH	D013015	Sotalol	CHEBI	CHEBI:63622	sotalol
 MESH	D013034	Sparteine	CHEBI	CHEBI:28827	sparteine
+MESH	D013035	Spasm	EFO	0009846	muscle cramp
+MESH	D013036	Spasms, Infantile	DOID	DOID:0050562	West syndrome
 MESH	D013049	Spectrin	GO	GO:0008091	spectrin
 MESH	D013075	Sperm Capacitation	GO	GO:0048240	sperm capacitation
 MESH	D013077	Sperm Head	GO	GO:0061827	sperm head
@@ -3027,6 +3500,10 @@ MESH	D013097	Spermine Synthase	HGNC	11123	SMS
 MESH	D013107	Sphingolipids	CHEBI	CHEBI:26739	sphingolipid
 MESH	D013108	Sphingomyelin Phosphodiesterase	HGNC	11120	SMPD1
 MESH	D013110	Sphingosine	CHEBI	CHEBI:16393	sphingosine
+MESH	D013122	Spinal Diseases	DOID	DOID:0060564	spinal disease
+MESH	D013123	Spinal Fusion	HP	HP:0002948	Vertebral fusion
+MESH	D013125	Spinal Neoplasms	DOID	DOID:14150	spinal cord lymphoma
+MESH	D013130	Spinal Stenosis	HP	HP:0004610	Lumbar spinal canal stenosis
 MESH	D013134	Spiperone	CHEBI	CHEBI:9233	spiperone
 MESH	D013141	Spiro Compounds	CHEBI	CHEBI:33599	spiro compound
 MESH	D013148	Spironolactone	CHEBI	CHEBI:9241	spironolactone
@@ -3034,6 +3511,7 @@ MESH	D013185	Squalene	CHEBI	CHEBI:15440	squalene
 MESH	D013186	Farnesyl-Diphosphate Farnesyltransferase	HGNC	3629	FDFT1
 MESH	D013196	Dihydrotestosterone	CHEBI	CHEBI:16330	17beta-hydroxy-5alpha-androstan-3-one
 MESH	D013197	Stanozolol	CHEBI	CHEBI:9249	stanozolol
+MESH	D013203	Staphylococcal Infections	EFO	0005681	Staphylococcus aureus infection
 MESH	D013205	Staphylococcal Protein A	HGNC	23458	CALHM3
 MESH	D013213	Starch	CHEBI	CHEBI:28017	starch
 MESH	D013216	Reflex, Startle	GO	GO:0001964	startle response
@@ -3049,6 +3527,8 @@ MESH	D013259	Steroids, Fluorinated	CHEBI	CHEBI:50830	fluorinated steroid
 MESH	D013261	Sterols	CHEBI	CHEBI:15889	sterol
 MESH	D013265	Stigmasterol	CHEBI	CHEBI:28824	stigmasterol
 MESH	D013267	Stilbenes	CHEBI	CHEBI:26776	stilbenoid
+MESH	D013274	Stomach Neoplasms	DOID	DOID:5517	stomach carcinoma
+MESH	D013281	Stomatitis, Aphthous	HP	HP:0032154	Aphthous ulcer
 MESH	D013308	Streptonigrin	CHEBI	CHEBI:9287	streptonigrin
 MESH	D013309	Streptothricins	CHEBI	CHEBI:26789	streptothricin
 MESH	D013310	Streptovaricin	CHEBI	CHEBI:26790	streptovaricin
@@ -3056,8 +3536,10 @@ MESH	D013311	Streptozocin	CHEBI	CHEBI:9288	streptozocin
 MESH	D013324	Strontium	CHEBI	CHEBI:35104	strontium(2+)
 MESH	D013327	Strophanthidin	CHEBI	CHEBI:38178	strophanthidin
 MESH	D013331	Strychnine	CHEBI	CHEBI:28973	strychnine
+MESH	D013342	Stuttering	HP	HP:0025268	Stuttering
 MESH	D013343	Styrenes	CHEBI	CHEBI:26799	styrenes
 MESH	D013373	Substance P	CHEBI	CHEBI:80308	Substance P
+MESH	D013375	Substance Withdrawal Syndrome	DOID	DOID:0060001	withdrawal disorder
 MESH	D013385	Succinate Dehydrogenase	FPLX	ETC_complex_II	ETC_complex_II
 MESH	D013386	Succinates	CHEBI	CHEBI:26806	succinate
 MESH	D013390	Succinylcholine	CHEBI	CHEBI:45652	succinylcholine
@@ -3065,6 +3547,7 @@ MESH	D013392	Sucralfate	CHEBI	CHEBI:9313	Sucralfate
 MESH	D013394	Sucrase-Isomaltase Complex	GO	GO:0070014	sucrase-isomaltase complex
 MESH	D013395	Sucrose	CHEBI	CHEBI:17992	sucrose
 MESH	D013402	Sugar Alcohols	CHEBI	CHEBI:17522	alditol
+MESH	D013405	Suicide	EFO	0007624	suicide
 MESH	D013407	Sulbactam	CHEBI	CHEBI:9321	sulbactam
 MESH	D013408	Sulbenicillin	CHEBI	CHEBI:9322	sulbenicillin
 MESH	D013409	Sulfacetamide	CHEBI	CHEBI:63845	sulfacetamide
@@ -3105,6 +3588,7 @@ MESH	D013459	Sulfur Hexafluoride	CHEBI	CHEBI:30496	sulfur hexafluoride
 MESH	D013461	Sulfur Oxides	CHEBI	CHEBI:48154	sulfur oxide
 MESH	D013467	Sulindac	CHEBI	CHEBI:9352	sulindac
 MESH	D013469	Sulpiride	CHEBI	CHEBI:32168	sulpiride
+MESH	D013479	Superior Vena Cava Syndrome	HP	HP:0031041	Obstruction of the superior vena cava
 MESH	D013481	Superoxides	CHEBI	CHEBI:18421	superoxide
 MESH	D013496	Suprofen	CHEBI	CHEBI:9362	suprofen
 MESH	D013498	Suramin	CHEBI	CHEBI:45906	suramin
@@ -3117,8 +3601,12 @@ MESH	D013570	Synaptic Membranes	GO	GO:0097060	synaptic membrane
 MESH	D013572	Synaptic Vesicles	GO	GO:0008021	synaptic vesicle
 MESH	D013573	Synaptonemal Complex	GO	GO:0000795	synaptonemal complex
 MESH	D013578	Synephrine	CHEBI	CHEBI:29081	synephrine
+MESH	D013589	Syphilis, Cardiovascular	DOID	DOID:9880	cardiovascular syphilis
 MESH	D013605	T-2 Toxin	CHEBI	CHEBI:9381	T-2 Toxin
+MESH	D013612	Tachycardia, Ectopic Atrial	HP	HP:0011701	Multifocal atrial tachycardia
+MESH	D013615	Tachycardia, Sinoatrial Nodal Reentry	HP	HP:0011717	Atrioventricular reentrant tachycardia
 MESH	D013619	Tacrine	CHEBI	CHEBI:45980	tacrine
+MESH	D013622	Taeniasis	DOID	DOID:0050596	taeniasis
 MESH	D013626	Talampicillin	CHEBI	CHEBI:9391	talampicillin
 MESH	D013627	Talc	CHEBI	CHEBI:32178	Talc
 MESH	D013629	Tamoxifen	CHEBI	CHEBI:41774	tamoxifen
@@ -3164,6 +3652,7 @@ MESH	D013793	Thallium	CHEBI	CHEBI:30440	thallium
 MESH	D013797	Thebaine	CHEBI	CHEBI:9519	thebaine
 MESH	D013805	Theobromine	CHEBI	CHEBI:28946	theobromine
 MESH	D013806	Theophylline	CHEBI	CHEBI:28177	theophylline
+MESH	D013812	Therapeutics	EFO	0000727	treatment
 MESH	D013827	Thiabendazole	CHEBI	CHEBI:45979	thiabendazole
 MESH	D013828	Thioacetazone	CHEBI	CHEBI:134958	thioacetazone
 MESH	D013830	Thiadiazoles	CHEBI	CHEBI:38099	thiadiazoles
@@ -3198,6 +3687,7 @@ MESH	D013890	Thiourea	CHEBI	CHEBI:36946	thiourea
 MESH	D013891	Thiouridine	CHEBI	CHEBI:20480	4-thiouridine
 MESH	D013892	Thioxanthenes	CHEBI	CHEBI:50930	thioxanthenes
 MESH	D013893	Thiram	CHEBI	CHEBI:9495	thiram
+MESH	D013896	Thoracic Diseases	DOID	DOID:0060118	thoracic disease
 MESH	D013910	Thorium	CHEBI	CHEBI:33385	thorium
 MESH	D013911	Thorium Dioxide	CHEBI	CHEBI:37339	thorium dioxide
 MESH	D013912	Threonine	CHEBI	CHEBI:16857	L-threonine
@@ -3215,19 +3705,25 @@ MESH	D013940	Thymidylate Synthase	HGNC	12441	TYMS
 MESH	D013941	Thymine	CHEBI	CHEBI:17821	thymine
 MESH	D013942	Thymine Nucleotides	CHEBI	CHEBI:27001	thymidine phosphate
 MESH	D013943	Thymol	CHEBI	CHEBI:27607	thymol
+MESH	D013945	Thymoma	DOID	DOID:3275	thymoma
+MESH	D013953	Thymus Neoplasms	DOID	DOID:3277	thymus cancer
 MESH	D013954	Thyroglobulin	HGNC	11764	TG
 MESH	D013956	Antithyroid Agents	CHEBI	CHEBI:50671	antithyroid drug
 MESH	D013963	Thyroid Hormones	CHEBI	CHEBI:60311	thyroid hormone
+MESH	D013964	Thyroid Neoplasms	DOID	DOID:3963	thyroid gland carcinoma
 MESH	D013972	Thyrotropin	CHEBI	CHEBI:81567	thyroid stimulating hormone
 MESH	D013973	Thyrotropin-Releasing Hormone	CHEBI	CHEBI:35940	protirelin
+MESH	D013981	Tic Disorders	HP	HP:0100033	Tics
 MESH	D013982	Ticarcillin	CHEBI	CHEBI:9587	ticarcillin
 MESH	D013988	Ticlopidine	CHEBI	CHEBI:9588	ticlopidine
 MESH	D013989	Ticrynafen	CHEBI	CHEBI:9590	tienilic acid
 MESH	D013993	Tilidine	CHEBI	CHEBI:77823	tilidine
 MESH	D013999	Timolol	CHEBI	CHEBI:9599	(S)-timolol (anhydrous)
 MESH	D014001	Tin	CHEBI	CHEBI:27007	tin atom
+MESH	D014005	Tinea	DOID	DOID:8913	dermatophytosis
 MESH	D014011	Tinidazole	CHEBI	CHEBI:63627	tinidazole
 MESH	D014014	Tissue Adhesives	CHEBI	CHEBI:53337	tissue adhesive
+MESH	D014019	Tissue Donors	EFO	0009633	tissue donor
 MESH	D014025	Titanium	CHEBI	CHEBI:33341	titanium atom
 MESH	D014031	Tobramycin	CHEBI	CHEBI:28864	tobramycin
 MESH	D014042	Tolazamide	CHEBI	CHEBI:9613	tolazamide
@@ -3240,6 +3736,9 @@ MESH	D014050	Toluene	CHEBI	CHEBI:17578	toluene
 MESH	D014051	Toluene 2,4-Diisocyanate	CHEBI	CHEBI:53556	toluene 2,4-diisocyanate
 MESH	D014053	Tomatine	CHEBI	CHEBI:9630	tomatine
 MESH	D014078	Tooth Eruption	GO	GO:0044691	tooth eruption
+MESH	D014095	Tooth, Impacted	HP	HP:0001571	Multiple impacted teeth
+MESH	D014097	Tooth, Unerupted	HP	HP:0000706	Unerupted tooth
+MESH	D014103	Torticollis	DOID	DOID:0050840	cervical dystonia
 MESH	D014106	Tosylarginine Methyl Ester	CHEBI	CHEBI:62167	TAMe
 MESH	D014108	Tosylphenylalanyl Chloromethyl Ketone	CHEBI	CHEBI:9642	N-tosyl-L-phenylalanyl chloromethyl ketone
 MESH	D014112	Toxaphene	CHEBI	CHEBI:77850	toxaphene
@@ -3314,6 +3813,7 @@ MESH	D014312	Trisaccharides	CHEBI	CHEBI:27150	trisaccharide
 MESH	D014315	Triterpenes	CHEBI	CHEBI:35191	triterpene
 MESH	D014316	Tritium	CHEBI	CHEBI:29298	ditritium
 MESH	D014325	Tromethamine	CHEBI	CHEBI:9754	tris
+MESH	D014328	Trophoblastic Neoplasms	HP	HP:0031502	Trophoblastic tumor
 MESH	D014331	Tropicamide	CHEBI	CHEBI:9757	Tropicamide
 MESH	D014333	Tropoelastin	HGNC	3327	ELN
 MESH	D014334	Tropolone	CHEBI	CHEBI:79966	Tropolone
@@ -3328,12 +3828,17 @@ MESH	D014364	Tryptophan	CHEBI	CHEBI:16828	L-tryptophan
 MESH	D014366	Tryptophan Oxygenase	HGNC	11708	TDO2
 MESH	D014368	Tryptophanase	HGNC	11708	TDO2
 MESH	D014372	Tubercidin	CHEBI	CHEBI:48267	tubercidin
+MESH	D014397	Tuberculosis, Pulmonary	HP	HP:0032262	Pulmonary tuberculosis
+MESH	D014402	Tuberous Sclerosis	DOID	DOID:2648	sebaceous adenoma
 MESH	D014403	Tubocurarine	CHEBI	CHEBI:9774	tubocurarine
 MESH	D014404	Tubulin	FPLX	Tubulin	Tubulin
 MESH	D014405	Tuftsin	CHEBI	CHEBI:88947	Tuftsin
+MESH	D014406	Tularemia	DOID	DOID:2123	tularemia
 MESH	D014409	Tumor Necrosis Factor-alpha	HGNC	11892	TNF
 MESH	D014414	Tungsten	CHEBI	CHEBI:27998	tungsten
 MESH	D014415	Tunicamycin	CHEBI	CHEBI:29699	tunicamycin
+MESH	D014437	Typhus, Endemic Flea-Borne	DOID	DOID:0050481	endemic typhus
+MESH	D014438	Typhus, Epidemic Louse-Borne	DOID	DOID:0050481	endemic typhus
 MESH	D014439	Tyramine	CHEBI	CHEBI:15760	tyramine
 MESH	D014440	Tyrocidine	CHEBI	CHEBI:71947	tyrocidine
 MESH	D014441	Tyropanoate	CHEBI	CHEBI:135862	tyropanoate
@@ -3349,6 +3854,7 @@ MESH	D014499	Uracil Mustard	CHEBI	CHEBI:9884	5-[bis(2-chloroethyl)amino]uracil
 MESH	D014500	Uracil Nucleotides	CHEBI	CHEBI:27237	uridine phosphate
 MESH	D014508	Urea	CHEBI	CHEBI:16199	urea
 MESH	D014520	Urethane	CHEBI	CHEBI:17967	urethane
+MESH	D014526	Urethritis	HP	HP:0500006	Urethritis
 MESH	D014529	Uridine	CHEBI	CHEBI:16704	uridine
 MESH	D014530	Uridine Diphosphate	CHEBI	CHEBI:17659	UDP
 MESH	D014535	Uridine Diphosphate Glucuronic Acid	CHEBI	CHEBI:17200	UDP-alpha-D-glucuronic acid
@@ -3361,6 +3867,7 @@ MESH	D014557	Urobilin	CHEBI	CHEBI:36378	urobilin
 MESH	D014558	Urobilinogen	CHEBI	CHEBI:29026	urobilinogen
 MESH	D014559	Urocanate Hydratase	HGNC	26444	UROC1
 MESH	D014568	Urokinase-Type Plasminogen Activator	HGNC	9052	PLAU
+MESH	D014570	Urologic Diseases	DOID	DOID:18	urinary system disease
 MESH	D014574	Uronic Acids	CHEBI	CHEBI:27252	uronic acid
 MESH	D014576	Uroporphyrinogen III Synthetase	HGNC	12592	UROS
 MESH	D014577	Uroporphyrinogens	CHEBI	CHEBI:27258	uroporphyrinogen
@@ -3374,6 +3881,7 @@ MESH	D014638	Vanadates	CHEBI	CHEBI:30528	vanadium oxoanion
 MESH	D014639	Vanadium	CHEBI	CHEBI:27698	vanadium atom
 MESH	D014640	Vancomycin	CHEBI	CHEBI:28001	vancomycin
 MESH	D014642	Vanilmandelic Acid	CHEBI	CHEBI:20106	vanillylmandelic acid
+MESH	D014647	Varicose Ulcer	EFO	1001923	varicose ulcer
 MESH	D014660	Vasoactive Intestinal Peptide	HGNC	12693	VIP
 MESH	D014661	Vasoconstriction	GO	GO:0042310	vasoconstriction
 MESH	D014662	Vasoconstrictor Agents	CHEBI	CHEBI:137431	antihypotensive agent
@@ -3383,6 +3891,7 @@ MESH	D014665	Vasodilator Agents	CHEBI	CHEBI:35620	vasodilator agent
 MESH	D014667	Vasopressins	CHEBI	CHEBI:9937	vasopressin
 MESH	D014668	Vasotocin	CHEBI	CHEBI:78364	vasotocin
 MESH	D014673	Vecuronium Bromide	CHEBI	CHEBI:9940	vecuronium bromide
+MESH	D014681	Velopharyngeal Insufficiency	EFO	0009336	velopharyngeal dysfunction
 MESH	D014698	Venturicidins	CHEBI	CHEBI:83165	venturicidin
 MESH	D014700	Verapamil	CHEBI	CHEBI:9948	verapamil
 MESH	D014701	Veratridine	CHEBI	CHEBI:28051	veratridine
@@ -3396,11 +3905,13 @@ MESH	D014750	Vincristine	CHEBI	CHEBI:28445	vincristine
 MESH	D014751	Vindesine	CHEBI	CHEBI:36373	vindesine
 MESH	D014752	Vinyl Chloride	CHEBI	CHEBI:28509	chloroethene
 MESH	D014756	Viomycin	CHEBI	CHEBI:15782	viomycin
+MESH	D014766	Viremia	HP	HP:0020071	Viremia
 MESH	D014769	Virginiamycin	CHEBI	CHEBI:87209	virginiamycin
 MESH	D014796	Visual Perception	GO	GO:0007601	visual perception
 MESH	D014801	Vitamin A	CHEBI	CHEBI:17336	all-trans-retinol
 MESH	D014803	Vitamin B Complex	CHEBI	CHEBI:75782	vitamin B complex
 MESH	D014805	Vitamin B 12	CHEBI	CHEBI:17439	cyanocob(III)alamin
+MESH	D014806	Vitamin B 12 Deficiency	DOID	DOID:0050731	vitamin B12 deficiency
 MESH	D014807	Vitamin D	CHEBI	CHEBI:27300	vitamin D
 MESH	D014809	Vitamin D-Binding Protein	HGNC	4187	GC
 MESH	D014810	Vitamin E	CHEBI	CHEBI:18145	(+)-alpha-tocopherol
@@ -3408,15 +3919,21 @@ MESH	D014812	Vitamin K	CHEBI	CHEBI:28384	vitamin K
 MESH	D014815	Vitamins	CHEBI	CHEBI:33229	vitamin
 MESH	D014818	Vitellogenesis	GO	GO:0007296	vitellogenesis
 MESH	D014841	von Willebrand Factor	HGNC	12726	VWF
+MESH	D014846	Vulvar Neoplasms	DOID	DOID:1294	vulva carcinoma
 MESH	D014859	Warfarin	CHEBI	CHEBI:10033	warfarin
+MESH	D014860	Warts	DOID	DOID:11165	common wart
 MESH	D014867	Water	CHEBI	CHEBI:15377	water
+MESH	D014899	Wernicke Encephalopathy	EFO	1001242	Wernicke-Korsakoff syndrome
+MESH	D014929	Wolfram Syndrome	DOID	DOID:0110629	Wolfram syndrome 1
 MESH	D014945	Wound Healing	GO	GO:0042060	wound healing
 MESH	D014960	X Chromosome	GO	GO:0000805	X chromosome
 MESH	D014966	Xanthenes	CHEBI	CHEBI:38835	xanthenes
 MESH	D014968	Xanthine Dehydrogenase	HGNC	12805	XDH
 MESH	D014970	Xanthines	CHEBI	CHEBI:15318	xanthine
+MESH	D014973	Xanthomatosis	EFO	0003075	xanthoma
 MESH	D014975	Lutein	CHEBI	CHEBI:28838	lutein
 MESH	D014978	Xenon	CHEBI	CHEBI:49957	xenon atom
+MESH	D014987	Xerostomia	EFO	0009869	xerostomia
 MESH	D014988	Xipamide	CHEBI	CHEBI:135499	xipamide
 MESH	D014992	Xylenes	CHEBI	CHEBI:27338	xylene
 MESH	D014993	Xylitol	CHEBI	CHEBI:17151	xylitol
@@ -3478,7 +3995,12 @@ MESH	D015125	Oxyquinoline	CHEBI	CHEBI:48981	quinolin-8-ol
 MESH	D015126	8,11,14-Eicosatrienoic Acid	CHEBI	CHEBI:53486	all-cis-icosa-8,11,14-trienoic acid
 MESH	D015127	9,10-Dimethyl-1,2-benzanthracene	CHEBI	CHEBI:254496	7,12-dimethyltetraphene
 MESH	D015149	Tocolytic Agents	CHEBI	CHEBI:66993	tocolytic agent
+MESH	D015155	Esophageal Spasm, Diffuse	HP	HP:0025271	Esophageal spasms
+MESH	D015160	Hydrops Fetalis	EFO	0009051	Non-immune hydrops fetalis
+MESH	D015175	Prolactinoma	HP	HP:0040278	Prolactinoma
+MESH	D015179	Colorectal Neoplasms	DOID	DOID:0050913	large intestine adenocarcinoma
 MESH	D015215	Zidovudine	CHEBI	CHEBI:10110	zidovudine
+MESH	D015228	Hypertriglyceridemia	HP	HP:0002155	Hypertriglyceridemia
 MESH	D015230	Prostaglandin D2	CHEBI	CHEBI:15555	prostaglandin D2
 MESH	D015232	Dinoprostone	CHEBI	CHEBI:15551	prostaglandin E2
 MESH	D015234	HLA-A Antigens	HGNC	4931	HLA-A
@@ -3496,6 +4018,8 @@ MESH	D015255	Idarubicin	CHEBI	CHEBI:42068	idarubicin
 MESH	D015259	Dopamine Agents	CHEBI	CHEBI:48560	dopaminergic agent
 MESH	D015260	Neprilysin	HGNC	7154	MME
 MESH	D015262	Xenobiotics	CHEBI	CHEBI:35703	xenobiotic
+MESH	D015266	Carcinoma, Merkel Cell	DOID	DOID:3965	Merkel cell carcinoma
+MESH	D015275	Tumor Lysis Syndrome	EFO	1001479	Tumor Lysis Syndrome
 MESH	D015281	Cefmenoxime	CHEBI	CHEBI:55490	cefmenoxime
 MESH	D015282	Octreotide	CHEBI	CHEBI:7726	octreotide
 MESH	D015283	Citalopram	CHEBI	CHEBI:3723	citalopram
@@ -3507,6 +4031,8 @@ MESH	D015292	Glycoprotein Hormones, alpha Subunit	HGNC	1885	CGA
 MESH	D015296	Ceftizoxime	CHEBI	CHEBI:553473	ceftizoxime
 MESH	D015311	Cefmetazole	CHEBI	CHEBI:3489	cefmetazole
 MESH	D015313	Cefotetan	CHEBI	CHEBI:3499	cefotetan
+MESH	D015325	Pyruvate Dehydrogenase Complex Deficiency Disease	HP	HP:0002928	Decreased activity of the pyruvate dehydrogenase complex
+MESH	D015356	Retinal Artery Occlusion	HP	HP:0025326	Retinal arterial occlusion
 MESH	D015363	Quinolones	CHEBI	CHEBI:23765	quinolone
 MESH	D015365	Enoxacin	CHEBI	CHEBI:157175	enoxacin
 MESH	D015366	Pefloxacin	CHEBI	CHEBI:50199	pefloxacin
@@ -3516,8 +4042,15 @@ MESH	D015378	Imipenem	CHEBI	CHEBI:471744	imipenem
 MESH	D015388	Organelles	GO	GO:0043226	organelle
 MESH	D015398	Signal Transduction	GO	GO:0007165	signal transduction
 MESH	D015415	Biomarkers	CHEBI	CHEBI:59163	biomarker
+MESH	D015444	Exercise	GO	GO:0003774	motor activity
+MESH	D015451	Leukemia, Lymphocytic, Chronic, B-Cell	DOID	DOID:1036	chronic leukemia
+MESH	D015452	Precursor B-Cell Lymphoblastic Leukemia-Lymphoma	DOID	DOID:7061	precursor B lymphoblastic lymphoma/leukemia
+MESH	D015458	Leukemia, T-Cell	DOID	DOID:5599	precursor T-lymphoblastic lymphoma/leukemia
+MESH	D015467	Leukemia, Neutrophilic, Chronic	DOID	DOID:0080187	chronic neutrophilic leukemia
 MESH	D015474	Isotretinoin	CHEBI	CHEBI:6067	isotretinoin
 MESH	D015478	Antigens, Heterophile	CHEBI	CHEBI:132710	xenoantigen
+MESH	D015479	Leukemia, Myelomonocytic, Acute	EFO	0000223	acute myelomonocytic leukemia
+MESH	D015497	HIV-1	EFO	0000180	HIV-1 infection
 MESH	D015525	Fatty Acids, Omega-3	CHEBI	CHEBI:25681	omega-3 fatty acid
 MESH	D015530	Nuclear Matrix	GO	GO:0016363	nuclear matrix
 MESH	D015539	Platelet Activation	GO	GO:0030168	platelet activation
@@ -3525,6 +4058,7 @@ MESH	D015544	Inositol 1,4,5-Trisphosphate	CHEBI	CHEBI:16595	1D-myo-inositol 1,4,
 MESH	D015570	Josamycin	CHEBI	CHEBI:31739	josamycin
 MESH	D015572	Spiramycin	CHEBI	CHEBI:85260	spiramycin I
 MESH	D015575	Roxithromycin	CHEBI	CHEBI:32109	(Z)-roxithromycin
+MESH	D015593	Retinal Drusen	DOID	DOID:0060746	basal laminar drusen
 MESH	D015632	1-Methyl-4-phenyl-1,2,3,6-tetrahydropyridine	CHEBI	CHEBI:17963	1-methyl-4-phenyl-1,2,3,6-tetrahydropyridine
 MESH	D015636	Magnesium Chloride	CHEBI	CHEBI:6636	magnesium dichloride
 MESH	D015638	Cytochalasin D	CHEBI	CHEBI:529996	cytochalasin D
@@ -3557,13 +4091,18 @@ MESH	D015774	Ganciclovir	CHEBI	CHEBI:465284	ganciclovir
 MESH	D015777	Eicosanoids	CHEBI	CHEBI:23899	icosanoid
 MESH	D015780	Carbapenems	CHEBI	CHEBI:46633	carbapenems
 MESH	D015784	Betaxolol	CHEBI	CHEBI:3082	betaxolol
+MESH	D015787	Erythema Chronicum Migrans	HP	HP:0031180	Erythema migrans
 MESH	D015790	Cefonicid	CHEBI	CHEBI:3491	cefonicid
+MESH	D015812	Glaucoma, Angle-Closure	DOID	DOID:1405	primary angle-closure glaucoma
+MESH	D015831	Osteochondroma	EFO	1000411	Osteochondroma
+MESH	D015840	Oculomotor Nerve Diseases	DOID	DOID:562	third cranial nerve disease
 MESH	D015844	Heparin Cofactor II	HGNC	4838	SERPIND1
 MESH	D015847	Interleukin-4	HGNC	6014	IL4
 MESH	D015848	Interleukin-5	HGNC	6016	IL5
 MESH	D015850	Interleukin-6	HGNC	6018	IL6
 MESH	D015851	Interleukin-7	HGNC	6023	IL7
 MESH	D015853	Cysteine Proteinase Inhibitors	CHEBI	CHEBI:64152	cysteine protease inhibitor
+MESH	D015867	Uveitis, Intermediate	EFO	0002927	International Unit
 MESH	D015870	Gene Expression	GO	GO:0010467	gene expression
 MESH	D015891	Cystatins	HGNC	2476	CST4
 MESH	D015923	Complement C1r	HGNC	1246	C1R
@@ -3575,10 +4114,12 @@ MESH	D015942	Factor VIIa	CHEBI	CHEBI:3777	Coagulation Factor VIIa
 MESH	D015946	Ethylene Dibromide	CHEBI	CHEBI:28534	1,2-dibromoethane
 MESH	D015951	Factor Xa	CHEBI	CHEBI:3783	Coagulation Factor Xa
 MESH	D015977	Eukaryotic Initiation Factor-1	HGNC	3249	EIF1
+MESH	D016022	Case-Control Studies	EFO	0001427	case control design
 MESH	D016023	Integrins	FPLX	Integrins	Integrins
 MESH	D016047	Zalcitabine	CHEBI	CHEBI:10101	zalcitabine
 MESH	D016048	Dideoxyadenosine	CHEBI	CHEBI:91207	2',3'-dideoxyadenosine
 MESH	D016049	Didanosine	CHEBI	CHEBI:490877	didanosine
+MESH	D016084	Bronchoconstriction	EFO	0009836	bronchoconstriction
 MESH	D016085	Bronchoconstrictor Agents	CHEBI	CHEBI:50141	bronchoconstrictor agent
 MESH	D016159	Tumor Suppressor Protein p53	HGNC	11998	TP53
 MESH	D016160	Retinoblastoma Protein	HGNC	9884	RB1
@@ -3609,13 +4150,23 @@ MESH	D016244	Guanosine 5'-O-(3-Thiotriphosphate)	CHEBI	CHEBI:43000	guanosine 5'-
 MESH	D016271	Proto-Oncogene Proteins c-myc	HGNC	7553	MYC
 MESH	D016285	Iloprost	CHEBI	CHEBI:63916	iloprost
 MESH	D016293	Moricizine	CHEBI	CHEBI:6997	moricizine
+MESH	D016301	Alveolar Bone Loss	HP	HP:0006308	Atrophy of alveolar ridges
 MESH	D016305	Thymopentin	CHEBI	CHEBI:135870	thymopentin
 MESH	D016314	Ethylketocyclazocine	CHEBI	CHEBI:4901	Ethylketocyclazocine
 MESH	D016316	Guanfacine	CHEBI	CHEBI:5558	Guanfacine
 MESH	D016318	Quisqualic Acid	CHEBI	CHEBI:8734	Quisqualic acid
 MESH	D016328	NF-kappa B	FPLX	NFkappaB	NFkappaB
 MESH	D016329	Sp1 Transcription Factor	HGNC	11205	SP1
+MESH	D016403	Lymphoma, Large B-Cell, Diffuse	DOID	DOID:0050745	diffuse large B-cell lymphoma
+MESH	D016411	Lymphoma, T-Cell, Peripheral	DOID	DOID:0050749	peripheral T-cell lymphoma
+MESH	D016470	Bacteremia	HP	HP:0031864	Bacteremia
+MESH	D016472	Motor Neuron Disease	HP	HP:0002366	Abnormal lower motor neuron morphology
+MESH	D016481	Helicobacter Infections	HP	HP:0005202	Helicobacter pylori infection
+MESH	D016512	Ankle Injuries	EFO	1002021	ankle injury
+MESH	D016530	Orthopedic Nursing	EFO	0009577	orthopedic nursing
+MESH	D016543	Central Nervous System Neoplasms	EFO	1000158	Central Nervous System Neoplasm
 MESH	D016547	Kinesin	FPLX	Kinesin	Kinesin
+MESH	D016553	Purpura, Thrombocytopenic, Idiopathic	DOID	DOID:1587	thrombocytopenia due to platelet alloimmunization
 MESH	D016559	Tacrolimus	CHEBI	CHEBI:61049	tacrolimus (anhydrous)
 MESH	D016564	Amyloid beta-Protein Precursor	HGNC	620	APP
 MESH	D016566	Organoselenium Compounds	CHEBI	CHEBI:25712	organoselenium compound
@@ -3623,6 +4174,8 @@ MESH	D016567	Nizatidine	CHEBI	CHEBI:7601	nizatidine
 MESH	D016572	Cyclosporine	CHEBI	CHEBI:4031	cyclosporin A
 MESH	D016573	Agrochemicals	CHEBI	CHEBI:33286	agrochemical
 MESH	D016576	Fleroxacin	CHEBI	CHEBI:31810	fleroxacin
+MESH	D016584	Panic Disorder	HP	HP:0025269	Panic attack
+MESH	D016586	Granular Cell Tumor	EFO	0002182	GCT
 MESH	D016587	Antimutagenic Agents	CHEBI	CHEBI:73190	antimutagen
 MESH	D016589	Astemizole	CHEBI	CHEBI:2896	astemizole
 MESH	D016590	Aphidicolin	CHEBI	CHEBI:2766	aphidicolin
@@ -3631,6 +4184,7 @@ MESH	D016595	Misoprostol	CHEBI	CHEBI:63610	misoprostol
 MESH	D016596	Vinculin	HGNC	12665	VCL
 MESH	D016597	Trimetrexate	CHEBI	CHEBI:9737	trimetrexate
 MESH	D016604	Aflatoxin B1	CHEBI	CHEBI:2504	aflatoxin B1
+MESH	D016606	Thyroid Nodule	HP	HP:0025388	Thyroid nodule
 MESH	D016607	Aflatoxin M1	CHEBI	CHEBI:78576	aflatoxin M1
 MESH	D016620	Enprostil	CHEBI	CHEBI:31538	Enprostil
 MESH	D016627	Oxidopamine	CHEBI	CHEBI:78741	oxidopamine
@@ -3639,34 +4193,50 @@ MESH	D016631	Lewy Bodies	GO	GO:0097413	Lewy body
 MESH	D016632	Apolipoprotein A-I	HGNC	600	APOA1
 MESH	D016633	Apolipoprotein A-II	HGNC	601	APOA2
 MESH	D016642	Bupropion	CHEBI	CHEBI:3219	bupropion
+MESH	D016643	Encephalopathy, Bovine Spongiform	EFO	0004597	variant Creutzfeld Jacob disease
 MESH	D016644	Canthaxanthin	CHEBI	CHEBI:3362	canthaxanthin
 MESH	D016650	Fluorescein-5-isothiocyanate	CHEBI	CHEBI:37926	fluorescein isothiocyanate
 MESH	D016651	Lithium Carbonate	CHEBI	CHEBI:6504	lithium carbonate
 MESH	D016660	NAD(P)H Dehydrogenase (Quinone)	HGNC	2874	NQO1
 MESH	D016666	Fluvoxamine	CHEBI	CHEBI:5138	fluvoxamine
 MESH	D016677	Tocainide	CHEBI	CHEBI:9611	tocainide
+MESH	D016682	Lupus Coagulation Inhibitor	HP	HP:0025343	Lupus anticoagulant
 MESH	D016685	Mitomycin	CHEBI	CHEBI:27504	mitomycin C
 MESH	D016686	Monocrotaline	CHEBI	CHEBI:6980	monocrotaline
+MESH	D016688	Mice, Inbred NOD	EFO	0002547	NOD mouse
 MESH	D016700	Encainide	CHEBI	CHEBI:4788	encainide
 MESH	D016708	Synaptophysin	HGNC	11506	SYP
 MESH	D016712	Mupirocin	CHEBI	CHEBI:7025	mupirocin
 MESH	D016713	Ritanserin	CHEBI	CHEBI:64195	ritanserin
 MESH	D016723	Bone Remodeling	GO	GO:0046849	bone remodeling
+MESH	D016724	Empyema, Pleural	DOID	DOID:3798	pleural empyema
 MESH	D016729	Leuprolide	CHEBI	CHEBI:6427	leuprolide
+MESH	D016750	Stiff-Person Syndrome	DOID	DOID:0060695	hyperekplexia
 MESH	D016753	Interleukin-10	HGNC	5962	IL10
+MESH	D016757	Death, Sudden, Cardiac	EFO	1001497	cardiac conduction defect
+MESH	D016854	Dental Anxiety	EFO	1001884	dental phobia
 MESH	D016859	Lipoxygenase Inhibitors	CHEBI	CHEBI:35856	lipoxygenase inhibitor
 MESH	D016861	Cyclooxygenase Inhibitors	CHEBI	CHEBI:35544	EC 1.14.99.1 (prostaglandin-endoperoxide synthase) inhibitor
 MESH	D016874	Neurofibrillary Tangles	GO	GO:0097418	neurofibrillary tangle
 MESH	D016877	Oxidants	CHEBI	CHEBI:63248	oxidising agent
+MESH	D016878	POEMS Syndrome	DOID	DOID:9541	osteosclerotic myeloma
+MESH	D016889	Endometrial Neoplasms	DOID	DOID:6212	ovarian endometrial cancer
 MESH	D016897	Respiratory Burst	GO	GO:0045730	respiratory burst
+MESH	D016898	Interferon-alpha	EFO	0003021	interferon alpha
 MESH	D016899	Interferon-beta	FPLX	IFNB	IFNB
 MESH	D016906	Interleukin-9	HGNC	6029	IL9
 MESH	D016912	Levonorgestrel	CHEBI	CHEBI:6443	levonorgestrel
+MESH	D016919	Meningitis, Cryptococcal	HP	HP:0032160	Cryptococcal meningitis
 MESH	D016922	Cellular Senescence	GO	GO:0090398	cellular senescence
 MESH	D016923	Cell Death	GO	GO:0008219	cell death
 MESH	D017026	Swainsonine	CHEBI	CHEBI:9367	swainsonine
+MESH	D017085	alpha-Thalassemia	DOID	DOID:0110031	hemoglobin H disease
+MESH	D017119	Porphyria Cutanea Tarda	EFO	0009043	Familial porphyria cutanea tarda
+MESH	D017121	Porphyria, Hepatoerythropoietic	EFO	0009043	Familial porphyria cutanea tarda
 MESH	D017135	Desogestrel	CHEBI	CHEBI:4453	desogestrel
 MESH	D017136	Ion Transport	GO	GO:0006811	ion transport
+MESH	D017152	Antibodies, Antiphospholipid	HP	HP:0003613	Antiphospholipid antibody positivity
+MESH	D017207	Rats, Sprague-Dawley	EFO	0001352	Sprague Dawley
 MESH	D017209	Apoptosis	GO	GO:0006915	apoptotic process
 MESH	D017228	Hepatocyte Growth Factor	HGNC	4236	GFER
 MESH	D017239	Paclitaxel	CHEBI	CHEBI:45863	paclitaxel
@@ -3724,6 +4294,7 @@ MESH	D017412	Ribonucleoprotein, U1 Small Nuclear	GO	GO:0005685	U1 snRNP
 MESH	D017413	Ribonucleoprotein, U2 Small Nuclear	GO	GO:0005686	U2 snRNP
 MESH	D017415	Ribonucleoprotein, U5 Small Nuclear	GO	GO:0005682	U5 snRNP
 MESH	D017430	Prostate-Specific Antigen	HGNC	6364	KLK3
+MESH	D017436	Kallmann Syndrome	DOID	DOID:0090094	hypogonadotropic hypogonadism 1 with or without anosmia
 MESH	D017442	Histamine Agonists	CHEBI	CHEBI:35678	histamine agonist
 MESH	D017447	Receptors, Dopamine D1	HGNC	3020	DRD1
 MESH	D017448	Receptors, Dopamine D2	HGNC	3023	DRD2
@@ -3732,14 +4303,20 @@ MESH	D017464	Receptors, Complement 3d	HGNC	2336	CR2
 MESH	D017476	Receptors, Neuropeptide Y	FPLX	NPYR	NPYR
 MESH	D017479	Receptors, Platelet-Derived Growth Factor	FPLX	PDGFR	PDGFR
 MESH	D017485	1-Deoxynojirimycin	CHEBI	CHEBI:44369	duvoglustat
+MESH	D017486	Acneiform Eruptions	DOID	DOID:4399	acneiform dermatitis
+MESH	D017492	Keratosis, Seborrheic	HP	HP:0031287	Seborrheic keratosis
 MESH	D017493	Leukocyte Common Antigens	HGNC	9666	PTPRC
+MESH	D017499	Porokeratosis	DOID	DOID:3805	porokeratosis
 MESH	D017510	Protein Folding	GO	GO:0006457	protein folding
+MESH	D017511	Pyoderma Gangrenosum	HP	HP:0025452	Pyoderma gangrenosum
 MESH	D017526	Receptor, IGF Type 1	HGNC	5465	IGF1R
 MESH	D017527	Receptor, IGF Type 2	HGNC	5467	IGF2R
+MESH	D017541	Aneurysm, False	HP	HP:0031625	Pseudoaneurysm
 MESH	D017556	Technetium Compounds	CHEBI	CHEBI:26865	technetium molecular entity
 MESH	D017572	Leukotriene A4	CHEBI	CHEBI:15651	leukotriene A4
 MESH	D017576	Daptomycin	CHEBI	CHEBI:600103	daptomycin
 MESH	D017578	Immunoglobulin Class Switching	GO	GO:0045190	isotype switching
+MESH	D017588	Hyperandrogenism	EFO	0009006	hyperandrogenism
 MESH	D017605	Bromine Compounds	CHEBI	CHEBI:22928	bromine molecular entity
 MESH	D017607	Aluminum Compounds	CHEBI	CHEBI:33620	aluminium molecular entity
 MESH	D017608	Chromium Compounds	CHEBI	CHEBI:23237	chromium molecular entity
@@ -3761,15 +4338,23 @@ MESH	D017655	Silicon Compounds	CHEBI	CHEBI:26677	silicon molecular entity
 MESH	D017663	Peplomycin	CHEBI	CHEBI:135909	peplomycin
 MESH	D017665	Hydroxyl Radical	CHEBI	CHEBI:29191	hydroxyl
 MESH	D017666	Deuterium Oxide	CHEBI	CHEBI:41981	dideuterium oxide
+MESH	D017668	Age of Onset	EFO	0004847	age at onset
 MESH	D017669	Mercury Compounds	CHEBI	CHEBI:25196	mercury molecular entity
 MESH	D017670	Sodium Compounds	CHEBI	CHEBI:26712	sodium molecular entity
 MESH	D017671	Platinum Compounds	CHEBI	CHEBI:33749	platinum molecular entity
 MESH	D017672	Nitrogen Compounds	CHEBI	CHEBI:51143	nitrogen molecular entity
 MESH	D017673	Sodium Chloride, Dietary	CHEBI	CHEBI:26710	sodium chloride
+MESH	D017676	Lichen Planus, Oral	EFO	0008517	oral lichen planus
+MESH	D017681	Hypereosinophilic Syndrome	DOID	DOID:396	Loeffler endocarditis
+MESH	D017689	Polydactyly	HP	HP:0100259	Postaxial polydactyly
 MESH	D017693	Sodium Bicarbonate	CHEBI	CHEBI:32139	sodium hydrogencarbonate
+MESH	D017701	Reticulocyte Count	EFO	0007986	reticulocyte count
 MESH	D017705	Lignans	CHEBI	CHEBI:25036	lignan
 MESH	D017706	Lisinopril	CHEBI	CHEBI:6503	lisinopril dihydrate
+MESH	D017728	Lymphoma, Large-Cell, Anaplastic	DOID	DOID:0050744	anaplastic large cell lymphoma
 MESH	D017730	Ki-1 Antigen	HGNC	11923	TNFRSF8
+MESH	D017731	Lymphomatoid Papulosis	EFO	1000341	Lymphomatoid Papulosis
+MESH	D017733	Leukoplakia, Hairy	HP	HP:0025126	Oral hairy leukoplakia
 MESH	D017735	Virus Latency	GO	GO:0019042	viral latency
 MESH	D017738	Alkanesulfonic Acids	CHEBI	CHEBI:47901	alkanesulfonic acid
 MESH	D017739	Arylsulfonic Acids	CHEBI	CHEBI:33555	arenesulfonic acid
@@ -3780,8 +4365,10 @@ MESH	D017835	Nedocromil	CHEBI	CHEBI:7492	nedocromil
 MESH	D017868	Cyclic AMP-Dependent Protein Kinases	FPLX	PKA	PKA
 MESH	D017869	Cyclic GMP-Dependent Protein Kinases	FPLX	PRKG	PRKG
 MESH	D017878	4,4'-Diisothiocyanostilbene-2,2'-Disulfonic Acid	CHEBI	CHEBI:4286	4,4'-diisothiocyano-trans-stilbene-2,2'-disulfonic acid
+MESH	D017887	Ossification of Posterior Longitudinal Ligament	EFO	0005895	ossification of the posterior longitudinal ligament of the spine
 MESH	D017892	Osmium Compounds	CHEBI	CHEBI:35732	osmium molecular entity
 MESH	D017895	Manganese Compounds	CHEBI	CHEBI:25154	manganese molecular entity
+MESH	D017952	Ganglia, Invertebrate	EFO	0000890	invertebrate ganglion
 MESH	D017963	Azithromycin	CHEBI	CHEBI:2955	azithromycin
 MESH	D017964	Itraconazole	CHEBI	CHEBI:6076	itraconazole
 MESH	D017967	Zinc Compounds	CHEBI	CHEBI:27364	zinc molecular entity
@@ -3812,6 +4399,7 @@ MESH	D018042	Receptors, Neurokinin-3	HGNC	11528	TACR3
 MESH	D018043	Receptors, Corticotropin	HGNC	6930	MC2R
 MESH	D018046	Protein C Inhibitor	HGNC	8723	SERPINA5
 MESH	D018054	Hydrobromic Acid	CHEBI	CHEBI:47266	hydrogen bromide
+MESH	D018058	Tympanic Membrane Perforation	EFO	0009472	tympanic membrane perforation
 MESH	D018078	Receptors, Prostaglandin E	FPLX	PTGER	PTGER
 MESH	D018079	Receptors, GABA	FPLX	GABR	GABR
 MESH	D018087	Plastids	GO	GO:0009536	plastid
@@ -3827,6 +4415,7 @@ MESH	D018125	Receptors, Transforming Growth Factor beta	FPLX	TGFBR	TGFBR
 MESH	D018127	Tumor Necrosis Factor Receptor Superfamily, Member 7	HGNC	11922	CD27
 MESH	D018129	Phosphatidylinositol Phosphates	CHEBI	CHEBI:28765	phosphatidylinositol phosphate
 MESH	D018130	Diamond	CHEBI	CHEBI:33417	diamond
+MESH	D018149	Glucose Intolerance	HP	HP:0001952	Glucose intolerance
 MESH	D018161	Receptors, Mineralocorticoid	HGNC	7979	NR3C2
 MESH	D018167	Receptors, Calcitriol	HGNC	12679	VDR
 MESH	D018168	Receptors, Retinoic Acid	FPLX	RAR	RAR
@@ -3834,20 +4423,47 @@ MESH	D018170	Sumatriptan	CHEBI	CHEBI:10650	sumatriptan
 MESH	D018171	Agrin	HGNC	329	AGRN
 MESH	D018179	Receptors, Thrombin	HGNC	3537	F2R
 MESH	D018180	Thrombomodulin	HGNC	11784	THBD
+MESH	D018207	Angiomyolipoma	HP	HP:0006772	Renal angiomyolipoma
+MESH	D018208	Liposarcoma, Myxoid	DOID	DOID:5709	mixed-type liposarcoma
+MESH	D018215	Osteoblastoma	EFO	1000410	Osteoblastoma
+MESH	D018222	Fibromatosis, Aggressive	EFO	0009907	Desmoid-type fibromatosis
+MESH	D018226	Fibroadenoma	EFO	1000254	Fibroadenoma
+MESH	D018233	Rhabdomyosarcoma, Embryonal	DOID	DOID:3255	botryoid rhabdomyosarcoma
+MESH	D018236	Carcinoma, Embryonal	DOID	DOID:5681	ovarian embryonal carcinoma
+MESH	D018237	Germinoma	EFO	1000352	Malignant Germ Cell Tumor
+MESH	D018240	Endodermal Sinus Tumor	EFO	1000566	Testicular Germ Cell Tumor
+MESH	D018241	Neuroectodermal Tumors, Primitive, Peripheral	HP	HP:0006717	Peripheral neuroepithelioma
+MESH	D018253	Adenoma, Villous	DOID	DOID:0050869	villous adenoma
 MESH	D018260	Gelsolin	HGNC	4620	GSN
+MESH	D018262	Adenocarcinoma, Clear Cell	EFO	0006719	mesonephric adenocarcinoma
+MESH	D018263	Adenocarcinoma, Follicular	DOID	DOID:0080524	thyroid gland adenocarcinoma
+MESH	D018266	Adenocarcinoma, Sebaceous	DOID	DOID:4840	sebaceous carcinoma
+MESH	D018268	Adrenocortical Carcinoma	DOID	DOID:3959	adrenal cortical adenocarcinoma
+MESH	D018269	Carcinoma, Endometrioid	DOID	DOID:2871	endometrial carcinoma
 MESH	D018271	Signal Recognition Particle	GO	GO:0048500	signal recognition particle
+MESH	D018275	Carcinoma, Lobular	DOID	DOID:0050938	breast lobular carcinoma
+MESH	D018290	Cervical Intraepithelial Neoplasia	HP	HP:0032242	Cervical intraepithelial neoplasia
+MESH	D018293	Cystadenoma, Serous	DOID	DOID:5746	ovarian serous cystadenocarcinoma
+MESH	D018296	Pilomatrixoma	EFO	0009082	Pilomatrixoma
+MESH	D018312	Sex Cord-Gonadal Stromal Tumors	DOID	DOID:192	sex cord-gonadal stromal tumor
+MESH	D018319	Neurofibrosarcoma	DOID	DOID:8353	epithelioid malignant peripheral nerve sheath tumor
 MESH	D018336	Receptors, Aryl Hydrocarbon	HGNC	348	AHR
 MESH	D018342	Receptors, Adrenergic, beta-1	HGNC	285	ADRB1
 MESH	D018343	Receptors, Adrenergic, beta-2	HGNC	286	ADRB2
 MESH	D018350	alpha-Amino-3-hydroxy-5-methyl-4-isoxazolepropionic Acid	CHEBI	CHEBI:28812	(aminomethyl)phosphonic acid
+MESH	D018366	Vasculitis, Leukocytoclastic, Cutaneous	DOID	DOID:11450	allergic cutaneous vasculitis
 MESH	D018373	Peripheral Nervous System Agents	CHEBI	CHEBI:49110	peripheral nervous system drug
 MESH	D018375	Neutrophil Activation	GO	GO:0042119	neutrophil activation
 MESH	D018377	Neurotransmitter Agents	CHEBI	CHEBI:35942	neurotransmitter agent
+MESH	D018384	Oxidative Stress	HP	HP:0025464	Increased reactive oxygen species production
 MESH	D018385	Centrosome	GO	GO:0005813	centrosome
 MESH	D018386	Kinetochores	GO	GO:0000776	kinetochore
 MESH	D018392	Genomic Imprinting	GO	GO:0071514	genetic imprinting
 MESH	D018394	CA-125 Antigen	HGNC	15582	MUC16
 MESH	D018396	Mucin-1	HGNC	7508	MUC1
+MESH	D018442	Lymphoma, B-Cell, Marginal Zone	DOID	DOID:0050909	MALT lymphoma
+MESH	D018451	Homosexuality, Male	EFO	0008486	male homosexuality
+MESH	D018459	Lichen Sclerosus et Atrophicus	DOID	DOID:8574	lichen disease
 MESH	D018490	Serotonin Agents	CHEBI	CHEBI:48278	serotonergic drug
 MESH	D018491	Dopamine Agonists	CHEBI	CHEBI:51065	dopamine agonist
 MESH	D018492	Dopamine Antagonists	CHEBI	CHEBI:48561	dopaminergic antagonist
@@ -3855,6 +4471,8 @@ MESH	D018494	Histamine Agents	CHEBI	CHEBI:37957	histaminergic drug
 MESH	D018522	Gravitropism	GO	GO:0009630	gravitropism
 MESH	D018523	Tropism	GO	GO:0009606	tropism
 MESH	D018524	Phototropism	GO	GO:0009638	phototropism
+MESH	D018566	Pregnancy, High-Risk	EFO	0009573	high-risk pregnancy
+MESH	D018633	Pulmonary Atresia	HP	HP:0004935	Pulmonary artery atresia
 MESH	D018663	Adrenergic Agents	CHEBI	CHEBI:37962	adrenergic agent
 MESH	D018664	Interleukin-12	FPLX	IL12	IL12
 MESH	D018674	Adrenergic Antagonists	CHEBI	CHEBI:37887	adrenergic antagonist
@@ -3884,6 +4502,7 @@ MESH	D018757	GABA Modulators	CHEBI	CHEBI:50268	GABA modulator
 MESH	D018759	Adrenergic Uptake Inhibitors	CHEBI	CHEBI:35640	adrenergic uptake inhibitor
 MESH	D018765	Dopamine Uptake Inhibitors	CHEBI	CHEBI:51039	dopamine uptake inhibitor
 MESH	D018793	Interleukin-13	HGNC	5973	IL13
+MESH	D018798	Anemia, Iron-Deficiency	DOID	DOID:11758	iron deficiency anemia
 MESH	D018799	Intercellular Adhesion Molecule-1	HGNC	5344	ICAM1
 MESH	D018800	Thy-1 Antigens	HGNC	11801	THY1
 MESH	D018808	Transcription Factor AP-1	FPLX	AP1	AP1
@@ -3900,6 +4519,8 @@ MESH	D018835	Chaperonin 10	HGNC	5269	HSPE1
 MESH	D018840	HSP70 Heat-Shock Proteins	FPLX	HSPA	HSPA
 MESH	D018870	Endoplasmic Reticulum, Rough	GO	GO:0005791	rough endoplasmic reticulum
 MESH	D018871	Endoplasmic Reticulum, Smooth	GO	GO:0005790	smooth endoplasmic reticulum
+MESH	D018879	Ventricular Premature Complexes	EFO	0009276	ventricular ectopy
+MESH	D018880	Atrial Premature Complexes	EFO	0009277	supraventricular ectopy
 MESH	D018919	Neovascularization, Physiologic	GO	GO:0001525	angiogenesis
 MESH	D018925	Chemokines	FPLX	Chemokine	Chemokine
 MESH	D018926	Anti-Allergic Agents	CHEBI	CHEBI:50857	anti-allergic agent
@@ -3946,6 +4567,7 @@ MESH	D019108	Tight Junctions	GO	GO:0070160	tight junction
 MESH	D019154	Protein Splicing	GO	GO:0030908	protein splicing
 MESH	D019158	N-Acetylneuraminic Acid	CHEBI	CHEBI:26667	sialic acid
 MESH	D019163	Reducing Agents	CHEBI	CHEBI:63247	reducing agent
+MESH	D019169	Jurkat Cells	EFO	0002796	Jurkat
 MESH	D019175	DNA Methylation	GO	GO:0006306	DNA methylation
 MESH	D019187	Cadmium Compounds	CHEBI	CHEBI:22978	cadmium molecular entity
 MESH	D019204	GTP-Binding Proteins	FPLX	G_protein	G_protein
@@ -3965,7 +4587,9 @@ MESH	D019272	Leukocyte Elastase	HGNC	3309	ELANE
 MESH	D019274	Botulinum Toxins, Type A	CHEBI	CHEBI:3160	Botulinum toxin type A
 MESH	D019275	Radiopharmaceuticals	CHEBI	CHEBI:35232	radiopharmaceutical
 MESH	D019276	Glycocalyx	GO	GO:0030112	glycocalyx
+MESH	D019283	Pancreatitis, Acute Necrotizing	DOID	DOID:2913	acute pancreatitis
 MESH	D019284	Thapsigargin	CHEBI	CHEBI:9516	thapsigargin
+MESH	D019288	Herpesvirus 8, Human	EFO	0002612	human herpesvirus 8 infection
 MESH	D019290	Megestrol Acetate	CHEBI	CHEBI:6723	megestrol acetate
 MESH	D019297	2,4-Dinitrophenol	CHEBI	CHEBI:42017	2,4-dinitrophenol
 MESH	D019301	Oleic Acid	CHEBI	CHEBI:16196	oleic acid
@@ -4001,12 +4625,20 @@ MESH	D019405	Cytochrome P-450 CYP11B2	HGNC	2592	CYP11B2
 MESH	D019408	Platelet Endothelial Cell Adhesion Molecule-1	HGNC	8823	PECAM1
 MESH	D019409	Interleukin-15	HGNC	5977	IL15
 MESH	D019410	Interleukin-16	HGNC	5980	IL16
+MESH	D019411	Clinical Laboratory Techniques	EFO	0004297	clinical laboratory measurement
 MESH	D019422	Dietary Sucrose	CHEBI	CHEBI:17992	sucrose
 MESH	D019438	Ritonavir	CHEBI	CHEBI:45409	ritonavir
 MESH	D019457	Chromosome Breakage	GO	GO:0031052	chromosome breakage
 MESH	D019469	Indinavir	CHEBI	CHEBI:44032	indinavir
+MESH	D019522	Vaginal Discharge	EFO	0009365	vaginal discharge
+MESH	D019572	Retinal Neoplasms	EFO	1000509	Retinal Neoplasm
+MESH	D019584	Hot Flashes	HP	HP:0031217	Hot flashes
+MESH	D019591	Pseudophakia	HP	HP:0500081	Pseudophakia
+MESH	D019595	Severe Dengue	DOID	DOID:12206	dengue hemorrhagic fever
 MESH	D019599	Mossy Fibers, Hippocampal	GO	GO:0097457	hippocampal mossy fiber
 MESH	D019606	Phosphoamino Acids	CHEBI	CHEBI:26051	phosphoamino acid
+MESH	D019636	Neurodegenerative Diseases	DOID	DOID:1443	cerebral degeneration
+MESH	D019644	Arthroplasty, Replacement, Hip	EFO	0009806	total hip arthroplasty
 MESH	D019679	Kininogen, High-Molecular-Weight	HGNC	6383	KNG1
 MESH	D019695	Glycyrrhizic Acid	CHEBI	CHEBI:15939	glycyrrhizinic acid
 MESH	D019699	Thrombospondins	FPLX	THBS	THBS
@@ -4046,6 +4678,7 @@ MESH	D019825	gamma-MSH	CHEBI	CHEBI:80349	gamma-Melanotropin
 MESH	D019829	Nevirapine	CHEBI	CHEBI:63613	nevirapine
 MESH	D019830	Adenosine-5'-(N-ethylcarboxamide)	CHEBI	CHEBI:73284	N-ethyl-5'-carboxamidoadenosine
 MESH	D019832	N-Methylscopolamine	CHEBI	CHEBI:135361	methscopolamine
+MESH	D019838	Neck Injuries	EFO	0009476	neck injury
 MESH	D019840	2-Propanol	CHEBI	CHEBI:17824	propan-2-ol
 MESH	D019850	Heptanol	CHEBI	CHEBI:43003	1-heptanol
 MESH	D019852	Diacylglycerol Kinase	FPLX	DGK	DGK
@@ -4072,12 +4705,14 @@ MESH	D019947	Receptors, Interleukin-6	HGNC	6019	IL6R
 MESH	D019948	Receptors, Interleukin-4	HGNC	6015	IL4R
 MESH	D019950	Mitogen-Activated Protein Kinase 1	HGNC	6871	MAPK1
 MESH	D019951	DNA Polymerase beta	HGNC	9174	POLB
+MESH	D019966	Substance-Related Disorders	DOID	DOID:9974	drug dependence
 MESH	D019980	Amoxicillin-Potassium Clavulanate Combination	CHEBI	CHEBI:2677	Augmentin
 MESH	D020001	1-Butanol	CHEBI	CHEBI:28885	butan-1-ol
 MESH	D020002	tert-Butyl Alcohol	CHEBI	CHEBI:45895	tert-butanol
 MESH	D020003	1-Octanol	CHEBI	CHEBI:16188	octan-1-ol
 MESH	D020008	Delavirdine	CHEBI	CHEBI:119573	delavirdine
 MESH	D020011	Protective Agents	CHEBI	CHEBI:50267	protective agent
+MESH	D020018	Sexual Dysfunctions, Psychological	DOID	DOID:10132	psychosexual disorder
 MESH	D020024	Leukotriene Antagonists	CHEBI	CHEBI:49159	leukotriene antagonist
 MESH	D020030	Nitric Oxide Donors	CHEBI	CHEBI:50566	nitric oxide donor
 MESH	D020032	Tyrphostins	CHEBI	CHEBI:38637	tyrosine kinase inhibitor
@@ -4085,6 +4720,7 @@ MESH	D020051	N-Acetylgalactosamine-4-Sulfatase	HGNC	714	ARSB
 MESH	D020058	Styrene	CHEBI	CHEBI:27452	styrene
 MESH	D020059	Cathepsin E	HGNC	2530	CTSE
 MESH	D020090	Chromosome Segregation	GO	GO:0007059	chromosome segregation
+MESH	D020096	Zygomycosis	DOID	DOID:8485	mucormycosis
 MESH	D020098	Natriuretic Peptide, C-Type	HGNC	7941	NPPC
 MESH	D020101	Acrosome Reaction	GO	GO:0007340	acrosome reaction
 MESH	D020105	Milrinone	CHEBI	CHEBI:50693	milrinone
@@ -4104,22 +4740,40 @@ MESH	D020123	Sirolimus	CHEBI	CHEBI:9168	sirolimus
 MESH	D020126	Brefeldin A	CHEBI	CHEBI:48080	brefeldin A
 MESH	D020135	Peptide Nucleic Acids	CHEBI	CHEBI:48021	peptide nucleic acid
 MESH	D020155	3-Hydroxybutyric Acid	CHEBI	CHEBI:20067	3-hydroxybutyric acid
+MESH	D020159	Citrullinemia	HP	HP:0032397	Citrullinuria
+MESH	D020162	Hyperargininemia	HP	HP:0500153	Hyperargininemia
 MESH	D020168	ATP Binding Cassette Transporter, Subfamily B, Member 1	HGNC	40	ABCB1
 MESH	D020169	Caspases	FPLX	Caspase	Caspase
 MESH	D020170	Caspase 1	HGNC	1499	CASP1
+MESH	D020176	Tyrosinemias	HP	HP:0003231	Hypertyrosinemia
+MESH	D020182	Sleep Apnea, Central	DOID	DOID:0060731	congenital central hypoventilation syndrome
+MESH	D020188	Sleep Paralysis	HP	HP:0025233	Sleep paralysis
+MESH	D020237	Alexia, Pure	DOID	DOID:0060156	visual verbal agnosia
 MESH	D020245	p-Chloromercuribenzoic Acid	CHEBI	CHEBI:28420	p-chloromercuribenzoic acid
+MESH	D020246	Venous Thrombosis	EFO	0003907	deep vein thrombosis
+MESH	D020277	Polyradiculoneuropathy, Chronic Inflammatory Demyelinating	EFO	0009538	chronic inflammatory demyelinating polyneuropathy
 MESH	D020280	Sertraline	CHEBI	CHEBI:9123	sertraline
+MESH	D020288	Papilloma, Choroid Plexus	EFO	1000177	Choroid Plexus Papilloma
+MESH	D020315	Latex Hypersensitivity	DOID	DOID:0060532	latex allergy
+MESH	D020323	Tics	HP	HP:0100033	Tics
 MESH	D020358	Sodium Cholate	CHEBI	CHEBI:26711	sodium cholate
 MESH	D020366	Methylmethacrylate	CHEBI	CHEBI:34840	methyl methacrylate
 MESH	D020372	Dexfenfluramine	CHEBI	CHEBI:439329	(S)-fenfluramine
 MESH	D020381	Interleukin-17	HGNC	5981	IL17A
 MESH	D020382	Interleukin-18	HGNC	5986	IL18
 MESH	D020383	Neutral Glycosphingolipids	CHEBI	CHEBI:25513	neutral glycosphingolipid
+MESH	D020385	Myokymia	EFO	1001897	Morvan syndrome
+MESH	D020386	Isaacs Syndrome	DOID	DOID:963	episodic ataxia
 MESH	D020395	Receptors, Interleukin-7	HGNC	6024	IL7R
 MESH	D020404	Glycerophospholipids	CHEBI	CHEBI:37739	glycerophospholipid
 MESH	D020410	Activated-Leukocyte Cell Adhesion Molecule	HGNC	400	ALCAM
+MESH	D020422	Mononeuropathies	HP	HP:0032018	Multiple mononeuropathy
+MESH	D020433	Trigeminal Nerve Diseases	DOID	DOID:561	trigeminal nerve disease
+MESH	D020435	Glossopharyngeal Nerve Diseases	DOID	DOID:3418	glossopharyngeal nerve disease
 MESH	D020439	Growth Cones	GO	GO:0030426	growth cone
+MESH	D020447	Parasomnias	HP	HP:0025234	Parasomnia
 MESH	D020460	Melanosomes	GO	GO:0042470	melanosome
+MESH	D020521	Stroke	HP	HP:0002140	Ischemic stroke
 MESH	D020524	Thylakoids	GO	GO:0009579	thylakoid
 MESH	D020533	Angiogenesis Inhibitors	CHEBI	CHEBI:48422	angiogenesis inhibitor
 MESH	D020537	RNA, Small Nucleolar	CHEBI	CHEBI:133334	small nucleolar RNA
@@ -4140,20 +4794,23 @@ MESH	D020735	Guanine Nucleotide-Releasing Factor 2	HGNC	4568	RAPGEF1
 MESH	D020738	Leptin	HGNC	6553	LEP
 MESH	D020742	rhoA GTP-Binding Protein	HGNC	667	RHOA
 MESH	D020748	Mibefradil	CHEBI	CHEBI:6920	Mibefradil
+MESH	D020751	Alcohol-Induced Disorders	DOID	DOID:0050741	alcohol dependence
 MESH	D020764	cdc42 GTP-Binding Protein	HGNC	1736	CDC42
+MESH	D020767	Intracranial Thrombosis	HP	HP:0005305	Cerebral venous thrombosis
 MESH	D020778	Matrix Metalloproteinase 2	HGNC	7166	MMP2
 MESH	D020780	Matrix Metalloproteinase 9	HGNC	7176	MMP9
 MESH	D020781	Matrix Metalloproteinase 1	HGNC	7155	MMP1
 MESH	D020782	Matrix Metalloproteinases	FPLX	MMP	MMP
 MESH	D020783	Matrix Metalloproteinase 7	HGNC	7174	MMP7
 MESH	D020789	Cathepsin C	HGNC	2528	CTSC
-MESH	D020794	Receptor Protein-Tyrosine Kinases	HGNC	8031	NTRK1
 MESH	D020796	Receptor, Platelet-Derived Growth Factor alpha	HGNC	8803	PDGFRA
 MESH	D020797	Receptor, Platelet-Derived Growth Factor beta	HGNC	8804	PDGFRB
 MESH	D020800	Receptor, Nerve Growth Factor	HGNC	7809	NGFR
 MESH	D020801	Receptor, Ciliary Neurotrophic Factor	HGNC	2170	CNTFR
+MESH	D020803	Encephalitis, Herpes Simplex	HP	HP:0020098	Herpes encephalitis
 MESH	D020812	Receptor, trkC	HGNC	8033	NTRK3
 MESH	D020813	Receptor, trkB	HGNC	8032	NTRK2
+MESH	D020821	Dystonic Disorders	DOID	DOID:0090056	dystonia 12
 MESH	D020823	ADP-Ribosylation Factor 1	HGNC	652	ARF1
 MESH	D020830	rac1 GTP-Binding Protein	HGNC	9801	RAC1
 MESH	D020837	SOS1 Protein	HGNC	11187	SOS1
@@ -4178,6 +4835,7 @@ MESH	D020910	Ketorolac	CHEBI	CHEBI:6129	ketorolac
 MESH	D020911	Ketorolac Tromethamine	CHEBI	CHEBI:6130	ketorolac tromethamine
 MESH	D020912	Moclobemide	CHEBI	CHEBI:83531	moclobemide
 MESH	D020913	Perindopril	CHEBI	CHEBI:8024	perindopril
+MESH	D020915	Korsakoff Syndrome	EFO	1001242	Wernicke-Korsakoff syndrome
 MESH	D020917	Receptor, trkA	HGNC	8031	NTRK1
 MESH	D020926	Medetomidine	CHEBI	CHEBI:48552	medetomidine
 MESH	D020927	Dexmedetomidine	CHEBI	CHEBI:4466	dexmedetomidine
@@ -4188,6 +4846,9 @@ MESH	D020933	Neurotrophin 3	HGNC	8023	NTF3
 MESH	D020934	Ciliary Neurotrophic Factor	HGNC	2169	CNTF
 MESH	D020947	Tea Tree Oil	CHEBI	CHEBI:83629	tea tree oil
 MESH	D020959	Polyethylene	CHEBI	CHEBI:53227	poly(ethylene)
+MESH	D021181	Egg Hypersensitivity	HP	HP:0410328	Egg allergy
+MESH	D021184	Nut Hypersensitivity	HP	HP:0410331	Nut food product allergy
+MESH	D021362	Palate, Hard	DOID	DOID:9149	hard palate cancer
 MESH	D021381	Protein Transport	GO	GO:0015031	protein transport
 MESH	D021581	Active Transport, Cell Nucleus	GO	GO:0051169	nuclear transport
 MESH	D021601	trans-Golgi Network	GO	GO:0005802	trans-Golgi network
@@ -4215,11 +4876,15 @@ MESH	D023082	Defensins	CHEBI	CHEBI:82761	defensin
 MESH	D023102	Anoikis	GO	GO:0043276	anoikis
 MESH	D023201	CD40 Ligand	HGNC	11935	CD40LG
 MESH	D023303	Oxazolidinones	CHEBI	CHEBI:55374	oxazolidinone
+MESH	D023341	Chills	HP	HP:0025143	Chills
+MESH	D023461	Myeloid Progenitor Cells	EFO	0009242	Myeloid Progenitor Cell Count
 MESH	D023581	HIV Fusion Inhibitors	CHEBI	CHEBI:59886	HIV fusion inhibitor
 MESH	D023902	Chromosome Pairing	GO	GO:0007129	synapsis
+MESH	D023981	Sarcoma, Myeloid	EFO	1000286	Granulocytic Sarcoma
 MESH	D024042	Collagen Type I	FPLX	COL1	COL1
 MESH	D024062	Collagen Type V	FPLX	COL5	COL5
 MESH	D024141	Collagen Type IV	FPLX	COL4	COL4
+MESH	D024182	Uniparental Disomy	HP	HP:0032382	Uniparental disomy
 MESH	D024241	HMGN1 Protein	HGNC	4984	HMGN1
 MESH	D024242	HMGN2 Protein	HGNC	4986	HMGN2
 MESH	D024243	HMGB1 Protein	HGNC	4983	HMGB1
@@ -4277,24 +4942,32 @@ MESH	D026601	Protein D-Aspartate-L-Isoaspartate Methyltransferase	HGNC	8728	PCMT
 MESH	D026941	Sodium Channel Blockers	CHEBI	CHEBI:38633	sodium channel blocker
 MESH	D027201	Cationic Amino Acid Transporter 1	HGNC	11057	SLC7A1
 MESH	D027202	Cationic Amino Acid Transporter 2	HGNC	11060	SLC7A2
-MESH	D027261	Fusion Regulatory Protein-1	HGNC	10776	SFRP1
 MESH	D027283	Large Neutral Amino Acid-Transporter 1	HGNC	11063	SLC7A5
 MESH	D027341	Excitatory Amino Acid Transporter 1	HGNC	10941	SLC1A3
 MESH	D027342	Excitatory Amino Acid Transporter 2	HGNC	10940	SLC1A2
 MESH	D027362	Organic Anion Transport Protein 1	HGNC	10970	SLC22A6
 MESH	D027381	Liver-Specific Organic Anion Transporter 1	HGNC	10959	SLCO1B1
+MESH	D027582	Humulus	DOID	DOID:0110914	infantile hypophosphatasia
 MESH	D027702	Organic Cation Transporter 1	HGNC	10963	SLC22A1
 MESH	D027982	Sodium-Bicarbonate Symporters	HGNC	11030	SLC4A4
+MESH	D028227	Amyloid Neuropathies, Familial	DOID	DOID:0050761	paramyloidosis
 MESH	D028341	Activins	FPLX	Activin	Activin
 MESH	D028421	Isoprostanes	CHEBI	CHEBI:138408	isoprostane
 MESH	D028441	F2-Isoprostanes	CHEBI	CHEBI:142058	F2-isoprostane
 MESH	D028561	Transition Elements	CHEBI	CHEBI:27081	transition element atom
 MESH	D028581	Lanthanoid Series Elements	CHEBI	CHEBI:33319	lanthanoid atom
+MESH	D029424	Pulmonary Disease, Chronic Obstructive	DOID	DOID:234	colon adenocarcinoma
+MESH	D029481	Bronchitis, Chronic	EFO	0006505	chronic bronchitis
 MESH	D029563	Cellular Apoptosis Susceptibility Protein	HGNC	2431	CSE1L
+MESH	D029597	Romano-Ward Syndrome	DOID	DOID:0110644	long QT syndrome 1
+MESH	D030361	Papillomavirus Infections	EFO	0001668	human papilloma virus infection
 MESH	D030421	Peroxynitrous Acid	CHEBI	CHEBI:25942	peroxynitrous acid
 MESH	D030741	Carbonic Anhydrase IV	HGNC	1375	CA4
 MESH	D030762	Estrous Cycle	GO	GO:0044849	estrous cycle
+MESH	D031249	Erdheim-Chester Disease	HP	HP:0040139	Lipogranulomatosis
+MESH	D031300	Retinal Vasculitis	HP	HP:0025188	Retinal vasculitis
 MESH	D032961	Sperm Midpiece	GO	GO:0097225	sperm midpiece
+MESH	D033461	Hyperuricemia	EFO	0009104	hyperuricemia
 MESH	D033721	Equilibrative Nucleoside Transporter 1	HGNC	11003	SLC29A1
 MESH	D033741	Adenine Nucleotide Translocator 1	HGNC	10990	SLC25A4
 MESH	D033742	Adenine Nucleotide Translocator 2	HGNC	10991	SLC25A5
@@ -4309,6 +4982,7 @@ MESH	D034281	Dynamins	FPLX	DNM	DNM
 MESH	D034284	Dynamin I	HGNC	2972	DNM1
 MESH	D034285	Dynamin II	HGNC	2974	DNM2
 MESH	D034286	Dynamin III	HGNC	29125	DNM3
+MESH	D034321	Hyperamylasemia	HP	HP:0410288	Hyperamylasemia
 MESH	D034443	RNA Transport	GO	GO:0050658	RNA transport
 MESH	D034461	Luteinization	GO	GO:0001553	luteinization
 MESH	D034482	Heterogeneous-Nuclear Ribonucleoprotein Group C	HGNC	5035	HNRNPC
@@ -4316,9 +4990,11 @@ MESH	D034502	Heterogeneous-Nuclear Ribonucleoprotein D	HGNC	5036	HNRNPD
 MESH	D034622	RNA Interference	GO	GO:0016246	RNA interference
 MESH	D034641	Heterogeneous-Nuclear Ribonucleoprotein K	HGNC	5044	HNRNPK
 MESH	D034664	Heterogeneous-Nuclear Ribonucleoprotein L	HGNC	5045	HNRNPL
+MESH	D034701	Mastocytosis, Cutaneous	DOID	DOID:1751	malignant conjunctival melanoma
 MESH	D034702	RNA-Binding Protein FUS	HGNC	4010	FUS
 MESH	D034722	Heterogeneous-Nuclear Ribonucleoprotein U	HGNC	5048	HNRNPU
 MESH	D034761	Heterogeneous-Nuclear Ribonucleoprotein Group M	HGNC	5046	HNRNPM
+MESH	D034801	Mastocytoma	DOID	DOID:3664	mast cell neoplasm
 MESH	D034802	RNA-Binding Protein EWS	HGNC	3508	EWSR1
 MESH	D034881	Nuclear Lamina	GO	GO:0005652	nuclear lamina
 MESH	D035181	TATA-Box Binding Protein	HGNC	11588	TBP
@@ -4409,7 +5085,10 @@ MESH	D040281	Vascular Endothelial Growth Factor Receptor-1	HGNC	3763	FLT1
 MESH	D040301	Vascular Endothelial Growth Factor Receptor-2	HGNC	6307	KDR
 MESH	D040321	Vascular Endothelial Growth Factor Receptor-3	HGNC	3767	FLT4
 MESH	D040501	Calgranulin A	HGNC	10498	S100A8
+MESH	D040701	Stress Disorders, Traumatic, Acute	DOID	DOID:6088	acute stress disorder
 MESH	D040881	CD11a Antigen	HGNC	6148	ITGAL
+MESH	D040921	Stress Disorders, Traumatic	DOID	DOID:6088	acute stress disorder
+MESH	D041721	3T3-L1 Cells	EFO	0001084	3T3-L1
 MESH	D042003	DNA Packaging	GO	GO:0006323	DNA packaging
 MESH	D042561	Vascular Endothelial Growth Factor B	HGNC	12681	VEGFB
 MESH	D042582	Vascular Endothelial Growth Factor C	HGNC	12682	VEGFC
@@ -4478,6 +5157,7 @@ MESH	D044388	GTP-Binding Protein gamma Subunits	FPLX	G_gamma	G_gamma
 MESH	D044463	Receptor, PAR-1	HGNC	3537	F2R
 MESH	D044502	Thymine DNA Glycosylase	HGNC	11700	TDG
 MESH	D044503	5-Methylcytosine	CHEBI	CHEBI:27551	5-methylcytosine
+MESH	D044542	LEOPARD Syndrome	DOID	DOID:0080548	LEOPARD syndrome 1
 MESH	D044603	Cellulosomes	GO	GO:0043263	cellulosome
 MESH	D044763	Ubiquitin-Conjugating Enzymes	FPLX	UBE2	UBE2
 MESH	D044764	Ubiquitin-Activating Enzymes	HGNC	12469	UBA1
@@ -4512,13 +5192,13 @@ MESH	D045728	Corrinoids	CHEBI	CHEBI:33913	corrinoid
 MESH	D045782	Hemiterpenes	CHEBI	CHEBI:35188	hemiterpene
 MESH	D046148	Donor Selection	GO	GO:0007535	donor selection
 MESH	D046249	Transfer RNA Aminoacylation	GO	GO:0043039	tRNA aminoacylation
+MESH	D046768	Nesidioblastosis	HP	HP:0000825	Hyperinsulinemic hypoglycemia
 MESH	D046934	Ginkgolides	CHEBI	CHEBI:136909	ginkgolide
 MESH	D046988	Proteasome Endopeptidase Complex	FPLX	Proteasome	Proteasome
 MESH	D047068	Arylalkylamine N-Acetyltransferase	HGNC	19	AANAT
 MESH	D047069	Pyrazolones	CHEBI	CHEBI:83328	pyrazolone
 MESH	D047072	Aromatase Inhibitors	CHEBI	CHEBI:50790	EC 1.14.14.14 (aromatase) inhibitor
 MESH	D047090	beta-Lactams	CHEBI	CHEBI:35627	beta-lactam
-MESH	D047108	Embryonic Development	GO	GO:0009790	embryo development
 MESH	D047150	Eosinophil Cationic Protein	HGNC	10046	RNASE3
 MESH	D047188	Chalcones	CHEBI	CHEBI:23086	chalcones
 MESH	D047208	Eosinophil-Derived Neurotoxin	HGNC	10045	RNASE2
@@ -4539,7 +5219,9 @@ MESH	D047495	PPAR gamma	HGNC	9236	PPARG
 MESH	D047628	Estrogen Receptor alpha	HGNC	3467	ESR1
 MESH	D047629	Estrogen Receptor beta	HGNC	3468	ESR2
 MESH	D047630	Depsipeptides	CHEBI	CHEBI:23643	depsipeptide
+MESH	D047728	Myopia, Degenerative	DOID	DOID:11829	degenerative myopia
 MESH	D047768	Glycerophosphoinositol Inositolphosphodiesterase	HGNC	541	ANXA3
+MESH	D047868	Pulmonary Sclerosing Hemangioma	DOID	DOID:495	sclerosing hemangioma
 MESH	D047888	Receptors, Tumor Necrosis Factor, Type I	HGNC	11916	TNFRSF1A
 MESH	D047889	Receptors, Tumor Necrosis Factor, Type II	HGNC	11917	TNFRSF1B
 MESH	D047990	TNF Receptor-Associated Factor 1	HGNC	12031	TRAF1
@@ -4557,6 +5239,7 @@ MESH	D048057	Mitogen-Activated Protein Kinase 10	HGNC	6872	MAPK10
 MESH	D048068	PPAR-beta	HGNC	9235	PPARD
 MESH	D048148	Casein Kinase Idelta	HGNC	2452	CSNK1D
 MESH	D048149	Casein Kinase Iepsilon	HGNC	2453	CSNK1E
+MESH	D048209	Echinococcus granulosus	DOID	DOID:1495	cystic echinococcosis
 MESH	D048271	Chitosan	CHEBI	CHEBI:16261	chitosan
 MESH	D048288	Imidazolines	CHEBI	CHEBI:53095	imidazolines
 MESH	D048289	Imidazolidines	CHEBI	CHEBI:38261	imidazolidines
@@ -4590,14 +5273,21 @@ MESH	D049030	Dystroglycans	HGNC	2666	DAG1
 MESH	D049071	Endopeptidase Clp	HGNC	2084	CLPP
 MESH	D049109	Cell Proliferation	GO	GO:0008283	cell population proliferation
 MESH	D049229	Dendritic Spines	GO	GO:0043197	dendritic spine
+MESH	D049309	Acanthoma	HP	HP:0025432	Acanthoma
+MESH	D049310	Distal Myopathies	DOID	DOID:0070198	Miyoshi muscular dystrophy
 MESH	D049411	Utrophin	HGNC	12635	UTRN
 MESH	D049469	Meiotic Prophase I	GO	GO:0007128	meiotic prophase I
 MESH	D049488	Phosphatidylethanolamine Binding Protein	HGNC	8630	PEBP1
+MESH	D049590	Postpartum Period	EFO	0008562	postpartum
+MESH	D049912	Growth Hormone-Secreting Pituitary Adenoma	DOID	DOID:6255	growth hormone secreting pituitary adenoma
+MESH	D049913	ACTH-Secreting Pituitary Adenoma	EFO	1000066	ACTH-Producing Pituitary Gland Adenoma
 MESH	D049934	Isocoumarins	CHEBI	CHEBI:38758	isocoumarins
 MESH	D049971	Thiazides	CHEBI	CHEBI:50264	thiazide
 MESH	D049990	Membrane Transport Modulators	CHEBI	CHEBI:38632	membrane transport modulator
+MESH	D050031	Hashimoto Disease	EFO	0002200	HT
 MESH	D050071	Bone Density Conservation Agents	CHEBI	CHEBI:50646	bone density conservation agent
 MESH	D050091	Dendrimers	CHEBI	CHEBI:61483	dendritic polymer
+MESH	D050177	Overweight	HP	HP:0025502	Overweight
 MESH	D050178	Monoglycerides	CHEBI	CHEBI:17408	monoglyceride
 MESH	D050256	Antimitotic Agents	CHEBI	CHEBI:64911	antimitotic
 MESH	D050257	Tubulin Modulators	CHEBI	CHEBI:60832	tubulin modulator
@@ -4659,6 +5349,7 @@ MESH	D050796	STAT3 Transcription Factor	HGNC	11364	STAT3
 MESH	D050804	D-Aspartate Oxidase	HGNC	2727	DDO
 MESH	D050808	ets-Domain Protein Elk-4	HGNC	3326	ELK4
 MESH	D050814	Octamer Transcription Factor-3	HGNC	9221	POU5F1
+MESH	D050815	Fractures, Compression	HP	HP:0002953	Vertebral compression fractures
 MESH	D050819	Transcription Factor Brn-3A	HGNC	9218	POU4F1
 MESH	D050820	Transcription Factor Brn-3B	HGNC	9219	POU4F2
 MESH	D050821	Transcription Factor Brn-3C	HGNC	9220	POU4F3
@@ -4856,8 +5547,10 @@ MESH	D052243	Resistin	HGNC	20389	RETN
 MESH	D052244	Endocrine Disruptors	CHEBI	CHEBI:138015	endocrine disruptor
 MESH	D052276	Creatine Kinase, BB Form	HGNC	1991	CKB
 MESH	D052578	Ionic Liquids	CHEBI	CHEBI:63895	ionic liquid
+MESH	D052858	Cystocele	HP	HP:0100645	Cystocele
 MESH	D052998	Microcystins	CHEBI	CHEBI:48041	microcystin
 MESH	D053038	Quorum Sensing	GO	GO:0009372	quorum sensing
+MESH	D053058	Trophozoites	EFO	0002592	trophozoite
 MESH	D053119	Benzophenanthridines	CHEBI	CHEBI:38518	benzophenanthridine
 MESH	D053139	Oseltamivir	CHEBI	CHEBI:7798	oseltamivir
 MESH	D053143	Caspase 2	HGNC	1503	CASP2
@@ -4867,6 +5560,7 @@ MESH	D053178	Caspase 6	HGNC	1507	CASP6
 MESH	D053179	Caspase 7	HGNC	1508	CASP7
 MESH	D053181	Caspase 8	HGNC	1509	CASP8
 MESH	D053200	Fas-Associated Death Domain Protein	HGNC	3573	FADD
+MESH	D053201	Urinary Bladder, Overactive	DOID	DOID:12144	low compliance bladder
 MESH	D053205	Pollen Tube	GO	GO:0090406	pollen tube
 MESH	D053218	Receptors, Death Domain	FPLX	Death_receptor	Death_receptor
 MESH	D053219	Receptors, Tumor Necrosis Factor, Member 25	HGNC	11910	TNFRSF25
@@ -4888,6 +5582,7 @@ MESH	D053300	Tumor Necrosis Factor Ligand Superfamily Member 13	HGNC	11928	TNFSF
 MESH	D053302	Apolipoprotein C-I	HGNC	607	APOC1
 MESH	D053304	Apolipoprotein C-II	HGNC	609	APOC2
 MESH	D053305	Apolipoprotein C-III	HGNC	610	APOC3
+MESH	D053306	Hyper-IgM Immunodeficiency Syndrome	DOID	DOID:0080544	hyper IgM syndrome
 MESH	D053308	Lymphotoxin-beta	HGNC	6711	LTB
 MESH	D053320	Receptors, Tumor Necrosis Factor, Member 10c	HGNC	11906	TNFRSF10C
 MESH	D053326	Tumor Necrosis Factor Ligand Superfamily Member 14	HGNC	11930	TNFSF14
@@ -4914,6 +5609,7 @@ MESH	D053477	Apoptotic Protease-Activating Factor 1	HGNC	576	APAF1
 MESH	D053478	Apoptosomes	GO	GO:0043293	apoptosome
 MESH	D053481	Secretory Leukocyte Peptidase Inhibitor	HGNC	11092	SLPI
 MESH	D053482	beta 2-Glycoprotein I	HGNC	616	APOH
+MESH	D053483	Eye Movement Measurements	EFO	0007699	eye movement measurement
 MESH	D053492	Elafin	HGNC	8947	PI3
 MESH	D053493	Cholestanetriol 26-Monooxygenase	HGNC	2605	CYP27A1
 MESH	D053495	Osteopontin	HGNC	11255	SPP1
@@ -4934,6 +5630,7 @@ MESH	D053536	Keratin-16	HGNC	6423	KRT16
 MESH	D053537	Keratin-17	HGNC	6427	KRT17
 MESH	D053538	Keratin-18	HGNC	6430	KRT18
 MESH	D053539	Keratin-19	HGNC	6436	KRT19
+MESH	D053546	Keratoderma, Palmoplantar, Epidermolytic	DOID	DOID:0080223	epidermolytic palmoplantar keratoderma
 MESH	D053547	Keratin-14	HGNC	6416	KRT14
 MESH	D053550	Keratin-10	HGNC	6413	KRT10
 MESH	D053551	Keratin-12	HGNC	6414	KRT12
@@ -4958,6 +5655,7 @@ MESH	D053614	Janus Kinase 2	HGNC	6192	JAK2
 MESH	D053616	Janus Kinase 3	HGNC	6193	JAK3
 MESH	D053626	Atovaquone	CHEBI	CHEBI:575568	atovaquone
 MESH	D053628	Receptors, Thrombopoietin	HGNC	7217	MPL
+MESH	D053632	X-Linked Combined Immunodeficiency Diseases	DOID	DOID:0060013	X-linked severe combined immunodeficiency
 MESH	D053634	TYK2 Kinase	HGNC	12440	TYK2
 MESH	D053647	Receptors, Interleukin-15	FPLX	IL15R	IL15R
 MESH	D053651	Receptors, Interleukin-9	HGNC	6030	IL9R
@@ -4992,10 +5690,18 @@ MESH	D053802	Tryptases	FPLX	Tryptase	Tryptase
 MESH	D053818	Chymases	HGNC	2097	CMA1
 MESH	D053829	Amyloid Precursor Protein Secretases	HGNC	2527	CTSB
 MESH	D053834	Explosive Agents	CHEBI	CHEBI:63490	explosive
+MESH	D053840	Brugada Syndrome	DOID	DOID:0110218	Brugada syndrome 1
 MESH	D053843	DNA Mismatch Repair	GO	GO:0006298	mismatch repair
 MESH	D053959	Alpha-Amanitin	CHEBI	CHEBI:37415	alpha-amanitin
+MESH	D054000	Nevus, Sebaceous of Jadassohn	DOID	DOID:7039	Borst-Jadassohn intraepidermal carcinoma
+MESH	D054068	Livedo Reticularis	HP	HP:0000965	Cutis marmorata
+MESH	D054079	Vascular Malformations	EFO	0006888	vascular malformation
+MESH	D054084	Myocardial Bridging	HP	HP:0025490	Myocardial bridging
+MESH	D054091	Periventricular Nodular Heterotopia	HP	HP:0032388	Periventricular nodular heterotopia
+MESH	D054179	Angioedemas, Hereditary	DOID	DOID:0060002	C1 inhibitor deficiency
 MESH	D054199	Pseudoephedrine	CHEBI	CHEBI:51209	pseudoephedrine
 MESH	D054262	Gastrulation	GO	GO:0007369	gastrulation
+MESH	D054278	Embryonal Carcinoma Stem Cells	EFO	0004987	embryonal carcinoma cell
 MESH	D054304	Anti-Mullerian Hormone	HGNC	464	AMH
 MESH	D054328	Proton Pump Inhibitors	CHEBI	CHEBI:49200	EC 3.6.3.10 (H(+)/K(+)-exchanging ATPase) inhibitor
 MESH	D054337	Cell Dedifferentiation	GO	GO:0043697	cell dedifferentiation
@@ -5032,6 +5738,7 @@ MESH	D054425	Chemokine CCL27	HGNC	10626	CCL27
 MESH	D054426	Chemokine CXCL2	HGNC	4603	CXCL2
 MESH	D054427	Chemokine CXCL6	HGNC	10643	CXCL6
 MESH	D054428	Chemokine CX3CL1	HGNC	10647	CX3CL1
+MESH	D054437	Myelodysplastic-Myeloproliferative Diseases	DOID	DOID:4972	myelodysplastic/myeloproliferative neoplasm
 MESH	D054439	Ghrelin	HGNC	18129	GHRL
 MESH	D054440	Receptors, Ghrelin	HGNC	4267	GHSR
 MESH	D054447	Receptors, CCR10	HGNC	4474	CCR10
@@ -5045,8 +5752,10 @@ MESH	D054481	Thioredoxin Reductase 1	HGNC	12437	TXNRD1
 MESH	D054482	Thioredoxin Reductase 2	HGNC	18155	TXNRD2
 MESH	D054509	Group X Phospholipases A2	HGNC	9029	PLA2G10
 MESH	D054512	Phospholipases A2, Calcium-Independent	HGNC	30802	PNPLA2
+MESH	D054514	Persistent Hyperplastic Primary Vitreous	HP	HP:0009922	Vascular remnant arising from the disc
 MESH	D054520	Group III Phospholipases A2	HGNC	17934	PLA2G3
 MESH	D054522	Group VI Phospholipases A2	HGNC	9039	PLA2G6
+MESH	D054537	Atrioventricular Block	EFO	0005305	atrioventricular node disease
 MESH	D054578	Protein Tyrosine Phosphatase, Non-Receptor Type 2	HGNC	9650	PTPN2
 MESH	D054594	Protein Tyrosine Phosphatase, Non-Receptor Type 12	HGNC	9645	PTPN12
 MESH	D054595	Protein Tyrosine Phosphatase, Non-Receptor Type 13	HGNC	9646	PTPN13
@@ -5072,6 +5781,9 @@ MESH	D054728	Cucurbitacins	CHEBI	CHEBI:16219	cucurbitacin
 MESH	D054729	Calcium-Calmodulin-Dependent Protein Kinase Type 1	HGNC	1459	CAMK1
 MESH	D054732	Calcium-Calmodulin-Dependent Protein Kinase Type 2	FPLX	CAMK2_complex	CAMK2_complex
 MESH	D054735	Phosphorothioate Oligonucleotides	CHEBI	CHEBI:76674	phosphorothioate oligonucleotide
+MESH	D054739	Dendritic Cell Sarcoma, Interdigitating	DOID	DOID:8538	reticulosarcoma
+MESH	D054740	Dendritic Cell Sarcoma, Follicular	DOID	DOID:7849	dendritic cell sarcoma
+MESH	D054747	Histiocytic Sarcoma	EFO	1001499	histiocytic medullary reticulosis
 MESH	D054754	Cyclic AMP-Dependent Protein Kinase RIIalpha Subunit	HGNC	9391	PRKAR2A
 MESH	D054769	G-Protein-Coupled Receptor Kinase 2	HGNC	289	GRK2
 MESH	D054770	G-Protein-Coupled Receptor Kinase 3	HGNC	290	GRK3
@@ -5089,8 +5801,12 @@ MESH	D054872	Fatty Acid Synthesis Inhibitors	CHEBI	CHEBI:50185	fatty acid synthe
 MESH	D054873	Dipeptidyl-Peptidase IV Inhibitors	CHEBI	CHEBI:68612	EC 3.4.14.5 (dipeptidyl-peptidase IV) inhibitor
 MESH	D054876	Prenylation	GO	GO:0097354	prenylation
 MESH	D054883	Oxylipins	CHEBI	CHEBI:61121	oxylipin
+MESH	D054969	Primary Dysautonomias	HP	HP:0012332	Abnormal autonomic nervous system physiology
+MESH	D054971	Orthostatic Intolerance	DOID	DOID:0111154	postural orthostatic tachycardia syndrome
+MESH	D054972	Postural Orthostatic Tachycardia Syndrome	DOID	DOID:0111154	postural orthostatic tachycardia syndrome
 MESH	D054974	Costameres	GO	GO:0043034	costamere
 MESH	D054992	Immunological Synapses	GO	GO:0001772	immunological synapse
+MESH	D055009	Spondylosis	EFO	0009477	vertebral joint disease
 MESH	D055212	Photoreceptor Connecting Cilium	GO	GO:0032391	photoreceptor connecting cilium
 MESH	D055257	Mucin-5B	HGNC	7516	MUC5B
 MESH	D055262	Mucin-2	HGNC	7512	MUC2
@@ -5107,6 +5823,7 @@ MESH	D055415	Bone Morphogenetic Protein 4	HGNC	1071	BMP4
 MESH	D055417	Bone Morphogenetic Protein 5	HGNC	1072	BMP5
 MESH	D055418	Bone Morphogenetic Protein 6	HGNC	1073	BMP6
 MESH	D055419	Bone Morphogenetic Protein 7	HGNC	1074	BMP7
+MESH	D055423	Diet, Ketogenic	EFO	0009371	ketogenic diet
 MESH	D055427	Growth Differentiation Factor 2	HGNC	4217	GDF2
 MESH	D055428	Growth Differentiation Factor 5	HGNC	4220	GDF5
 MESH	D055429	Growth Differentiation Factor 9	HGNC	4224	GDF9
@@ -5130,10 +5847,20 @@ MESH	D055551	HSP27 Heat-Shock Proteins	HGNC	5246	HSPB1
 MESH	D055572	Ceramidases	HGNC	735	ASAH1
 MESH	D055573	Acid Ceramidase	HGNC	735	ASAH1
 MESH	D055576	Neutral Ceramidase	HGNC	18860	ASAH2
+MESH	D055623	Keratosis, Actinic	HP	HP:0025127	Actinic keratosis
+MESH	D055624	Methicillin-Resistant Staphylococcus aureus	EFO	0008555	Methicillin-Resistant Staphylococcus Aureus Infection
 MESH	D055627	Natural Cytotoxicity Triggering Receptor 1	HGNC	6731	NCR1
+MESH	D055665	Purpura Fulminans	EFO	1001913	Purpura Fulminans
 MESH	D055666	Lipopeptides	CHEBI	CHEBI:46895	lipopeptide
+MESH	D055732	Pulmonary Aspergillosis	DOID	DOID:0050153	pulmonary aspergilloma
+MESH	D055744	Invasive Pulmonary Aspergillosis	HP	HP:0020103	Invasive pulmonary aspergillosis
+MESH	D055752	Small Cell Lung Carcinoma	DOID	DOID:5411	lung oat cell carcinoma
+MESH	D055786	Gene Knockout Techniques	EFO	0000506	gene knock out
+MESH	D055879	Gene Knock-In Techniques	EFO	0004963	gene knock in
+MESH	D055959	Intervertebral Disc Degeneration	DOID	DOID:90	degenerative disc disease
 MESH	D056245	Mi-2 Nucleosome Remodeling and Deacetylase Complex	GO	GO:0016581	NuRD complex
 MESH	D056264	Sin3 Histone Deacetylase and Corepressor Complex	GO	GO:0016580	Sin3 complex
+MESH	D056344	Executive Function	EFO	0007046	executive function
 MESH	D056404	Chaperonin Containing TCP-1	FPLX	CCT_complex	CCT_complex
 MESH	D056465	Retinoblastoma-Binding Protein 1	HGNC	9885	ARID4A
 MESH	D056505	Retinoblastoma-Binding Protein 4	HGNC	9887	RBBP4
@@ -5144,12 +5871,14 @@ MESH	D056566	Sirtuin 3	HGNC	14931	SIRT3
 MESH	D056572	Histone Deacetylase Inhibitors	CHEBI	CHEBI:61115	EC 3.5.1.98 (histone deacetylase) inhibitor
 MESH	D056646	Cathepsin F	HGNC	2531	CTSF
 MESH	D056649	Cathepsin G	HGNC	2532	CTSG
+MESH	D056650	Vulvodynia	HP	HP:0030943	Vulvodynia
 MESH	D056655	Cathepsin H	HGNC	2535	CTSH
 MESH	D056657	Cathepsin K	HGNC	2536	CTSK
 MESH	D056663	Cathepsin Z	HGNC	2547	CTSZ
 MESH	D056664	Cathepsin W	HGNC	2546	CTSW
 MESH	D056668	Cathepsin L	HGNC	2537	CTSL
 MESH	D056690	Prolactin-Releasing Hormone	HGNC	17945	PRLH
+MESH	D056734	Monilethrix	HP	HP:0032470	Monilethrix
 MESH	D056741	Cyclin D	FPLX	Cyclin_D	Cyclin_D
 MESH	D056742	Cyclin D2	HGNC	1583	CCND2
 MESH	D056743	Cyclin D3	HGNC	1585	CCND3
@@ -5162,17 +5891,23 @@ MESH	D056751	Cyclin A2	HGNC	1578	CCNA2
 MESH	D056765	Cyclin B2	HGNC	1580	CCNB2
 MESH	D056766	Cyclin G1	HGNC	1592	CCNG1
 MESH	D056767	Cyclin G2	HGNC	1593	CCNG2
+MESH	D056807	Argininosuccinic Aciduria	HP	HP:0025630	Argininosuccinic aciduria
 MESH	D056810	Acaricides	CHEBI	CHEBI:22153	acaricide
 MESH	D056825	Thyroxine-Binding Globulin	HGNC	11583	SERPINA7
+MESH	D056833	Central Serous Chorioretinopathy	HP	HP:0025567	Central serous chorioretinopathy
 MESH	D056849	Cyclin-Dependent Kinase 3	HGNC	1772	CDK3
 MESH	D056850	Cyclin-Dependent Kinase 8	HGNC	1779	CDK8
 MESH	D056892	Mediator Complex	GO	GO:0016592	mediator complex
 MESH	D056913	Mediator Complex Subunit 1	HGNC	9234	MED1
 MESH	D056920	Nuclear Receptor Coactivator 1	HGNC	7668	NCOA1
 MESH	D056921	Nuclear Receptor Coactivator 3	HGNC	7670	NCOA3
+MESH	D056945	Hep G2 Cells	EFO	0001187	HepG2
 MESH	D056971	Nuclear Receptor Co-Repressor 1	HGNC	8001	NRIP1
 MESH	D056985	Nuclear Receptor Co-Repressor 2	HGNC	7673	NCOR2
+MESH	D057026	Induced Pluripotent Stem Cells	EFO	0004905	induced pluripotent stem cell
 MESH	D057050	Receptor Tyrosine Kinase-like Orphan Receptors	FPLX	ROR	ROR
+MESH	D057088	Anetoderma	HP	HP:0032026	Anetoderma
+MESH	D057092	Geographic Atrophy	HP	HP:0031609	Geographic atrophy
 MESH	D057094	Nuclear Receptor Subfamily 1, Group F, Member 1	HGNC	10258	RORA
 MESH	D057095	Nuclear Receptor Subfamily 1, Group F, Member 2	HGNC	10259	RORB
 MESH	D057105	Nuclear Receptor Subfamily 4, Group A, Member 1	HGNC	7980	NR4A1
@@ -5181,8 +5916,10 @@ MESH	D057107	Nuclear Receptor Subfamily 2, Group C, Member 1	HGNC	7971	NR2C1
 MESH	D057125	Nuclear Receptor Subfamily 2, Group C, Member 2	HGNC	7972	NR2C2
 MESH	D057126	Nuclear Receptor Subfamily 4, Group A, Member 2	HGNC	7981	NR4A2
 MESH	D057132	Nuclear Receptor Subfamily 1, Group F, Member 3	HGNC	10260	RORC
+MESH	D057135	Wet Macular Degeneration	DOID	DOID:10873	Kuhnt-Junius degeneration
 MESH	D057136	Nuclear Receptor Subfamily 6, Group A, Member 1	HGNC	7985	NR6A1
 MESH	D057137	DAX-1 Orphan Nuclear Receptor	HGNC	7960	NR0B1
+MESH	D057215	Body Dysmorphic Disorders	DOID	DOID:0060163	body dysmorphic disorder
 MESH	D057465	Catabolite Repression	GO	GO:0061984	catabolite repression
 MESH	D057786	Peptidomimetics	CHEBI	CHEBI:63175	peptidomimetic
 MESH	D057897	Reflex, Righting	GO	GO:0060013	righting reflex
@@ -5204,13 +5941,18 @@ MESH	D058307	Receptors, Prostaglandin E, EP2 Subtype	HGNC	9594	PTGER2
 MESH	D058308	Receptors, Prostaglandin E, EP3 Subtype	HGNC	9595	PTGER3
 MESH	D058309	Receptors, Prostaglandin E, EP4 Subtype	HGNC	9596	PTGER4
 MESH	D058486	Receptors, Purinergic P2X7	HGNC	8537	P2RX7
+MESH	D058494	Walker-Warburg Syndrome	DOID	DOID:0111237	congenital muscular dystrophy-dystroglycanopathy type A1
+MESH	D058503	Mesophyll Cells	EFO	0002439	mesophyll cell
 MESH	D058539	Phosphatidylinositol 3-Kinase	FPLX	PI3K	PI3K
+MESH	D058566	Sacroiliitis	HP	HP:0012317	Sacroiliac arthritis
+MESH	D058568	Necrolytic Migratory Erythema	HP	HP:0031181	Necrolytic migratory erythema
 MESH	D058570	TOR Serine-Threonine Kinases	HGNC	3942	MTOR
 MESH	D058574	Integrin-Binding Sialoprotein	HGNC	5341	IBSP
 MESH	D058575	Decorin	HGNC	2705	DCN
 MESH	D058578	Biglycan	HGNC	1044	BGN
 MESH	D058580	Neurocan	HGNC	2465	NCAN
 MESH	D058581	Brevican	HGNC	23059	BCAN
+MESH	D058627	Megalencephaly	HP	HP:0000256	Macrocephaly
 MESH	D058750	Epithelial-Mesenchymal Transition	GO	GO:0001837	epithelial to mesenchymal transition
 MESH	D058766	Levoleucovorin	CHEBI	CHEBI:63606	(6S)-5-formyltetrahydrofolic acid
 MESH	D058767	Protein Unfolding	GO	GO:0043335	protein unfolding
@@ -5245,9 +5987,22 @@ MESH	D058988	Phosphodiesterase 4 Inhibitors	CHEBI	CHEBI:68844	phosphodiesterase 
 MESH	D059004	Topoisomerase I Inhibitors	CHEBI	CHEBI:50276	EC 5.99.1.2 (DNA topoisomerase) inhibitor
 MESH	D059005	Topoisomerase II Inhibitors	CHEBI	CHEBI:50750	EC 5.99.1.3 [DNA topoisomerase (ATP-hydrolysing)] inhibitor
 MESH	D059007	Polytene Chromosomes	GO	GO:0005700	polytene chromosome
+MESH	D059020	Suicidal Ideation	HP	HP:0031589	Suicidal ideation
+MESH	D059246	Tachypnea	EFO	0009840	tachypnea
+MESH	D059268	Atrophic Vaginitis	DOID	DOID:11968	postmenopausal atrophic vaginitis
+MESH	D059305	Diet, High-Fat	EFO	0002757	high fat diet
+MESH	D059327	Brachydactyly	DOID	DOID:0050581	brachydactyly
+MESH	D059345	Cerebral Small Vessel Diseases	EFO	0008493	cerebral small vessel disease
+MESH	D059348	Peripheral Nerve Injuries	EFO	0009510	peripheral nerve injury
+MESH	D059349	Urine Specimen Collection	EFO	0009123	urine collection
 MESH	D059370	RNA Folding	GO	GO:0034337	RNA folding
+MESH	D059390	Breakthrough Pain	HP	HP:0032149	Breakthrough pain
+MESH	D059407	Pinguecula	HP	HP:0031830	Pinguecula
+MESH	D059409	Stroke, Lacunar	HP	HP:0032325	Lacunar stroke
+MESH	D059446	Heterotaxy Syndrome	EFO	0009081	Heterotaxia
 MESH	D059447	Cell Cycle Checkpoints	GO	GO:0000075	cell cycle checkpoint
 MESH	D059547	Stereocilia	GO	GO:0032420	stereocilium
+MESH	D059630	Mesenchymal Stem Cells	EFO	0000586	mesenchymal stem cell
 MESH	D059666	Lysosomal-Associated Membrane Protein 3	HGNC	14582	LAMP3
 MESH	D059748	Proteolysis	GO	GO:0006508	proteolysis
 MESH	D059765	Homologous Recombination	GO	GO:0035825	homologous recombination
@@ -5258,6 +6013,7 @@ MESH	D059811	HLA-DRB1 Chains	HGNC	4948	HLA-DRB1
 MESH	D059826	HLA-DRB3 Chains	HGNC	4951	HLA-DRB3
 MESH	D059845	HLA-DRB4 Chains	HGNC	4952	HLA-DRB4
 MESH	D059847	HLA-DRB5 Chains	HGNC	4953	HLA-DRB5
+MESH	D059905	Endocarditis, Non-Infective	DOID	DOID:0060068	marantic endocarditis
 MESH	D059951	HLA-G Antigens	HGNC	4964	HLA-G
 MESH	D060049	Asymmetric Cell Division	GO	GO:0008356	asymmetric cell division
 MESH	D060149	Tetraspanin 30	HGNC	1692	CD63
@@ -5275,6 +6031,7 @@ MESH	D060406	Brassinosteroids	CHEBI	CHEBI:22921	brassinosteroid
 MESH	D060449	Wnt Signaling Pathway	GO	GO:0016055	Wnt signaling pathway
 MESH	D060465	Axin Signaling Complex	GO	GO:0030877	beta-catenin destruction complex
 MESH	D060589	Zyxin	HGNC	13200	ZYX
+MESH	D060705	Dyscalculia	HP	HP:0002442	Dyscalculia
 MESH	D060746	Endoplasmic Reticulum-Associated Degradation	GO	GO:0036503	ERAD pathway
 MESH	D060749	alpha-2-HS-Glycoprotein	HGNC	349	AHSG
 MESH	D060752	Fetuin-B	HGNC	3658	FETUB
@@ -5288,8 +6045,12 @@ MESH	D060945	Inducible T-Cell Co-Stimulator Ligand	HGNC	17087	ICOSLG
 MESH	D061065	Polyketides	CHEBI	CHEBI:26188	polyketide
 MESH	D061105	Peroxiredoxin III	HGNC	9354	PRDX3
 MESH	D061107	Nucleoside Diphosphate Kinase D	HGNC	7852	NME4
+MESH	D061206	Neoplasm Micrometastasis	EFO	0009710	micrometastasis
 MESH	D061207	Calcium Ionophores	CHEBI	CHEBI:22986	calcium ionophore
 MESH	D061216	Potassium Ionophores	CHEBI	CHEBI:88227	potassium ionophore
+MESH	D061218	Depressive Disorder, Treatment-Resistant	EFO	0009854	treatment resistant depression
+MESH	D061307	Human Umbilical Vein Endothelial Cells	EFO	0002451	HUVEC cell
+MESH	D061346	Laser Capture Microdissection	EFO	0009111	laser capture microdissection
 MESH	D061466	Lopinavir	CHEBI	CHEBI:31781	lopinavir
 MESH	D061965	Matrix Metalloproteinase Inhibitors	CHEBI	CHEBI:50664	matrix metalloproteinase inhibitor
 MESH	D061988	Proteasome Inhibitors	CHEBI	CHEBI:52726	proteasome inhibitor
@@ -5331,6 +6092,8 @@ MESH	D063386	Cannabinoid Receptor Agonists	CHEBI	CHEBI:67072	cannabinoid recepto
 MESH	D063387	Cannabinoid Receptor Antagonists	CHEBI	CHEBI:73413	cannabinoid receptor antagonist
 MESH	D063388	Endocannabinoids	CHEBI	CHEBI:67197	endocannabinoid
 MESH	D063546	Apicoplasts	GO	GO:0020011	apicoplast
+MESH	D063748	Bland White Garland Syndrome	HP	HP:0011638	Anomalous origin of left coronary artery from the pulmonary artery
+MESH	D063807	Dandruff	DOID	DOID:8941	seborrheic infantile dermatitis
 MESH	D063994	Peroxisomal Bifunctional Enzyme	HGNC	3247	EHHADH
 MESH	D064006	Dodecenoyl-CoA Isomerase	HGNC	2703	ECI1
 MESH	D064026	Calbindins	HGNC	1434	CALB1
@@ -5360,11 +6123,13 @@ MESH	D064247	Separase	HGNC	16856	ESPL1
 MESH	D064248	Geminin	HGNC	17493	GMNN
 MESH	D064249	Securin	HGNC	9690	PTTG1
 MESH	D064286	ATP Binding Cassette Transporter 1	HGNC	29	ABCA1
+MESH	D064386	Ankle Fractures	EFO	0009615	ankle fracture
 MESH	D064412	Levalbuterol	CHEBI	CHEBI:8746	(R)-salbutamol
 MESH	D064451	Hepcidins	HGNC	15598	HAMP
 MESH	D064466	Solute Carrier Family 12, Member 1	HGNC	10910	SLC12A1
 MESH	D064486	Solute Carrier Family 12, Member 3	HGNC	10912	SLC12A3
 MESH	D064507	Solute Carrier Family 12, Member 4	HGNC	10913	SLC12A4
+MESH	D064527	Etiolation	EFO	0007589	etiolation
 MESH	D064529	Receptor, Metabotropic Glutamate 5	HGNC	4597	GRM5
 MESH	D064546	Protein Kinase C beta	HGNC	9395	PRKCB
 MESH	D064549	Myeloid Cell Leukemia Sequence 1 Protein	HGNC	6943	MCL1
@@ -5373,6 +6138,8 @@ MESH	D064690	Wakefulness-Promoting Agents	CHEBI	CHEBI:77567	eugeroic
 MESH	D064692	Hyoscyamine	CHEBI	CHEBI:17486	(S)-atropine
 MESH	D064697	Racemethionine	CHEBI	CHEBI:16811	methionine
 MESH	D064704	Levofloxacin	CHEBI	CHEBI:63598	levofloxacin
+MESH	D064706	Vocal Cord Dysfunction	HP	HP:0031801	Vocal cord dysfunction
+MESH	D064726	Triple Negative Breast Neoplasms	DOID	DOID:0060081	triple-receptor negative breast cancer
 MESH	D064730	Dexrazoxane	CHEBI	CHEBI:50223	(+)-dexrazoxane
 MESH	D064747	Lansoprazole	CHEBI	CHEBI:6375	lansoprazole
 MESH	D064748	Dexlansoprazole	CHEBI	CHEBI:135931	dexlansoprazole
@@ -5390,19 +6157,27 @@ MESH	D065098	Catechol O-Methyltransferase Inhibitors	CHEBI	CHEBI:48406	EC 2.1.1.
 MESH	D065105	Aromatic Amino Acid Decarboxylase Inhibitors	CHEBI	CHEBI:59321	EC 4.1.1.28 (aromatic-L-amino-acid decarboxylase) inhibitor
 MESH	D065168	Bradykinin Receptor Antagonists	CHEBI	CHEBI:68557	bradykinin receptor antagonist
 MESH	D065171	Estrogen Receptor Antagonists	CHEBI	CHEBI:50792	estrogen receptor antagonist
+MESH	D065290	Acute-On-Chronic Liver Failure	EFO	0007949	acute-on-chronic liver failure
 MESH	D065366	Cryptoxanthins	CHEBI	CHEBI:10362	beta-cryptoxanthin
 MESH	D065427	Factor Xa Inhibitors	CHEBI	CHEBI:68581	EC 3.4.21.6 (coagulation factor Xa) inhibitor
 MESH	D065607	Cytochrome P-450 Enzyme Inhibitors	CHEBI	CHEBI:50183	P450 inhibitor
 MESH	D065608	Renal Reabsorption	GO	GO:0070293	renal absorption
+MESH	D065626	Non-alcoholic Fatty Liver Disease	DOID	DOID:0080208	non-alcoholic fatty liver disease
+MESH	D065627	Familial Primary Pulmonary Hypertension	DOID	DOID:14557	primary pulmonary hypertension
+MESH	D065631	Rhinitis, Allergic	DOID	DOID:4481	allergic rhinitis
+MESH	D065632	Chikungunya Fever	DOID	DOID:0050012	chikungunya
 MESH	D065636	Myotonin-Protein Kinase	HGNC	2933	DMPK
 MESH	D065637	Cytochrome P-450 CYP2A6	HGNC	2610	CYP2A6
+MESH	D065646	Thyroid Carcinoma, Anaplastic	DOID	DOID:0080522	thyroid gland anaplastic carcinoma
 MESH	D065668	Vitamin D3 24-Hydroxylase	HGNC	2602	CYP24A1
 MESH	D065702	Cytochrome P-450 CYP2B6	HGNC	2615	CYP2B6
 MESH	D065727	Cytochrome P-450 CYP2C8	HGNC	2622	CYP2C8
 MESH	D065729	Cytochrome P-450 CYP2C9	HGNC	2623	CYP2C9
 MESH	D065731	Cytochrome P-450 CYP2C19	HGNC	2621	CYP2C19
+MESH	D065766	Atypical Hemolytic Uremic Syndrome	DOID	DOID:0080301	atypical hemolytic-uremic syndrome
 MESH	D065808	Prepulse Inhibition	GO	GO:0060134	prepulse inhibition
 MESH	D065819	Voriconazole	CHEBI	CHEBI:10023	voriconazole
+MESH	D065927	Waist-Height Ratio	EFO	0005191	waist height ratio
 MESH	D066146	Cell Body	GO	GO:0044297	cell body
 MESH	D066247	Receptor, ErbB-4	HGNC	3432	ERBB4
 MESH	D066257	Heparin-binding EGF-like Growth Factor	HGNC	3059	HBEGF

--- a/gilda/scorer.py
+++ b/gilda/scorer.py
@@ -238,6 +238,16 @@ def score_status(term):
     return scores[term.status]
 
 
+def score_namespace(term):
+    """Note: this is currently not included as an explicit score term.
+    It is just used to rank identically scored entries."""
+    order = ['FPLX', 'HGNC', 'UP', 'CHEBI', 'GO', 'MESH', 'DOID', 'HP', 'EFO']
+    try:
+        return len(order) - order.index(term.db)
+    except ValueError:
+        return 0
+
+
 def score(match, term):
     string_match_score = score_string_match(match)
     status_score = score_status(term)

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -70,4 +70,8 @@ def test_disambiguate_gilda():
             assert match.disambiguation['score'] > 0.99
         if match.term.db == 'HGNC' and match.term.id == '7679':
             assert match.disambiguation['score'] < 0.01
-        print(match)
+
+
+def test_rank_namespace():
+    matches = gr.ground('interferon-gamma')
+    assert matches[0].term.db == 'HGNC'

--- a/scripts/generate_mesh_mappings.py
+++ b/scripts/generate_mesh_mappings.py
@@ -1,8 +1,6 @@
 import os
 from collections import defaultdict
-from gilda.generate_terms import generate_famplex_terms, generate_hgnc_terms, \
-    generate_mesh_terms, generate_uniprot_terms, generate_chebi_terms, \
-    generate_go_terms, filter_out_duplicates
+from gilda.generate_terms import *
 from indra.databases import mesh_client
 
 
@@ -56,7 +54,10 @@ def get_mesh_mappings(ambigs):
         order = [('FPLX', is_protein),
                  ('HGNC', is_protein),
                  ('CHEBI', is_chemical),
-                 ('GO', lambda x: True)]
+                 ('GO', lambda x: True),
+                 ('DOID', lambda x: True),
+                 ('HP', lambda x: True),
+                 ('EFO', lambda x: True)]
         me = ambigs_by_db['MESH'][0]
         for ns, mesh_constraint in order:
             if len(ambigs_by_db.get(ns, [])) == 1 and mesh_constraint(me.id):
@@ -91,7 +92,10 @@ def get_terms():
         generate_hgnc_terms() + \
         generate_famplex_terms() + \
         generate_uniprot_terms(download=False) + \
-        generate_chebi_terms()
+        generate_chebi_terms() + \
+        generate_efo_terms() + \
+        generate_hp_terms() + \
+        generate_doid_terms()
     terms = filter_out_duplicates(terms)
     return terms
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 
 setup(name='gilda',
-      version='0.3.0',
+      version='0.3.1',
       description=('Grounding for biomedical entities with contextual '
                    'disambiguation'),
       long_description=long_description,


### PR DESCRIPTION
This PR is a first attempt at handling some of the redundancy between EFO, HP, and DOID and MESH. The automated equivalence finding script works pretty much immediately for these cases too, and has found 789 new mappings. These new mappings are applied towards MESH (other mappings are applied from MESH). The PR also implements a simple ordering between scored matches that have the exact same score to introduce a priority between namespaces.

This PR doesn't directly address redundancies between EFO, HP, and DOID (other than the special case when they happen to map to the same MESH ID), but there are some of those too.