### PR TITLE
Support for non-human proteins

### DIFF
--- a/benchmarks/fplx_evaluation.py
+++ b/benchmarks/fplx_evaluation.py
@@ -3,6 +3,7 @@ import pandas
 import itertools
 from indra.databases import chebi_client
 from gilda import ground
+from gilda.resources import popular_organisms
 
 service_url = 'http://localhost:8001'
 
@@ -44,7 +45,10 @@ correct_assertions = {'Stat': {'FPLX': 'STAT'},
                       'PP5': {'HGNC': '9322'},
                       'aminopeptidases': {'MESH': 'D000626'},
                       'IMP1': {'HGNC': '28866'},
-                      '293T': {'EFO': '0001082'}}
+                      '293T': {'EFO': '0001082'},
+                      'GR': {'HGNC': '7978'},
+                      'integrin alpha': {'FPLX': 'ITGA'},
+                      'DC': {'MESH': 'D003713'}}
 
 
 incorrect_assertions = {'IGF': {'HGNC': '5464'},
@@ -53,7 +57,13 @@ incorrect_assertions = {'IGF': {'HGNC': '5464'},
                         'BMD': {'HGNC': '2928'},
                         'DC': {'HGNC': '2714'},
                         'ARs': {'HGNC': '644'},
-                        'BA': {'CHEBI': 'CHEBI:32594'}}
+                        'BA': {'CHEBI': 'CHEBI:32594'},
+                        'HP1': {'HGNC': '1555'},
+                        'PRF': {'UP': 'Q6P3D7'},
+                        'CUL4': {'UP': 'Q17392'},
+                        'MEKK3': {'GO': 'GO:0004709'},
+                        'Hrs': {'GO': 'GO:0000725'},
+                        'thioredoxin-1': {'UP': 'P47938'}}
 
 
 def process_fplx_groundings(df):
@@ -86,7 +96,7 @@ def process_fplx_groundings(df):
             if k == 'PUBCHEM':
                 chebi_id = chebi_client.get_chebi_id_from_pubchem(v)
                 if chebi_id:
-                    grounding['db_refs']['CHEBI'] = 'CHEBI:%s' % chebi_id
+                    grounding['db_refs']['CHEBI'] = chebi_id
         groundings.append(grounding)
     return groundings
 
@@ -136,7 +146,8 @@ def make_comparison(groundings):
         old_eval = evaluate_old_grounding(grounding)
         # Send grounding requests
         matches = ground(text=grounding['text'],
-                         context=grounding['context'])
+                         context=grounding['context'],
+                         organisms=popular_organisms)
         if not matches:
             comparison['%s_ungrounded' % old_eval].append((idx, grounding,
                                                            None))

--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4'
+__version__ = '0.5'
 import logging
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'

--- a/gilda/api.py
+++ b/gilda/api.py
@@ -12,8 +12,9 @@ class GrounderInstance(object):
             self.grounder = Grounder()
         return self.grounder
 
-    def ground(self, text, context=None):
-        return self.get_grounder().ground(text, context=context)
+    def ground(self, text, context=None, organisms=None):
+        return self.get_grounder().ground(text, context=context,
+                                          organisms=organisms)
 
     def get_models(self):
         return self.get_grounder().get_models()
@@ -27,7 +28,7 @@ class GrounderInstance(object):
 grounder = GrounderInstance()
 
 
-def ground(text, context=None):
+def ground(text, context=None, organisms=None):
     """Return a list of scored matches for a text to ground.
 
     Parameters
@@ -44,7 +45,7 @@ def ground(text, context=None):
     list[gilda.grounder.ScoredMatch]
         A list of ScoredMatch objects representing the groundings.
     """
-    return grounder.ground(text=text, context=context)
+    return grounder.ground(text=text, context=context, organisms=organisms)
 
 
 def get_models():

--- a/gilda/app/templates/home.html
+++ b/gilda/app/templates/home.html
@@ -1,10 +1,25 @@
 {% extends "base.html" %}
