### PR TITLE
Include package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,5 @@
-graft gilda
 graft doc
-prune benchmarks
-prune scripts
-prune notebooks
-prune models
+graft gilda/resources
+include README.md LICENSE
 
 global-exclude *.py[cod] __pycache__ *.so *.dylib .DS_Store *.gpickle
-
-include README.md LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+graft gilda
+graft doc
+prune benchmarks
+prune scripts
+prune notebooks
+prune models
+
+global-exclude *.py[cod] __pycache__ *.so *.dylib .DS_Store *.gpickle
+
+include README.md LICENSE

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,6 @@ setup(name='gilda',
       extras_require={'test': ['nose', 'coverage'],
                       'terms': ['indra'],
                       'benchmarks': ['pandas', 'requests']},
-      keywords=['nlp', 'biology']
+      keywords=['nlp', 'biology'],
+      include_package_data=True,
       )


### PR DESCRIPTION
right now, if you do `from gilda.resources import MESH_MAPPINGS_PATH`, there isn't actually a file there. If you set `include_package_data=True` in the setup configuration, this file should get propagated through to the package. I'm pretty sure this is the case, and if not, you just need to add something to the MANIFEST.in file.