### PR TITLE
Automatically add missing groundings to COVID-19 Disease Map

### DIFF
--- a/scripts/git_patch_process.py
+++ b/scripts/git_patch_process.py
@@ -1,0 +1,69 @@
+"""This is a helper script to edit the git patch created by
+changes in grounding_cell_designer.py on the COVID-19 Disease Map XMLs.
+The edited patch can then be applied and committed to that repo."""
+import sys
+
+
+def get_blocks(fname):
+    """Get blocks of the diff that can be independently filtered."""
+    with open(fname, 'r') as fh:
+        lines = iter(fh.readlines())
+        parts = []
+        line = next(lines)
+        while True:
+            if line.startswith('diff --git'):
+                block = [line]
+                for line in lines:
+                    if line.startswith('@@'):
+                        break
+                    block.append(line)
+                parts.append(block)
+            if line.startswith('@@'):
+                block = [line]
+                for line in lines:
+                    if line.startswith('@@') or line.startswith('dioff --git'):
+                        break
+                    block.append(line)
+                parts.append(block)
+            if line.startswith('\\ No newline'):
+                parts[-1].append(line)
+                try:
+                    line = next(lines)
+                except StopIteration:
+                    break
+            if not lines:
+                break
+    return parts
+
+
+def filter_blocks(blocks):
+    """Filter out spurious diffs caused by XML deserialization/serialization."""
+    new_blocks = []
+    for block in blocks:
+        if any(l.startswith('-<rdf:RDF') for l in block):
+            continue
+        if any(l.startswith('-<math') for l in block):
+            continue
+        if any('&apos;' in l for l in block):
+            continue
+        new_blocks.append(block)
+    return new_blocks
+
+
+def dump_blocks(blocks, fname):
+    """Dump filtered diffs back into a patch file."""
+    with open(fname, 'w') as fh:
+        for block in blocks:
+            for line in block:
+                fh.write(line)
+
+
+if __name__ == '__main__':
+    # 1. run the grounding_cell_designer.py script
+    # 2. in the C19DM repo run git diff --binary > patch.diff
+    # 3. run this script on patch.diff
+    # 4. git apply patch_edited.diff
+    patch_path = sys.argv[1]
+    blocks = get_blocks(patch_path)
+    blocks = filter_blocks(blocks)
+    dump_blocks(blocks, patch_path[:-5] + '_edited.diff')

--- a/scripts/git_patch_process.py
+++ b/scripts/git_patch_process.py
@@ -21,7 +21,7 @@ def get_blocks(fname):
             if line.startswith('@@'):
                 block = [line]
                 for line in lines:
-                    if line.startswith('@@') or line.startswith('dioff --git'):
+                    if line.startswith('@@') or line.startswith('diff --git'):
                         break
                     block.append(line)
                 parts.append(block)