-
 {% block gcontent %}
+<script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
+<script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+
+<script>
+    $(document).ready(function() {
+        // see https://github.com/jshjohnson/Choices
+        const organismSelect = new Choices('#organism-select');
+    })
+</script>
+
 <div class="panel-heading">
     <h3 class="panel-title">Gilda grounding input</h3>
 </div>
 <div class="panel-body">
-    {{ wtf.quick_form(form, form_type='horizontal') }}
+    <form class="form" method="POST" role="form">
+    {{ wtf.form_field(form.text) }}
+    {{ wtf.form_field(form.context) }}
+    {{ wtf.form_field(form.organisms, class_="form-control") }}
+    {{ wtf.form_field(form.submit, class="btn btn-primary")}}
+    </form>
 </div>
 {% endblock %}

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -16,19 +16,13 @@ from indra.databases import hgnc_client, uniprot_client, chebi_client, \
 from indra.statements.resources import amino_acids
 from .term import Term
 from .process import normalize
-from .resources import resource_dir
+from .resources import resource_dir, popular_organisms
 
 
 indra_module_path = indra.__path__[0]
 indra_resources = os.path.join(indra_module_path, 'resources')
 
 logger = logging.getLogger('gilda.generate_terms')
-
-# Popular organisms per UniProt, see
-# https://www.uniprot.org/help/filter_options
-popular_organisms = ['9606', '10090', '10116', '9913', '7955', '7227',
-                     '6239', '44689', '3702', '39947', '83333', '224308',
-                     '559292']
 
 
 def read_csv(fname, header=False, delimiter='\t'):

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -273,7 +273,7 @@ def generate_uniprot_terms(download=False, organisms=None):
     org_filter_str = ' OR '.join(organisms)
     if not os.path.exists(path) or download:
         url = (f'https://www.uniprot.org/uniprot/?format=tab&columns=id,'
-               f'genes(PREFERRED),protein%20names,organism-id&sort=score&'
+               f'genes(PREFERRED),genes(ALTERNATIVE),protein%20names,organism-id&sort=score&'
                f'query=reviewed:yes&fil=organism:{org_filter_str}')
         logger.info('Downloading UniProt resource file')
         res = requests.get(url)
@@ -281,29 +281,63 @@ def generate_uniprot_terms(download=False, organisms=None):
             fh.write(res.text)
     terms = []
     for row in read_csv(path, delimiter='\t', header=True):
-        names = parse_uniprot_synonyms(row['Protein names'])
         up_id = row['Entry']
-        standard_name = row['Gene names  (primary )']
-        ns = 'UP'
-        id = row['Entry']
         organism = row['Organism ID']
+        protein_names = parse_uniprot_synonyms(row['Protein names'])
+        primary_gene_name = row['Gene names  (primary )'].strip()
+        if primary_gene_name == ';':
+            primary_gene_name = None
+        gene_synonyms_str = row['Gene names  (synonym )'].strip()
+        if gene_synonyms_str == ';':
+            gene_synonyms_str = None
+        # We generally use the gene name as the standard name
+        # except when there are multiple gene names (separated by
+        # semi-colons) in which case we take the first protein name.
+        if not primary_gene_name or ';' in primary_gene_name:
+            standard_name = protein_names[0]
+        else:
+            standard_name = primary_gene_name
         # We skip a small number of not critical entries that don't have
         # standard names
         if not standard_name:
             continue
+        ns = 'UP'
+        id = up_id
         hgnc_id = uniprot_client.get_hgnc_id(up_id)
         if hgnc_id:
             ns = 'HGNC'
             id = hgnc_id
             standard_name = hgnc_client.get_hgnc_name(hgnc_id)
-        for name in names:
+        for name in protein_names:
             # Skip names that are EC codes
             if name.startswith('EC '):
