### PR TITLE
Make flask requirement optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ also be run locally as
 python -m gilda.app
 ```
 
+Gilda's optional `[web]` requirements need to be installed to use this command with:
+
+```bash
+pip install git+https://github.com/indralab/gilda.git
+```
+
 Below is an example request using `curl`:
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,10 @@ setup(name='gilda',
           'Programming Language :: Python :: 3.7'
       ],
       packages=find_packages(),
-      install_requires=['regex', 'adeft>=0.4.0', 'boto3', 'flask',
-                        'flask-wtf', 'flask-bootstrap', 'obonet'],
+      install_requires=['regex', 'adeft>=0.4.0', 'boto3', 'obonet'],
       extras_require={'test': ['nose', 'coverage'],
                       'terms': ['indra'],
-                      'benchmarks': ['pandas', 'requests']},
+                      'benchmarks': ['pandas', 'requests'],
+                      'web': ['flask', 'flask-wtf', 'flask-bootstrap']},
       keywords=['nlp', 'biology']
       )


### PR DESCRIPTION
This PR updates the `setup.py` configuration to make the flask dependencies optional for users who might just want the grounding functionalities without installing the web dependencies.

Further, we need to do this for the biomappings repository since there's a conflict between the `flask-bootstrap` and `bootstrap-flask` dependencies in Gilda and Biomappings, respectively.

Related: #41 upgrades Gilda to use `flask-bootstrap`, but this is a rather large change in comparison to changing the requirements - that's why it's now got its own PR.