--- a/scripts/grounding_cell_designer.py
+++ b/scripts/grounding_cell_designer.py
@@ -5,10 +5,13 @@ serialize the changes back into XML files."""
 
 import re
 import sys
-from pathlib import Path
 from collections import defaultdict
+from pathlib import Path
 from xml.etree import ElementTree as ET
+
+import click
 from indra.databases import identifiers
+
 import gilda
 
 rdf_str = (
@@ -161,9 +164,11 @@ def dump(et, fname):
         fh.write(xml_str)
 
 
-if __name__ == '__main__':
-    base_path = sys.argv[1]
-    stable_xmls = list(Path(base_path).rglob('*_stable.xml'))
+@click.command()
+@click.argument('directory', type=Path)
+def main(directory: Path):
+    """Run grounding on the directory for the COVID 19 Disease Maps repository."""
+    stable_xmls = list(directory.resolve().rglob('*_stable.xml'))
     for stable_xml in stable_xmls:
         print('Grounding %s' % stable_xml)
         register_all_namespaces(stable_xml)
@@ -172,3 +177,7 @@ if __name__ == '__main__':
         out_fname = stable_xml
         dump(et, out_fname)
         print()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/grounding_cell_designer.py
+++ b/scripts/grounding_cell_designer.py
@@ -22,6 +22,16 @@ namespaces = {'sbml': 'http://www.sbml.org/sbml/level2/version4',
               'dc': 'http://purl.org/dc/elements/1.1/'}
 
 
+irrelevant_grounding_ns = {'pubmed', 'taxonomy', 'doi', 'wikipathways', 'pdb',
+                           'intact', 'biogrid', 'pmc'}
+relevant_grounding_ns = {'ncbiprotein', 'ncbigene', 'uniprot', 'obo.go',
+                         'obo.chebi', 'pubchem.compound', 'pubchem.substance',
+                         'hgnc', 'hgnc.symbol', 'mesh', 'interpro',
+                         'refseq', 'ensembl', 'ec-code', 'brenda',
+                         'kegg.compound', 'drugbank'}
+irrelevant_classes = {'DEGRADED'}
+
+
 def register_all_namespaces(fname):
     namespaces = dict([node for _, node in
                        ET.iterparse(fname, events=['start-ns'])])
@@ -33,16 +43,22 @@ def add_groundings(et):
     species = et.findall('sbml:model/sbml:listOfSpecies/sbml:species',
                          namespaces=namespaces)
     for species in species:
-        name = species.attrib.get('name')
-        print(name)
+        existing_grounding = get_existing_grounding(species)
+        # Important: this is where we decide if we will add any grounding.
+        # Here we skip this species if it has any relevant grounding
+        if set(existing_grounding) & relevant_grounding_ns:
+            continue
         class_tag = species.find(
             'sbml:annotation/celldesigner:extension/'
             'celldesigner:speciesIdentity/celldesigner:class',
             namespaces=namespaces)
         if class_tag is not None:
-            cls = class_tag.text
-            print(cls)
-        print(get_existing_grounding(species))
+            entity_class = class_tag.text
+            if entity_class in irrelevant_classes:
+                continue
+        name = species.attrib.get('name')
+        print(name)
+        print(entity_class)
         matches = gilda.ground(name)
         if matches:
             print(name, matches[0].term.db, matches[0].term.id,
@@ -54,21 +70,26 @@ def add_groundings(et):
 
 
 def get_existing_grounding(species):
-    grounding_elements = \
-        species.findall('sbml:annotation/rdf:RDF/rdf:Description/'
-                        'bqbiol:isDescribedBy/rdf:Bag/rdf:li',
-                        namespaces=namespaces)
+    # Others: isHomologTo
+    bqbio_tags = ['isDescribedBy', 'isEncodedBy', 'is', 'encodes',
+                  'occursIn']
+
     groundings = defaultdict(list)
-    for element in grounding_elements:
-        urn = element.attrib['{http://www.w3.org/1999/02/22-rdf-syntax-ns#}'
-                             'resource']
-        match = re.match(r'urn:miriam:([^:]+):(.+)', urn)
-        if not match:
-            print('Unmatched urn: %s' % urn)
-            continue
-        else:
-            db_ns, db_id = match.groups()
-            groundings[db_ns].append(db_id)
+    for tag in bqbio_tags:
+        grounding_elements = \
+            species.findall('sbml:annotation/rdf:RDF/rdf:Description/'
+                            'bqbiol:%s/rdf:Bag/rdf:li' % tag,
+                            namespaces=namespaces)
+        for element in grounding_elements:
+            urn = element.attrib['{http://www.w3.org/1999/02/22-rdf-syntax-ns#}'
+                                 'resource']
+            match = re.match(r'urn:miriam:([^:]+):(.+)', urn)
+            if not match:
+                print('Unmatched urn: %s' % urn)
+                continue
+            else:
+                db_ns, db_id = match.groups()
+                groundings[db_ns].append(db_id)
     return groundings
 
 
@@ -114,10 +135,11 @@ def dump(et, fname):
 if __name__ == '__main__':
     base_path = sys.argv[1]
     stable_xmls = list(Path(base_path).rglob('*_stable.xml'))
-    for stable_xml in stable_xmls[:1]:
+    for stable_xml in stable_xmls:
         print('Grounding %s' % stable_xml)
         register_all_namespaces(stable_xml)
         et = ET.parse(stable_xml)
         et = add_groundings(et)
         out_fname = stable_xml.as_posix()[:-4] + '_grounded.xml'
         dump(et, out_fname)
+        print()

--- a/scripts/grounding_cell_designer.py
+++ b/scripts/grounding_cell_designer.py
@@ -1,0 +1,123 @@
+import re
+import sys
+from collections import defaultdict
+import gilda
+from pathlib import Path
+from xml.etree import ElementTree as ET
+from indra.databases import identifiers
+
+rdf_str = (b'<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" '
+           b'xmlns:dc="http://purl.org/dc/elements/1.1/" '
+           b'xmlns:dcterms="http://purl.org/dc/terms/" '
+           b'xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" '
+           b'xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" '
+           b'xmlns:bqmodel="http://biomodels.net/model-qualifiers/">')
+
+namespaces = {'sbml': 'http://www.sbml.org/sbml/level2/version4',
+              'celldesigner': 'http://www.sbml.org/2001/ns/celldesigner',
+              'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+              'bqbiol': 'http://biomodels.net/biology-qualifiers/',
+              'bqmodel': 'http://biomodels.net/model-qualifiers/',
+              'vCard': 'http://www.w3.org/2001/vcard-rdf/3.0#',
+              'dc': 'http://purl.org/dc/elements/1.1/'}
+
+
+def register_all_namespaces(fname):
+    namespaces = dict([node for _, node in
+                       ET.iterparse(fname, events=['start-ns'])])
+    for ns in namespaces:
+        ET.register_namespace(ns, namespaces[ns])
+
+
+def add_groundings(et):
+    species = et.findall('sbml:model/sbml:listOfSpecies/sbml:species',
+                         namespaces=namespaces)
+    for species in species:
+        name = species.attrib.get('name')
+        print(name)
+        class_tag = species.find(
+            'sbml:annotation/celldesigner:extension/'
+            'celldesigner:speciesIdentity/celldesigner:class',
+            namespaces=namespaces)
+        if class_tag is not None:
+            cls = class_tag.text
+            print(cls)
+        print(get_existing_grounding(species))
+        matches = gilda.ground(name)
+        if matches:
+            print(name, matches[0].term.db, matches[0].term.id,
+                  matches[0].term.entry_name)
+            add_grounding_element(species, matches[0].term.db,
+                                  matches[0].term.id)
+        print('---')
+    return et
+
+
+def get_existing_grounding(species):
+    grounding_elements = \
+        species.findall('sbml:annotation/rdf:RDF/rdf:Description/'
+                        'bqbiol:isDescribedBy/rdf:Bag/rdf:li',
+                        namespaces=namespaces)
+    groundings = defaultdict(list)
+    for element in grounding_elements:
+        urn = element.attrib['{http://www.w3.org/1999/02/22-rdf-syntax-ns#}'
+                             'resource']
+        match = re.match(r'urn:miriam:([^:]+):(.+)', urn)
+        if not match:
+            print('Unmatched urn: %s' % urn)
+            continue
+        else:
+            db_ns, db_id = match.groups()
+            groundings[db_ns].append(db_id)
+    return groundings
+
+
+def add_grounding_element(species, db_ns, db_id):
+    identifiers_ns = identifiers.get_identifiers_ns(db_ns)
+    grounding_str = 'urn:miriam:%s:%s' % (identifiers_ns, db_id)
+
+    tag_sequence = [
+        'sbml:annotation',
+        'rdf:RDF',
+        'rdf:Description',
+        'bqmodel:is',
+        'rdf:Bag',
+    ]
+    root = species
+    for tag in tag_sequence:
+        element = root.find(tag, namespaces=namespaces)
+        if element is not None:
+            root = element
+        else:
+            new_element = ET.Element(tag)
+            root.append(new_element)
+            root = new_element
+
+    li = ET.Element('rdf:li', attrib={'rdf:resource': grounding_str})
+    root.append(li)
+    return species
+
+
+def dump(et, fname):
+    xml_str = ET.tostring(et.getroot(), xml_declaration=False,
+                          encoding='UTF-8')
+    xml_str = b'<?xml version="1.0" encoding="UTF-8"?>\n' + xml_str
+    xml_str = xml_str.replace(b'ns0:', b'')
+    xml_str = xml_str.replace(b' />', b'/>')
+    xml_str = xml_str.replace(b'<html>',
+                              b'<html xmlns="http://www.w3.org/1999/xhtml">')
+    xml_str = xml_str.replace(b'<rdf:RDF>', rdf_str)
+    with open(fname, 'wb') as fh:
+        fh.write(xml_str)
+
+
+if __name__ == '__main__':
+    base_path = sys.argv[1]
+    stable_xmls = list(Path(base_path).rglob('*_stable.xml'))
+    for stable_xml in stable_xmls[:1]:
+        print('Grounding %s' % stable_xml)
+        register_all_namespaces(stable_xml)
+        et = ET.parse(stable_xml)
+        et = add_groundings(et)
+        out_fname = stable_xml.as_posix()[:-4] + '_grounded.xml'
+        dump(et, out_fname)


### PR DESCRIPTION
This PR adds a script to process the COVID-19 Disease Map Cell Designer XMLs, identify species with missing grounding, ground them with Gilda based on their string name, and add these groundings as annotations to the XML. The changes can then be committed/PR-ed in that repository for review.