+                continue
+            if name == standard_name:
                 continue
             term = Term(normalize(name), name, ns, id,
                         standard_name, 'synonym', 'uniprot',
                         organism)
             terms.append(term)
+        # For non-human proteins we add the gene name and synonyms
+        # here. For human proteins we get these from HGNC.
+        if organism != '9606':
+            term = Term(normalize(standard_name), standard_name,
+                        ns, id, standard_name, 'name', 'uniprot',
+                        organism)
+            terms.append(term)
+            if gene_synonyms_str:
+                # This is to deal with all the variations in which
+                # synonyms are listed, including degenerate strings
+                # like "; ;"
+                for synonym_group in gene_synonyms_str.split('; '):
+                    for synonym in synonym_group.split(' '):
+                        if not synonym or synonym == ';':
+                            continue
+                        term = Term(normalize(synonym), synonym,
+                                    ns, id, standard_name, 'synonym', 'uniprot',
+                                    organism)
+                        terms.append(term)
+
     return terms
 
 

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -50,6 +50,7 @@ def generate_hgnc_terms():
     rows = [r for r in read_csv(fname, header=True, delimiter='\t')]
     id_name_map = {r['HGNC ID'].split(':')[1]: r['Approved symbol']
                    for r in rows}
+    organism = '9606'  # human
     for row in rows:
         db, id = row['HGNC ID'].split(':')
         name = row['Approved symbol']
@@ -60,7 +61,7 @@ def generate_hgnc_terms():
             new_id = m.groups()[0]
             new_name = id_name_map[new_id]
             term_args = (normalize(name), name, db, new_id,
-                         new_name, 'previous', 'hgnc')
+                         new_name, 'previous', 'hgnc', organism)
             all_term_args[term_args] = None
             # NOTE: consider adding withdrawn synonyms e.g.,
             # symbol withdrawn, see pex1     symbol withdrawn, see PEX1
@@ -68,12 +69,13 @@ def generate_hgnc_terms():
             continue
         # Handle regular entry official names
         else:
-            term_args = (normalize(name), name, db, id, name, 'name', 'hgnc')
+            term_args = (normalize(name), name, db, id, name, 'name', 'hgnc',
+                         organism)
             all_term_args[term_args] = None
             if row['Approved name']:
                 app_name = row['Approved name']
                 term_args = (normalize(app_name), app_name, db, id, name,
-                             'name', 'hgnc')
+                             'name', 'hgnc', organism)
                 all_term_args[term_args] = None
 
         # Handle regular entry synonyms
@@ -82,7 +84,7 @@ def generate_hgnc_terms():
             synonyms += row['Alias symbols'].split(', ')
         for synonym in synonyms:
             term_args = (normalize(synonym), synonym, db, id, name, 'synonym',
-                         'hgnc')
+                         'hgnc', organism)
             all_term_args[term_args] = None
 
         # Handle regular entry previous symbols
@@ -90,7 +92,7 @@ def generate_hgnc_terms():
             prev_symbols = row['Previous symbols'].split(', ')
             for prev_symbol in prev_symbols:
                 term_args = (normalize(prev_symbol), prev_symbol, db, id, name,
-                             'previous', 'hgnc')
+                             'previous', 'hgnc', organism)
                 all_term_args[term_args] = None
 
     terms = [Term(*args) for args in all_term_args.keys()]

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -269,7 +269,7 @@ def generate_famplex_terms(ignore_mappings=False):
     return terms
 
 
-def generate_uniprot_terms(download=True, organisms=None):
+def generate_uniprot_terms(download=False, organisms=None):
     if not organisms:
         organisms = popular_organisms
     path = os.path.join(resource_dir, 'up_synonyms.tsv')
@@ -289,6 +289,7 @@ def generate_uniprot_terms(download=True, organisms=None):
         standard_name = row['Gene names  (primary )']
         ns = 'UP'
         id = row['Entry']
+        organism = row['Organism ID']
         # We skip a small number of not critical entries that don't have
         # standard names
         if not standard_name:
