### PR TITLE
Remove AA synonyms

### DIFF
--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 import logging
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -140,7 +140,7 @@ def generate_chebi_terms():
         # We skip entries of the form Glu-Lys with synonyms like EK since
         # there are highly ambiguous with other acronyms, and are unlikely
         # to be used in practice.
-        if is_aa_sequence(chebi_name) and re.match(r'(^[A-Z]+$)', name):
+        if is_aa_sequence(chebi_name) and re.match(r'(^[A-Z-]+$)', name):
             continue
 
         term_args = (normalize(name), name, db, id, chebi_name, 'synonym',

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -13,6 +13,7 @@ import indra
 from indra.util import write_unicode_csv
 from indra.databases import hgnc_client, uniprot_client, chebi_client, \
     go_client, mesh_client, doid_client
+from indra.statements.resources import amino_acids
 from .term import Term
 from .process import normalize
 from .resources import resource_dir
@@ -136,6 +137,11 @@ def generate_chebi_terms():
         if chebi_name is None:
             logger.info('Could not get valid name for %s' % chebi_id)
             continue
+        # We skip entries of the form Glu-Lys with synonyms like EK since
+        # there are highly ambiguous with other acronyms, and are unlikely
+        # to be used in practice.
+        if is_aa_sequence(chebi_name) and re.match(r'(^[A-Z]+$)', name):
+            continue
 
         term_args = (normalize(name), name, db, id, chebi_name, 'synonym',
                      'chebi')
@@ -147,6 +153,16 @@ def generate_chebi_terms():
             added.add(term_args)
     logger.info('Loaded %d terms' % len(terms))
     return terms
+
+
+def is_aa_sequence(txt):
+    """Return True if the given text is a sequence of amino acids like Tyr-Glu.
+    """
+    return ('-' in txt) and (all(part in aa_abbrevs
+                                 for part in txt.split('-')))
+
+
+aa_abbrevs = {aa['short_name'].capitalize() for aa in amino_acids.values()}
 
 
 def generate_mesh_terms(ignore_mappings=False):

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -75,3 +75,11 @@ def test_disambiguate_gilda():
 def test_rank_namespace():
     matches = gr.ground('interferon-gamma')
     assert matches[0].term.db == 'HGNC'
+
+
+def test_aa_synonym():
+    matches = gr.ground('WN')
+    assert '141447' not in {m.term.id for m in matches}
+
+    matches = gr.ground('W-N')
+    assert '141447' not in {m.term.id for m in matches}


### PR DESCRIPTION
This PR removes synonyms of the form
```
wn    W-N     CHEBI   CHEBI:141447    Trp-Asn synonym chebi
```
that represent capital letter acronyms for sequences of two or more amino acids. These aren't used in practice but do to ambiguity with other terms, they result in frequent misgrounding.