### PR TITLE
Compress and add header to grounding terms file

### DIFF
--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.6.1'
+__version__ = '0.7.0'
 import logging
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -5,6 +5,7 @@ to be available locally."""
 import re
 import os
 import csv
+import gzip
 import json
 import logging
 import requests
@@ -596,7 +597,7 @@ def main():
     logger.info('Dumping into %s' % fname)
     header = ['norm_text', 'text', 'db', 'id', 'entry_name', 'status',
               'source', 'organism']
-    with open(fname, 'w') as fh:
+    with gzip.open(fname, 'wt', encoding='utf-8') as fh:
         writer = csv.writer(fh, delimiter='\t')
         writer.writerow(header)
         writer.writerows([t.to_list() for t in terms])

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -594,7 +594,12 @@ def main():
     terms = get_all_terms()
     from .resources import GROUNDING_TERMS_PATH as fname
     logger.info('Dumping into %s' % fname)
-    write_unicode_csv(fname, [t.to_list() for t in terms], delimiter='\t')
+    header = ['norm_text', 'text', 'db', 'id', 'entry_name', 'status',
+              'source', 'organism']
+    with open(fname, 'w') as fh:
+        writer = csv.writer(fh, delimiter='\t')
+        writer.writerow(header)
+        writer.writerows([t.to_list() for t in terms])
 
 
 if __name__ == '__main__':

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import gzip
 import pickle
 import logging
 import itertools
@@ -339,9 +340,12 @@ def load_terms_file(terms_file):
         A lookup dictionary whose keys are normalized entity texts, and values
         are lists of Terms with that normalized entity text.
     """
-    with open(terms_file, 'r', encoding='utf-8') as fh:
+    with gzip.open(terms_file, 'rt', encoding='utf-8') as fh:
         entries = {}
-        for row in csv.reader(fh, delimiter='\t'):
+        reader = csv.reader(fh, delimiter='\t')
+        # Skip header
+        next(reader)
+        for row in reader:
             row_nones = [r if r else None for r in row]
             entry = Term(*row_nones)
             if row[0] in entries:

--- a/gilda/resources/__init__.py
+++ b/gilda/resources/__init__.py
@@ -12,7 +12,7 @@ MESH_MAPPINGS_PATH = os.path.join(HERE, 'mesh_mappings.tsv')
 
 resource_dir = pystow.join('gilda', __version__)
 
-GROUNDING_TERMS_BASE_NAME = 'grounding_terms.tsv'
+GROUNDING_TERMS_BASE_NAME = 'grounding_terms.tsv.gz'
 GROUNDING_TERMS_PATH = os.path.join(resource_dir, GROUNDING_TERMS_BASE_NAME)
 
 

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -17,6 +17,10 @@ class Term(object):
         The relationship of the text entry to the grounded term, e.g., synonym.
     source : str
         The source from which the term was obtained.
+    organism : Optional[str]
+        When the term represents a protein, this attribute provides the
+        taxonomy code of the species for the protein.
+        For non-proteins, not provided. Default: None
     """
     def __init__(self, norm_text, text, db, id, entry_name, status, source,
                  organism=None):


### PR DESCRIPTION
This PR makes the changes proposed in #59 and #60. It adds a header to the grounding terms file and stores it in a compressed form. Compression does seem to result in slower startup times, as far as I can tell by about 15-20%.  

Fixes #59 and #60.