@@ -303,7 +304,8 @@ def generate_uniprot_terms(download=True, organisms=None):
             if name.startswith('EC '):
                 continue
             term = Term(normalize(name), name, ns, id,
-                        standard_name, 'synonym', 'uniprot')
+                        standard_name, 'synonym', 'uniprot',
+                        organism)
             terms.append(term)
     return terms
 

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -233,7 +233,7 @@ def generate_famplex_terms(ignore_mappings=False):
         elif 'HGNC' in groundings:
             id = groundings['HGNC']
             term = Term(norm_txt, txt, 'HGNC', hgnc_client.get_hgnc_id(id), id,
-                        'assertion', 'famplex')
+                        'assertion', 'famplex', '9606')
         elif 'UP' in groundings:
             db = 'UP'
             id = groundings['UP']
@@ -247,6 +247,7 @@ def generate_famplex_terms(ignore_mappings=False):
                         id = hgnc_id
                 else:
                     logger.warning('No gene name for %s' % id)
+            # TODO: should we add organism info here?
             term = Term(norm_txt, txt, db, id, name, 'assertion', 'famplex')
         elif 'CHEBI' in groundings:
             id = groundings['CHEBI']

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -267,9 +267,8 @@ def generate_uniprot_terms(download=False):
     path = os.path.join(resource_dir, 'up_synonyms.tsv')
     if not os.path.exists(path) or download:
         url = ('https://www.uniprot.org/uniprot/?format=tab&columns=id,'
-               'genes(PREFERRED),protein%20names&sort=score&'
-               'fil=organism:"Homo%20sapiens%20(Human)%20[9606]"'
-               '%20AND%20reviewed:yes')
+               'genes(PREFERRED),protein%20names,organism-id&sort=score&'
+               'query=reviewed:yes')
         logger.info('Downloading UniProt resource file')
         res = requests.get(url)
         with open(path, 'w') as fh:

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -232,7 +232,9 @@ def generate_famplex_terms(ignore_mappings=False):
             db = 'UP'
             id = groundings['UP']
             name = id
+            organism = None
             if uniprot_client.is_human(id):
+                organism = '9606'
                 hgnc_id = uniprot_client.get_hgnc_id(id)
                 if hgnc_id:
                     name = hgnc_client.get_hgnc_name(hgnc_id)
@@ -242,7 +244,8 @@ def generate_famplex_terms(ignore_mappings=False):
                 else:
                     logger.warning('No gene name for %s' % id)
             # TODO: should we add organism info here?
-            term = Term(norm_txt, txt, db, id, name, 'assertion', 'famplex')
+            term = Term(norm_txt, txt, db, id, name, 'assertion', 'famplex',
+                        organism)
         elif 'CHEBI' in groundings:
             id = groundings['CHEBI']
             name = chebi_client.get_chebi_name_from_id(id[6:])

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -352,8 +352,8 @@ def filter_for_organism(terms, organisms):
     # We then filter out any proteins whose organism isn't in the list
     # and then sort the remaining ones for priority in the organism list
     org_terms = sorted([t for t in terms if t.organism is not None
-                        and t in organisms],
-                       key=lambda t: t.organism.index(t))
+                        and t.organism in organisms],
+                       key=lambda t: organisms.index(t.organism))
     # If there are any organism-specific proteins, we add the top one
     # to the list
     if org_terms:

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -110,6 +110,8 @@ class Grounder(object):
         if not organisms:
             organisms = ['9606']
         entries = self.lookup(raw_str)
+        logger.debug('Filtering %d entries by organism' % len(entries))
+        entries = filter_for_organism(entries, organisms)
         logger.debug('Comparing %s with %d entries' %
                      (raw_str, len(entries)))
         # For each entry to compare to, we generate a match data structure
@@ -355,14 +357,15 @@ def filter_for_organism(terms, organisms):
         if term.organism is not None and term.organism not in organisms:
             continue
         terms_by_organism[term.organism].append(term)
