### PR TITLE
Enable specifying query in path

### DIFF
--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -32,11 +32,19 @@ class GroundForm(FlaskForm):
 
 @app.route('/', methods=['GET', 'POST'])
 def home():
+    text = request.args.get('text')
+    if text is not None:
+        context = request.args.get('context')
+        organisms = request.args.getlist('organisms')
+        matches = ground(text, context=context, organisms=organisms)
+        return render_template('matches.html', matches=matches, version=version,
+                               text=text, context=context)
+
     form = GroundForm()
     if form.validate_on_submit():
         matches = form.get_matches()
-        return render_template('matches.html', matches=matches, form=form,
-                               version=version)
+        return render_template('matches.html', matches=matches, version=version,
+                               text=form.text.data, context=form.context.data)
     return render_template('home.html', form=form, version=version)
 
 

--- a/gilda/app/templates/matches.html
+++ b/gilda/app/templates/matches.html
@@ -6,9 +6,9 @@
 </div>
 <div class="panel-body">
     <p>
-        Results for <code>{{ form.text.data }}</code>
-        {% if form.context.data %} with context
-        <i>{{ form.context.data }}</i>{% endif %}
+        Results for <code>{{ text }}</code>
+        {% if context %} with context
+        <i>{{ context }}</i>{% endif %}
     </p>
 </div>
 <table class="table table-striped table-hover">

--- a/gilda/tests/test_app.py
+++ b/gilda/tests/test_app.py
@@ -8,6 +8,26 @@ from gilda.app.app import app
 class TestApp(unittest.TestCase):
     """A test case for the Gilda Flask application."""
 
+    def test_get_home(self):
+        """Test the GET response on the home page."""
+        with app.test_client() as client:
+            res = client.get("/?text=Raf1")
+            self.assert_raf1_ui(res)
+
+    def test_post_home(self):
+        """Test the POST response on the home page."""
+        with app.test_client() as client:
+            res = client.post("/", json={"text": "Raf1"})
+            self.assert_raf1_ui(res)
+
+    def assert_raf1_ui(self, res) -> None:
+        text = res.data.decode()
+        self.assertEqual(200, res.status_code)
+        self.assertIn('RAF1', text)
+        self.assertIn('0.9998', text)
+        self.assertIn('RNASE3', text)
+        self.assertIn('0.5024', text)
+
     def test_post_grounding(self):
         """Test the POST response with text."""
         with app.test_client() as client:


### PR DESCRIPTION
This PR closes #57 by modifying the function that serves the "/" path. If there is a GET request with an argument called `text` in it, then it assumes the query is passed through path parameters. It also adds unit tests to check that both POST and GET requests do what they're supposed to.

Still to consider:
- The way it accepts organisms is the default, which means you have to double up the `organisms` parameter. Maybe better to parse an entry for commas?