### PR TITLE
Rename assertion to curated and previous to former_name

### DIFF
--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.7.1'
+__version__ = '0.8.0'
 import logging
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -108,7 +108,7 @@ term_model = api.model(
      'status': fields.String(
          description='The relationship of the text entry to the grounded '
                      'term, e.g., synonym.',
-         example='assertion'
+         example='curated'
      ),
      'source': fields.String(
          description='The source from which the term was obtained.',
@@ -154,9 +154,9 @@ get_names_input_model = api.model(
      ),
      'status': fields.String(
          description="If provided, only entity texts of the given status are "
-                     "returned(e.g., assertion, name, synonym, previous).",
+                     "returned (e.g., curated, name, synonym, former_name).",
          required=False,
-         enum=['assertion', 'name', 'synonym', 'previous'],
+         enum=['curated', 'name', 'synonym', 'former_name'],
          example='synonym'
      ),
      'source': fields.String(

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -56,7 +56,7 @@ def generate_hgnc_terms():
             new_id = m.groups()[0]
             new_name = id_name_map[new_id]
             term_args = (normalize(name), name, db, new_id,
-                         new_name, 'previous', 'hgnc', organism)
+                         new_name, 'former_name', 'hgnc', organism)
             all_term_args[term_args] = None
             # NOTE: consider adding withdrawn synonyms e.g.,
             # symbol withdrawn, see pex1     symbol withdrawn, see PEX1
@@ -87,7 +87,7 @@ def generate_hgnc_terms():
             prev_symbols = row['Previous symbols'].split(', ')
             for prev_symbol in prev_symbols:
                 term_args = (normalize(prev_symbol), prev_symbol, db, id, name,
-                             'previous', 'hgnc', organism)
+                             'former_name', 'hgnc', organism)
                 all_term_args[term_args] = None
 
     terms = [Term(*args) for args in all_term_args.keys()]
@@ -224,11 +224,11 @@ def generate_famplex_terms(ignore_mappings=False):
         groundings = {k: v for k, v in zip(row[1::2], row[2::2]) if (k and v)}
         if 'FPLX' in groundings:
             id = groundings['FPLX']
-            term = Term(norm_txt, txt, 'FPLX', id, id, 'assertion', 'famplex')
+            term = Term(norm_txt, txt, 'FPLX', id, id, 'curated', 'famplex')
         elif 'HGNC' in groundings:
             id = groundings['HGNC']
             term = Term(norm_txt, txt, 'HGNC', hgnc_client.get_hgnc_id(id), id,
-                        'assertion', 'famplex', '9606')
+                        'curated', 'famplex', '9606')
         elif 'UP' in groundings:
             db = 'UP'
             id = groundings['UP']
@@ -248,24 +248,24 @@ def generate_famplex_terms(ignore_mappings=False):
             # comes from and then add that organism info, otherwise
             # these groundings will be asserted even if the organism
             # doesn't match
-            term = Term(norm_txt, txt, db, id, name, 'assertion', 'famplex',
+            term = Term(norm_txt, txt, db, id, name, 'curated', 'famplex',
                         organism)
         elif 'CHEBI' in groundings:
             id = groundings['CHEBI']
             name = chebi_client.get_chebi_name_from_id(id[6:])
-            term = Term(norm_txt, txt, 'CHEBI', id, name, 'assertion',
+            term = Term(norm_txt, txt, 'CHEBI', id, name, 'curated',
                         'famplex')
         elif 'GO' in groundings:
             id = groundings['GO']
             term = Term(norm_txt, txt, 'GO', id,
-                        go_client.get_go_label(id), 'assertion', 'famplex')
+                        go_client.get_go_label(id), 'curated', 'famplex')
         elif 'MESH' in groundings:
             id = groundings['MESH']
             mesh_mapping = mesh_mappings.get(id)
             db, db_id, name = mesh_mapping if (mesh_mapping
                                                and not ignore_mappings) else \
                 ('MESH', id, mesh_client.get_mesh_name(id))
-            term = Term(norm_txt, txt, db, db_id, name, 'assertion', 'famplex')
+            term = Term(norm_txt, txt, db, db_id, name, 'curated', 'famplex')
         else:
             # TODO: handle HMDB, PUBCHEM, CHEMBL
             continue
@@ -539,7 +539,7 @@ mesh_mappings, mesh_mappings_reverse = _make_mesh_mappings()
 def filter_out_duplicates(terms):
     logger.info('Filtering %d terms for uniqueness...' % len(terms))
     term_key = lambda term: (term.db, term.id, term.text)
-    statuses = {'assertion': 1, 'name': 2, 'synonym': 3, 'previous': 4}
+    statuses = {'curated': 1, 'name': 2, 'synonym': 3, 'former_name': 4}
     new_terms = []
     for _, terms in itertools.groupby(sorted(terms, key=lambda x: term_key(x)),
                                       key=lambda x: term_key(x)):

--- a/gilda/scorer.py
+++ b/gilda/scorer.py
@@ -230,10 +230,10 @@ def score_string_match(match):
 
 def score_status(term):
     scores = {
-        'assertion': 4,
+        'curated': 4,
         'name': 3,
         'synonym': 2,
-        'previous': 1,
+        'former_name': 1,
     }
     return scores[term.status]
 

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -9,9 +9,9 @@ gr = Grounder()
 def test_grounder():
     entries = gr.lookup('kras')
     statuses = [e.status for e in entries]
-    assert 'assertion' in statuses
+    assert 'curated' in statuses
     for entry in entries:
-        if entry.status == 'assertion':
+        if entry.status == 'curated':
             assert entry.id == '6407', entry
 
     scores = gr.ground('kras')

--- a/models/find_ambiguities.py
+++ b/models/find_ambiguities.py
@@ -31,8 +31,8 @@ def get_ambiguities(skip_assertions=True, skip_names=True):
         # If there is a name in statuses, we skip it because it's prioritized
         if skip_names and 'name' in statuses:
             continue
-        # We skip assertions because they are prioritized anyway
-        if skip_assertions and 'assertion' in statuses:
+        # We skip curated terms because they are prioritized anyway
+        if skip_assertions and 'curated' in statuses:
             continue
         # We can't get CHEBI PMIDs yet
         if 'CHEBI' in dbs:


### PR DESCRIPTION
This PR renames status categories for clarity from `assertion` to `curated` and from `previous` to `former_name`.