+    # We first take the terms without organism
+    all_terms = terms_by_organism[None]
     # We now find the top organism for which we have at least
-    # one term
-    top_organism = min(set(terms_by_organism) - {None},
-                       key=lambda x: organisms.index(x))
-    # We then take any terms that either don't have an organism
-    # or are from the top organism
-    all_terms = terms_by_organism.get(None, []) + \
-        terms_by_organism.get(top_organism, [])
+    # one term and then add the corresponding terms to the list
+    # of all terms
+    if set(terms_by_organism) != {None}:
+        top_organism = min(set(terms_by_organism) - {None},
+                           key=lambda x: organisms.index(x))
+        all_terms += terms_by_organism[top_organism]
     return all_terms
 
 

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -87,7 +87,7 @@ class Grounder(object):
                      ', '.join(lookups))
         return lookups
 
-    def ground(self, raw_str, context=None):
+    def ground(self, raw_str, context=None, organisms=None):
         """Return scored groundings for a given raw string.
 
         Parameters
@@ -106,6 +106,8 @@ class Grounder(object):
             A list of ScoredMatch objects representing the groundings sorted
             by decreasing score.
         """
+        if not organisms:
+            organisms = ['9606']
         entries = self.lookup(raw_str)
         logger.debug('Comparing %s with %d entries' %
                      (raw_str, len(entries)))
@@ -342,6 +344,21 @@ def load_terms_file(terms_file):
             else:
                 entries[row[0]] = [entry]
         return entries
+
+
+def filter_for_organism(terms, organisms):
+    # We take everything that doesn't have organism information
+    filtered_terms = [t for t in terms if t.organism is None]
+    # We then filter out any proteins whose organism isn't in the list
+    # and then sort the remaining ones for priority in the organism list
+    org_terms = sorted([t for t in terms if t.organism is not None
+                        and t in organisms],
+                       key=lambda t: t.organism.index(t))
+    # If there are any organism-specific proteins, we add the top one
+    # to the list
+    if org_terms:
+        filtered_terms.append(org_terms[0])
+    return filtered_terms
 
 
 def load_adeft_models():

--- a/gilda/resources/__init__.py
+++ b/gilda/resources/__init__.py
@@ -23,6 +23,13 @@ GROUNDING_TERMS_BASE_NAME = 'grounding_terms.tsv'
 GROUNDING_TERMS_PATH = os.path.join(resource_dir, GROUNDING_TERMS_BASE_NAME)
 
 
+# Popular organisms per UniProt, see
+# https://www.uniprot.org/help/filter_options
+popular_organisms = ['9606', '10090', '10116', '9913', '7955', '7227',
+                     '6239', '44689', '3702', '39947', '83333', '224308',
+                     '559292']
+
+
 def _download_from_s3(path, base_name):
     config = botocore.client.Config(signature_version=botocore.UNSIGNED)
     s3 = boto3.client('s3', config=config)

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -20,6 +20,8 @@ class Term(object):
     """
     def __init__(self, norm_text, text, db, id, entry_name, status, source,
                  organism=None):
+        if not text:
+            raise ValueError('Text for Term cannot be empty')
         self.norm_text = norm_text
         self.text = text
         self.db = db

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -30,9 +30,9 @@ class Term(object):
         self.organism = organism
 
     def __str__(self):
-        return 'Term(%s,%s,%s,%s,%s,%s,%s)' % (
+        return 'Term(%s,%s,%s,%s,%s,%s,%s,%s)' % (
             self.norm_text, self.text, self.db, self.id, self.entry_name,
-            self.status, self.source)
+            self.status, self.source, self.organism)
 
     def __repr__(self):
         return str(self)

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -52,6 +52,7 @@ class Term(object):
         }
         if self.organism:
             js['organism'] = self.organism
+        return js
 
     def to_list(self):
         """Return the term serialized into a list of strings."""

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -18,7 +18,8 @@ class Term(object):
     source : str
         The source from which the term was obtained.
     """
