### PR TITLE
Add human gene synonyms from UniProt

### DIFF
--- a/benchmarks/fplx_evaluation.py
+++ b/benchmarks/fplx_evaluation.py
@@ -120,7 +120,8 @@ def evaluate_new_grounding(grounding, term):
         if term.id == \
                 incorrect_assertions[grounding['text']].get(term.db):
             return 'incorrect'
-    elif not grounding['correct']:
+
+    if not grounding['correct']:
         # If the grounding matches one of the known incorrect ones
         if grounding['db_refs'].get(term.db) == term.id:
             return 'incorrect'

--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 import logging
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -321,25 +321,22 @@ def generate_uniprot_terms(download=False, organisms=None):
                         standard_name, 'synonym', 'uniprot',
                         organism)
             terms.append(term)
-        # For non-human proteins we add the gene name and synonyms
-        # here. For human proteins we get these from HGNC.
-        if organism != '9606':
-            term = Term(normalize(standard_name), standard_name,
-                        ns, id, standard_name, 'name', 'uniprot',
-                        organism)
-            terms.append(term)
-            if gene_synonyms_str:
-                # This is to deal with all the variations in which
-                # synonyms are listed, including degenerate strings
-                # like "; ;"
-                for synonym_group in gene_synonyms_str.split('; '):
-                    for synonym in synonym_group.split(' '):
-                        if not synonym or synonym == ';':
-                            continue
-                        term = Term(normalize(synonym), synonym,
-                                    ns, id, standard_name, 'synonym', 'uniprot',
-                                    organism)
-                        terms.append(term)
+        term = Term(normalize(standard_name), standard_name,
+                    ns, id, standard_name, 'name', 'uniprot',
+                    organism)
+        terms.append(term)
+        if gene_synonyms_str:
+            # This is to deal with all the variations in which
+            # synonyms are listed, including degenerate strings
+            # like "; ;"
+            for synonym_group in gene_synonyms_str.split('; '):
+                for synonym in synonym_group.split(' '):
+                    if not synonym or synonym == ';':
+                        continue
+                    term = Term(normalize(synonym), synonym,
+                                ns, id, standard_name, 'synonym', 'uniprot',
+                                organism)
+                    terms.append(term)
 
     return terms
 

--- a/gilda/tests/test_api.py
+++ b/gilda/tests/test_api.py
@@ -38,9 +38,9 @@ def test_organisms():
     assert len(matches3) == 2, matches3
     assert matches3[0].term.db == 'UP'
     assert matches3[0].term.id == 'P63163'
-    # Here we use SMN again but prioritize human and get two bad groundings
+    # Here we use SMN again but prioritize human and get three bad groundings
     matches4 = ground('SMN', organisms=['9606', '10090'])
-    assert len(matches4) == 2, matches4
+    assert len(matches4) == 3, matches4
     assert all(m.term.organism == '9606' for m in matches4)
     # Finally we try grounding SMN1 with mouse prioritized, don't find a match
     # and end up with the human gene grounding

--- a/gilda/tests/test_generate_terms.py
+++ b/gilda/tests/test_generate_terms.py
@@ -1,4 +1,6 @@
-from gilda.generate_terms import parse_uniprot_synonyms
+from gilda.term import Term
+from gilda.generate_terms import parse_uniprot_synonyms, \
+    filter_out_duplicates
 
 
 def test_parse_embedded_parentheses_uniprot():
@@ -43,3 +45,13 @@ def test_parse_parentheses_in_name():
     assert syms == ['DNA (cytosine-5)-methyltransferase 1', 'EC:2.1.1.37'], \
         syms
 
+
+def test_filter_priority():
+    term1 = Term('mekk2', 'MEKK2', 'HGNC', '6854', 'MAP3K2',
+                 'previous', 'hgnc', '9606')
+    term2 = Term('mekk2', 'MEKK2', 'HGNC', '6854', 'MAP3K2',
+                 'synonym', 'up', '9606')
+    terms = filter_out_duplicates([term1, term2])
+    assert len(terms) == 1
+    term = terms[0]
+    assert term.status == 'synonym'

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -138,3 +138,9 @@ def test_nonhuman_gene_synonyms():
     matches = gr.ground('Tau', organisms=['10090'])
     assert matches[0].term.db == 'UP', matches
     assert matches[0].term.id == 'P10637', matches
+
+
+def test_uniprot_gene_synonym():
+    matches = gr.ground('MEKK2')
+    assert matches[0].term.db == 'HGNC', matches
+    assert matches[0].term.entry_name == 'MAP3K2'

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -46,7 +46,7 @@ def test_grounder_depluralize():
     # or filtering so we get two identical FPLX entries and a yeast protein
     # entry here.
     entries = gr.lookup('RAFs')
-    assert len(entries) == 7, entries
+    assert len(entries) == 9, entries
     for entry in entries:
         assert entry.norm_text == 'raf'
 


### PR DESCRIPTION
This PR changes the grounding resource file to contain human gene synonyms from UniProt which were not included before under the assumption that they were redundant. This fixes #44.