### PR TITLE
Add support for spelling out Greek letters

### DIFF
--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -9,7 +9,7 @@ from adeft.modeling.classify import load_model_info
 from adeft import available_shortforms as available_adeft_models
 from .term import Term
 from .process import normalize, replace_dashes, replace_greek_uni, \
-    replace_greek_latin, depluralize
+    replace_greek_latin, replace_greek_spelled_out, depluralize
 from .scorer import generate_match, score, score_namespace
 from .resources import get_gilda_models, get_grounding_terms
 
@@ -80,6 +80,8 @@ class Grounder(object):
         greek_replaced = normalize(replace_greek_uni(raw_str))
         lookups.add(greek_replaced)
         greek_replaced = normalize(replace_greek_latin(raw_str))
+        lookups.add(greek_replaced)
+        greek_replaced = normalize(replace_greek_spelled_out(raw_str))
         lookups.add(greek_replaced)
         # Finally, we attempt to depluralize the word
         depluralized = normalize(depluralize(raw_str)[0])

--- a/gilda/process.py
+++ b/gilda/process.py
@@ -114,6 +114,14 @@ def replace_greek_latin(s):
     return s
 
 
+def replace_greek_spelled_out(s):
+    """Replace Greek unicode character with latin spelled out.
+    """
+    for greek_uni, greek_spelled_out in greek_alphabet.items():
+        s = s.replace(greek_uni, greek_spelled_out)
+    return s
+
+
 def get_capitalization_pattern(word, beginning_of_sentence=False):
     """Return the type of capitalization for the string.
 

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -144,3 +144,9 @@ def test_uniprot_gene_synonym():
     matches = gr.ground('MEKK2')
     assert matches[0].term.db == 'HGNC', matches
     assert matches[0].term.entry_name == 'MAP3K2'
+
+
+def test_greek_to_spelled_out():
+    matches = gr.ground('interferon-γ')
+    assert matches
+    assert matches[0].term.entry_name == 'IFNG'

--- a/gilda/tests/test_process.py
+++ b/gilda/tests/test_process.py
@@ -1,4 +1,4 @@
-from gilda.process import depluralize
+from gilda.process import depluralize, replace_greek_spelled_out
 
 
 def test_depluralize():
@@ -9,3 +9,8 @@ def test_depluralize():
     assert depluralize('branches') == ('branch', 'plural_es')
     assert depluralize('CDs') == ('CD', 'plural_caps_s')
     assert depluralize('receptors') == ('receptor', 'plural_s')
+
+
+def test_greek():
+    assert replace_greek_spelled_out('interferon-γ') == \
+        'interferon-gamma'


### PR DESCRIPTION
This adds a third normalization mode related to Greek letters, namely to replace unicode Greek letters with their spelled out form.

Fixes #36 