-    def __init__(self, norm_text, text, db, id, entry_name, status, source):
+    def __init__(self, norm_text, text, db, id, entry_name, status, source,
+                 organism=None):
         self.norm_text = norm_text
         self.text = text
         self.db = db
@@ -26,6 +27,7 @@ class Term(object):
         self.entry_name = entry_name
         self.status = status
         self.source = source
+        self.organism = organism
 
     def __str__(self):
         return 'Term(%s,%s,%s,%s,%s,%s,%s)' % (
@@ -37,20 +39,23 @@ class Term(object):
 
     def to_json(self):
         """Return the term serialized into a JSON dict."""
-        return {
+        js = {
             'norm_text': self.norm_text,
             'text': self.text,
             'db': self.db,
             'id': self.id,
             'entry_name': self.entry_name,
             'status': self.status,
-            'source': self.source
+            'source': self.source,
         }
+        if self.organism:
+            js['organism'] = self.organism
 
     def to_list(self):
         """Return the term serialized into a list of strings."""
         return [self.norm_text, self.text, self.db, self.id,
-                self.entry_name, self.status, self.source]
+                self.entry_name, self.status, self.source,
+                self.organism]
 
     def get_idenfiers_url(self):
         return get_identifiers_url(self.db, self.id)

--- a/gilda/tests/test_api.py
+++ b/gilda/tests/test_api.py
@@ -20,3 +20,31 @@ def test_get_names():
     names = get_names('HGNC', '6407')
     assert len(names) > 5, names
     assert 'K-Ras' in names
+
+
+def test_organisms():
+    # Default human gene match
+    matches1 = ground('SMN1')
+    assert len(matches1) == 1
+    assert matches1[0].term.db == 'HGNC'
+    assert matches1[0].term.id == '11117'
+    # Prioritize human gene match
+    matches2 = ground('SMN1', organisms=['9606', '10090'])
+    assert len(matches2) == 1
+    assert matches2[0].term.db == 'HGNC'
+    assert matches2[0].term.id == '11117'
+    # Prioritize mouse, SMN is grounded correctly
+    matches3 = ground('SMN', organisms=['10090', '9606'])
+    assert len(matches3) == 1
+    assert matches3[0].term.db == 'UP'
+    assert matches3[0].term.id == 'P63163'
+    # Here we use SMN again but prioritize human and get two bad groundings
+    matches4 = ground('SMN', organisms=['9606', '10090'])
+    assert len(matches4) == 2
+    assert all(m.term.organism == '9606' for m in matches4)
+    # Finally we try grounding SMN1 with mouse prioritized, don't find a match
+    # and end up with the human gene grounding
+    matches5 = ground('SMN1', organisms=['10090', '9606'])
+    assert len(matches5) == 1
+    assert matches5[0].term.db == 'HGNC'
+    assert matches5[0].term.id == '11117'

--- a/gilda/tests/test_api.py
+++ b/gilda/tests/test_api.py
@@ -35,16 +35,16 @@ def test_organisms():
     assert matches2[0].term.id == '11117'
     # Prioritize mouse, SMN is grounded correctly
     matches3 = ground('SMN', organisms=['10090', '9606'])
-    assert len(matches3) == 1
+    assert len(matches3) == 2, matches3
     assert matches3[0].term.db == 'UP'
     assert matches3[0].term.id == 'P63163'
     # Here we use SMN again but prioritize human and get two bad groundings
     matches4 = ground('SMN', organisms=['9606', '10090'])
-    assert len(matches4) == 2
+    assert len(matches4) == 2, matches4
     assert all(m.term.organism == '9606' for m in matches4)
     # Finally we try grounding SMN1 with mouse prioritized, don't find a match
     # and end up with the human gene grounding
-    matches5 = ground('SMN1', organisms=['10090', '9606'])
-    assert len(matches5) == 1
-    assert matches5[0].term.db == 'HGNC'
-    assert matches5[0].term.id == '11117'
+    matches5 = ground('TDRD16A', organisms=['10090', '9606'])
+    assert len(matches5) == 1, matches5
+    assert matches5[0].term.db == 'HGNC', matches5
+    assert matches5[0].term.id == '11117', matches5

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -111,8 +111,20 @@ def test_organism_filter():
 def test_organisms():
     matches = gr.ground('Raf1')
     assert len(matches) == 2, len(matches)
-    assert {match.term.organism for match in matches}
-    print(organisms)
-    for match in matches:
-        print(match.term)
-    assert False
+    organisms = {match.term.organism for match in matches}
+    assert organisms == {'9606', None}, organisms
+
+    matches = gr.ground('Raf1', organisms=['10090'])
+    assert len(matches) == 2, len(matches)
+    organisms = {match.term.organism for match in matches}
+    assert organisms == {'10090', None}
+
+    matches = gr.ground('Raf1', organisms=['9606', '10090'])
+    assert len(matches) == 2, len(matches)
+    organisms = {match.term.organism for match in matches}
+    assert organisms == {'9606', None}
+
+    matches = gr.ground('Raf1', organisms=['10090', '9606'])
+    assert len(matches) == 2, len(matches)
+    organisms = {match.term.organism for match in matches}
+    assert organisms == {'10090', None}

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -1,4 +1,5 @@
-from gilda.grounder import Grounder
+from gilda.term import Term
+from gilda.grounder import Grounder, filter_for_organism
 from . import appreq
 
 
@@ -83,3 +84,22 @@ def test_aa_synonym():
 
     matches = gr.ground('W-N')
     assert '141447' not in {m.term.id for m in matches}
+
+
+def test_organism_filter():
+    t1 = Term('x', None, None, None, None, None, None, '9606')
+    t2 = Term('x', None, None, None, None, None, None, '10090')
+    t3 = Term('x', None, None, None, None, None, None, None)
+    terms = filter_for_organism([t1, t2, t3],
+                                organisms=['9606'])
+    assert len(terms) == 2, terms
+
+
+def test_organisms():
+    matches = gr.ground('Raf1')
+    assert len(matches) == 5, len(matches)
+    organisms = [match.term.organism for match in matches]
+    print(organisms)
+    for match in matches:
+        print(match.term)
+    assert False

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -131,3 +131,9 @@ def test_organisms():
     assert len(matches) == 2, len(matches)
     organisms = {match.term.organism for match in matches}
     assert organisms == {'10090', None}
+
+
+def test_nonhuman_gene_synonyms():
+    matches = gr.ground('Tau', organisms=['10090'])
+    assert matches[0].term.db == 'UP', matches
+    assert matches[0].term.id == 'P10637', matches

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -93,12 +93,25 @@ def test_organism_filter():
     terms = filter_for_organism([t1, t2, t3],
                                 organisms=['9606'])
     assert len(terms) == 2, terms
+    assert {t.organism for t in terms} == {None, '9606'}
+    terms = filter_for_organism([t1, t2, t3],
+                                organisms=['10090'])
+    assert len(terms) == 2, terms
+    assert {t.organism for t in terms} == {None, '10090'}
+    terms = filter_for_organism([t1, t2, t3],
+                                organisms=['10090', '9606'])
+    assert len(terms) == 2, terms
+    assert {t.organism for t in terms} == {None, '10090'}
+    terms = filter_for_organism([t1, t2, t3],
+                                organisms=['9606', '10090'])
+    assert len(terms) == 2, terms
+    assert {t.organism for t in terms} == {None, '9606'}
 
 
 def test_organisms():
     matches = gr.ground('Raf1')
-    assert len(matches) == 5, len(matches)
-    organisms = [match.term.organism for match in matches]
+    assert len(matches) == 2, len(matches)
+    organisms = {match.term.organism for match in matches}
     print(organisms)
     for match in matches:
         print(match.term)

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -42,8 +42,11 @@ def test_grounder_num_entries():
 
 
 def test_grounder_depluralize():
+    # Note that lookup returns all matches with no de-duplication
+    # or filtering so we get two identical FPLX entries and a yeast protein
+    # entry here.
     entries = gr.lookup('RAFs')
-    assert len(entries) == 2, entries
+    assert len(entries) == 3, entries
     for entry in entries:
         assert entry.norm_text == 'raf'
 

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -36,9 +36,9 @@ def test_grounder_bug():
 
 def test_grounder_num_entries():
     entries = gr.lookup('NPM1')
-    assert len(entries) == 1, entries
+    assert len(entries) == 4, entries
     entries = gr.lookup('H4')
-    assert len(entries) == 5, entries
+    assert len(entries) == 7, entries
 
 
 def test_grounder_depluralize():
@@ -46,7 +46,7 @@ def test_grounder_depluralize():
     # or filtering so we get two identical FPLX entries and a yeast protein
     # entry here.
     entries = gr.lookup('RAFs')
-    assert len(entries) == 3, entries
+    assert len(entries) == 7, entries
     for entry in entries:
         assert entry.norm_text == 'raf'
 
@@ -90,9 +90,10 @@ def test_aa_synonym():
 
 
 def test_organism_filter():
-    t1 = Term('x', None, None, None, None, None, None, '9606')
-    t2 = Term('x', None, None, None, None, None, None, '10090')
-    t3 = Term('x', None, None, None, None, None, None, None)
+    dummy = 'dummy'
+    t1 = Term('x', dummy, dummy, dummy, dummy, dummy, dummy, '9606')
+    t2 = Term('x', dummy, dummy, dummy, dummy, dummy, dummy, '10090')
+    t3 = Term('x', dummy, dummy, dummy, dummy, dummy, dummy, None)
     terms = filter_for_organism([t1, t2, t3],
                                 organisms=['9606'])
     assert len(terms) == 2, terms
@@ -115,22 +116,22 @@ def test_organisms():
     matches = gr.ground('Raf1')
     assert len(matches) == 2, len(matches)
     organisms = {match.term.organism for match in matches}
-    assert organisms == {'9606', None}, organisms
+    assert organisms == {'9606'}, matches
 
     matches = gr.ground('Raf1', organisms=['10090'])
-    assert len(matches) == 2, len(matches)
+    assert len(matches) == 1, len(matches)
     organisms = {match.term.organism for match in matches}
-    assert organisms == {'10090', None}
+    assert organisms == {'10090'}
 
     matches = gr.ground('Raf1', organisms=['9606', '10090'])
     assert len(matches) == 2, len(matches)
     organisms = {match.term.organism for match in matches}
-    assert organisms == {'9606', None}
+    assert organisms == {'9606'}, matches
 
     matches = gr.ground('Raf1', organisms=['10090', '9606'])
-    assert len(matches) == 2, len(matches)
+    assert len(matches) == 1, len(matches)
     organisms = {match.term.organism for match in matches}
-    assert organisms == {'10090', None}
+    assert organisms == {'10090'}, matches
 
 
 def test_nonhuman_gene_synonyms():

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -111,7 +111,7 @@ def test_organism_filter():
 def test_organisms():
     matches = gr.ground('Raf1')
     assert len(matches) == 2, len(matches)
-    organisms = {match.term.organism for match in matches}
+    assert {match.term.organism for match in matches}
     print(organisms)
     for match in matches:
         print(match.term)


### PR DESCRIPTION
This PR adds names and synonyms for proteins of 12 non-human organisms (the ones called "popular organisms" by UniProt) to the grounding resource file. It also allows passing a ranked list of organisms to define a priority order when grounding a string. By default, only human proteins are considered, however, one can also add other organisms to the list as fallback, or provide lists with other organisms being prioritized.