### PR TITLE
API docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ run the container based on the `docker-compose.yml` configuration:
 $ docker-compose up
 ```
 
+## Citation
+
+```bibtex
+@article{gyori2021gilda,
+  author = {Gyori, Benjamin M and Hoyt, Charles Tapley and Steppi, Albert},
+  doi = {10.1101/2021.09.10.459803},
+  journal = {bioRxiv},
+  publisher = {Cold Spring Harbor Laboratory},
+  title = {{Gilda: biomedical entity text normalization with machine-learned disambiguation as a service}},
+  url = {https://www.biorxiv.org/content/10.1101/2021.09.10.459803v1},
+  year = {2021}
+}
+```
+
 ## Funding
 The development of Gilda was funded under the DARPA Communicating with Computers
 program (ARO grant W911NF-15-1-0544).

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -225,3 +225,12 @@ class GetModels(Resource):
         the list of entity texts for which such a model is available.
         """
         return jsonify(get_models())
+
+    def get(self):
+        """Return a list of texts with Gilda disambiguation models.
+
+        Gilda makes available more than one thousand disambiguation models
+        between synonyms shared by multiple genes. This endpoint returns
+        the list of entity texts for which such a model is available.
+        """
+        return jsonify(get_models())

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -200,10 +200,10 @@ class GetNames(Resource):
     @base_ns.response(200, "Get names result", names_model)
     @base_ns.expect(get_names_input_model)
     def post(self):
-        """Return all known entity text for a grounding.
+        """Return all known entity texts for a grounding.
 
         This endpoint can be used as a reverse lookup to find out what entity
-        texts (names, synonyms, etc._ are known for a given grounded entity.
+        texts (names, synonyms, etc.) are known for a given grounded entity.
         """
         if request.json is None:
             abort(Response('Missing application/json header.', 415))


### PR DESCRIPTION
This PR makes some small changes:
- Fix typos in the REST API docs
- Enable GET requests to the `models` endpoint
- Add citation to README