### PR TITLE
Handle roman vs arabic numerals

### DIFF
--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -10,7 +10,8 @@ from adeft.modeling.classify import load_model_info
 from adeft import available_shortforms as available_adeft_models
 from .term import Term
 from .process import normalize, replace_dashes, replace_greek_uni, \
-    replace_greek_latin, replace_greek_spelled_out, depluralize
+    replace_greek_latin, replace_greek_spelled_out, depluralize, \
+    replace_roman_arabic
 from .scorer import generate_match, score, score_namespace
 from .resources import get_gilda_models, get_grounding_terms
 
@@ -84,9 +85,13 @@ class Grounder(object):
         lookups.add(greek_replaced)
         greek_replaced = normalize(replace_greek_spelled_out(raw_str))
         lookups.add(greek_replaced)
+        # We try exchanging roman and arabic numerals
+        roman_arabic = normalize(replace_roman_arabic(raw_str))
+        lookups.add(roman_arabic)
         # Finally, we attempt to depluralize the word
         depluralized = normalize(depluralize(raw_str)[0])
         lookups.add(depluralized)
+
         logger.debug('Looking up the following strings: %s' %
                      ', '.join(lookups))
         return lookups

--- a/gilda/process.py
+++ b/gilda/process.py
@@ -203,3 +203,36 @@ def depluralize(word):
         return word[:-1], 'plural_s'
     # Note: there don't seem to be any compelling examples of -f or -fe -> ves
     # so it is not implemented
+
+
+def replace_roman_arabic(s):
+    for pattern, result in roman_arabic_patterns:
+        sr = re.sub(pattern, result, s)
+        if sr != s:
+            return sr
+    return s
+
+
+
+def _make_roman_arabic_patterns():
+    roman_arabic = {
+        'I': '1',
+        'II': '2',
+        'III': '3',
+        'IV': '4',
+        'V': '5',
+        'VI': '6',
+        'VII': '7',
+        'VIII': '8',
+        'IX': '9',
+        'X': '10'
+    }
+
+    roman_arabic_patterns = []
+    for r, a in roman_arabic.items():
+        roman_arabic_patterns += [(re.compile(r'^(.*[- ])(%s)$' % a),
+                                   r'\g<1>%s' % b) for a,b in [(r, a), (a, r)]]
+    return roman_arabic_patterns
+
+
+roman_arabic_patterns = _make_roman_arabic_patterns()

--- a/gilda/process.py
+++ b/gilda/process.py
@@ -207,7 +207,9 @@ def depluralize(word):
 
 def replace_roman_arabic(s):
     for pattern, result in roman_arabic_patterns:
-        sr = re.sub(pattern, result, s)
+        sr = pattern.sub(result, s)
+        # This is to make sure we don't replace the string and then apply the
+        # reverse replacement pattern
         if sr != s:
             return sr
     return s

--- a/gilda/process.py
+++ b/gilda/process.py
@@ -230,7 +230,8 @@ def _make_roman_arabic_patterns():
 
     roman_arabic_patterns = []
     for r, a in roman_arabic.items():
-        roman_arabic_patterns += [(re.compile(r'^(.*[- ])(%s)$' % a),
+        roman_arabic_patterns += [(re.compile(r'^(.*[- ])(%s)$' % a,
+                                              re.IGNORECASE),
                                    r'\g<1>%s' % b) for a,b in [(r, a), (a, r)]]
     return roman_arabic_patterns
 

--- a/gilda/process.py
+++ b/gilda/process.py
@@ -234,7 +234,7 @@ def _make_roman_arabic_patterns():
     for r, a in roman_arabic.items():
         roman_arabic_patterns += [(re.compile(r'^(.*[- ])(%s)$' % a,
                                               re.IGNORECASE),
-                                   r'\g<1>%s' % b) for a,b in [(r, a), (a, r)]]
+                                   r'\g<1>%s' % b) for a, b in [(r, a), (a, r)]]
     return roman_arabic_patterns
 
 

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -150,3 +150,9 @@ def test_greek_to_spelled_out():
     matches = gr.ground('interferon-γ')
     assert matches
     assert matches[0].term.entry_name == 'IFNG'
+
+
+def test_roman_arabic_ground():
+    for term in ['neurexin II', 'neurexin 2', 'neurexin-2', 'neurexin-ii']:
+        matches = gr.ground(term)
+        assert any((m.term.db, m.term.id) == ('HGNC', '8009') for m in matches)

--- a/gilda/tests/test_process.py
+++ b/gilda/tests/test_process.py
@@ -1,4 +1,5 @@
-from gilda.process import depluralize, replace_greek_spelled_out
+from gilda.process import depluralize, replace_greek_spelled_out, \
+    replace_roman_arabic
 
 
 def test_depluralize():
@@ -14,3 +15,12 @@ def test_depluralize():
 def test_greek():
     assert replace_greek_spelled_out('interferon-γ') == \
         'interferon-gamma'
+
+
+def test_roman_arabic():
+    assert replace_roman_arabic('xx-1') == 'xx-I'
+    assert replace_roman_arabic('xx-10') == 'xx-X'
+    assert replace_roman_arabic('x1x') == 'x1x'
+    assert replace_roman_arabic('xx-I') == 'xx-1'
+    assert replace_roman_arabic('xx viii') == 'xx 8'
+    assert replace_roman_arabic('xx-iX') == 'xx-9'


### PR DESCRIPTION
This PR implements generating lookup variants that can map across corresponding roman and arabic numerals at the ends of entity strings.

Fixes #64