### PR TITLE
Improve synonym extraction from UniProt

### DIFF
--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -296,8 +296,6 @@ def generate_uniprot_terms(download=False, organisms=None):
 def get_terms_from_uniprot_row(row):
     terms = []
     up_id = row['Entry']
-    if up_id.startswith('P62805'):
-        breakpoint()
     organism = row['Organism ID']
     protein_names = parse_uniprot_synonyms(row['Protein names'])
     primary_gene_name = row['Gene names  (primary )'].strip()
@@ -383,11 +381,10 @@ def parse_uniprot_synonyms(synonyms_str):
             return [synonyms_str] + syns
 
         syn = find_block_from_right(synonyms_str)
-        syns = [syn] + syns
-        synonyms_str = synonyms_str[:-len(syn)-3]
         # EC codes are not valid synonyms
         if not re.match(r'EC [\d\.-]+', syn):
             syns = [syn] + syns
+        synonyms_str = synonyms_str[:-len(syn)-3]
 
 
 def generate_adeft_terms():

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -288,60 +288,68 @@ def generate_uniprot_terms(download=False, organisms=None):
             fh.write(res.text)
     terms = []
     for row in read_csv(path, delimiter='\t', header=True):
-        up_id = row['Entry']
-        organism = row['Organism ID']
-        protein_names = parse_uniprot_synonyms(row['Protein names'])
-        primary_gene_name = row['Gene names  (primary )'].strip()
-        if primary_gene_name == ';':
-            primary_gene_name = None
-        gene_synonyms_str = row['Gene names  (synonym )'].strip()
-        if gene_synonyms_str == ';':
-            gene_synonyms_str = None
-        # We generally use the gene name as the standard name
-        # except when there are multiple gene names (separated by
-        # semi-colons) in which case we take the first protein name.
-        if not primary_gene_name or ';' in primary_gene_name:
-            standard_name = protein_names[0]
-        else:
-            standard_name = primary_gene_name
-        # We skip a small number of not critical entries that don't have
-        # standard names
-        if not standard_name:
+        terms += get_terms_from_uniprot_row(row)
+
+    return terms
+
+
+def get_terms_from_uniprot_row(row):
+    terms = []
+    up_id = row['Entry']
+    if up_id.startswith('P62805'):
+        breakpoint()
+    organism = row['Organism ID']
+    protein_names = parse_uniprot_synonyms(row['Protein names'])
+    primary_gene_name = row['Gene names  (primary )'].strip()
+    if primary_gene_name == ';':
+        primary_gene_name = None
+    gene_synonyms_str = row['Gene names  (synonym )'].strip()
+    if gene_synonyms_str == ';':
+        gene_synonyms_str = None
+    # We generally use the gene name as the standard name
+    # except when there are multiple gene names (separated by
+    # semi-colons) in which case we take the first protein name.
+    if not primary_gene_name or ';' in primary_gene_name:
+        standard_name = protein_names[0]
+    else:
+        standard_name = primary_gene_name
+    # We skip a small number of non-critical entries that don't have
+    # standard names
+    if not standard_name:
+        return []
+    ns = 'UP'
+    id = up_id
+    hgnc_id = uniprot_client.get_hgnc_id(up_id)
+    if hgnc_id:
+        ns = 'HGNC'
+        id = hgnc_id
+        standard_name = hgnc_client.get_hgnc_name(hgnc_id)
+    for name in protein_names:
+        # Skip names that are EC codes
+        if name.startswith('EC '):
             continue
-        ns = 'UP'
-        id = up_id
-        hgnc_id = uniprot_client.get_hgnc_id(up_id)
-        if hgnc_id:
-            ns = 'HGNC'
-            id = hgnc_id
-            standard_name = hgnc_client.get_hgnc_name(hgnc_id)
-        for name in protein_names:
-            # Skip names that are EC codes
-            if name.startswith('EC '):
-                continue
-            if name == standard_name:
-                continue
-            term = Term(normalize(name), name, ns, id,
-                        standard_name, 'synonym', 'uniprot',
-                        organism)
-            terms.append(term)
-        term = Term(normalize(standard_name), standard_name,
-                    ns, id, standard_name, 'name', 'uniprot',
+        if name == standard_name:
+            continue
+        term = Term(normalize(name), name, ns, id,
+                    standard_name, 'synonym', 'uniprot',
                     organism)
         terms.append(term)
-        if gene_synonyms_str:
-            # This is to deal with all the variations in which
-            # synonyms are listed, including degenerate strings
-            # like "; ;"
-            for synonym_group in gene_synonyms_str.split('; '):
-                for synonym in synonym_group.split(' '):
-                    if not synonym or synonym == ';':
-                        continue
-                    term = Term(normalize(synonym), synonym,
-                                ns, id, standard_name, 'synonym', 'uniprot',
-                                organism)
-                    terms.append(term)
-
+    term = Term(normalize(standard_name), standard_name,
+                ns, id, standard_name, 'name', 'uniprot',
+                organism)
+    terms.append(term)
+    if gene_synonyms_str:
+        # This is to deal with all the variations in which
+        # synonyms are listed, including degenerate strings
+        # like "; ;"
+        for synonym_group in gene_synonyms_str.split('; '):
+            for synonym in synonym_group.split(' '):
+                if not synonym or synonym == ';':
+                    continue
+                term = Term(normalize(synonym), synonym,
+                            ns, id, standard_name, 'synonym', 'uniprot',
+                            organism)
+                terms.append(term)
     return terms
 
 

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -300,7 +300,7 @@ def get_terms_from_uniprot_row(row):
     protein_names = parse_uniprot_synonyms(row['Protein names'])
 
     # These two lists are aligned and each separated by "; " if there
-    # are multiple genes. If there are not genes listed, we simply have
+    # are multiple genes. If there are no genes listed, we simply have
     # an empty string here. If there are multiple genes but one doesn't
     # have a name given, a corresponding "; " placeholder is still there.
     # Consequently, we encounter cases like
@@ -323,7 +323,7 @@ def get_terms_from_uniprot_row(row):
     if not standard_name:
         return []
 
-    # By default we use the UniProt namespace and ID
+    # By default, we use the UniProt namespace and ID
     ns = 'UP'
     id = up_id
     # For human genes, we resolve redundancies by mapping to HGNC
@@ -363,10 +363,10 @@ def get_terms_from_uniprot_row(row):
                                                 gene_synonyms):
             all_synonyms = gene_synonyms_str.split(' ')
             # We can skip a gene name if we used it as standard name
-            if gene_name != standard_name:
+            if gene_name and (gene_name != standard_name):
                 all_synonyms.append(gene_name)
             for synonym in all_synonyms:
-                if not synonym or synonym == ';':
+                if not synonym:
                     continue
                 term = Term(normalize(synonym), synonym,
                             ns, id, standard_name, 'synonym', 'uniprot',

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -298,30 +298,44 @@ def get_terms_from_uniprot_row(row):
     up_id = row['Entry']
     organism = row['Organism ID']
     protein_names = parse_uniprot_synonyms(row['Protein names'])
-    primary_gene_name = row['Gene names  (primary )'].strip()
-    if primary_gene_name == ';':
-        primary_gene_name = None
-    gene_synonyms_str = row['Gene names  (synonym )'].strip()
-    if gene_synonyms_str == ';':
-        gene_synonyms_str = None
+
+    # These two lists are aligned and each separated by "; " if there
+    # are multiple genes. If there are not genes listed, we simply have
+    # an empty string here. If there are multiple genes but one doesn't
+    # have a name given, a corresponding "; " placeholder is still there.
+    # Consequently, we encounter cases like
+    # P34539»·; »·; »·
+    # where there are two genes but neither of them have names or
+    # synonyms listed.
+    primary_gene_names = row['Gene names  (primary )'].split('; ')
+    gene_synonyms = row['Gene names  (synonym )'].split('; ')
+
+    multi_gene = len(primary_gene_names) > 1
+
     # We generally use the gene name as the standard name
-    # except when there are multiple gene names (separated by
-    # semi-colons) in which case we take the first protein name.
-    if not primary_gene_name or ';' in primary_gene_name:
+    # except when there are multiple gene names or the gene name is missing
+    if not primary_gene_names or multi_gene:
         standard_name = protein_names[0]
     else:
-        standard_name = primary_gene_name
+        standard_name = primary_gene_names[0]
     # We skip a small number of non-critical entries that don't have
     # standard names
     if not standard_name:
         return []
+
+    # By default we use the UniProt namespace and ID
     ns = 'UP'
     id = up_id
+    # For human genes, we resolve redundancies by mapping to HGNC
     hgnc_id = uniprot_client.get_hgnc_id(up_id)
-    if hgnc_id:
+    # We only map to HGNC if there is a single gene corresponding to
+    # this protein. Otherwise, we keep the UniProt ID.
+    if hgnc_id and not multi_gene:
         ns = 'HGNC'
         id = hgnc_id
         standard_name = hgnc_client.get_hgnc_name(hgnc_id)
+
+    # We add all of the protein names as synonyms
     for name in protein_names:
         # Skip names that are EC codes
         if name.startswith('EC '):
@@ -332,16 +346,26 @@ def get_terms_from_uniprot_row(row):
                     standard_name, 'synonym', 'uniprot',
                     organism)
         terms.append(term)
+
+    # We add the standard name (usually the gene name)
     term = Term(normalize(standard_name), standard_name,
                 ns, id, standard_name, 'name', 'uniprot',
                 organism)
     terms.append(term)
-    if gene_synonyms_str:
-        # This is to deal with all the variations in which
-        # synonyms are listed, including degenerate strings
-        # like "; ;"
-        for synonym_group in gene_synonyms_str.split('; '):
-            for synonym in synonym_group.split(' '):
+
+    # If we have gene synonyms we include them according to the following logic.
+    # For human genes we do not include synonyms if there are multiple genes
+    # corresponding to this protein. For non-human genes, since we don't
+    # have a separate gene resource, we do include gene names and synonyms
+    # even if there are multiple genes corresponding to the protein.
+    if not ((organism == '9606') and multi_gene):
+        for gene_name, gene_synonyms_str in zip(primary_gene_names,
+                                                gene_synonyms):
+            all_synonyms = gene_synonyms_str.split(' ')
+            # We can skip a gene name if we used it as standard name
+            if gene_name != standard_name:
+                all_synonyms.append(gene_name)
+            for synonym in all_synonyms:
                 if not synonym or synonym == ';':
                     continue
                 term = Term(normalize(synonym), synonym,

--- a/gilda/tests/test_api.py
+++ b/gilda/tests/test_api.py
@@ -40,7 +40,7 @@ def test_organisms():
     assert matches3[0].term.id == 'P63163'
     # Here we use SMN again but prioritize human and get three bad groundings
     matches4 = ground('SMN', organisms=['9606', '10090'])
-    assert len(matches4) == 3, matches4
+    assert len(matches4) == 2, matches4
     assert all(m.term.organism == '9606' for m in matches4)
     # Finally we try grounding SMN1 with mouse prioritized, don't find a match
     # and end up with the human gene grounding

--- a/gilda/tests/test_generate_terms.py
+++ b/gilda/tests/test_generate_terms.py
@@ -58,12 +58,35 @@ def test_filter_priority():
 
 
 def test_get_terms_simple():
-    row = {'Entry': 'P15056', 'Gene names  (primary )': 'BRAF',
-    'Gene names  (synonym )': 'BRAF1 RAFB1',
-    'Protein names': ('Serine/threonine-protein kinase B-raf (EC 2.7.11.1) '
-        '(Proto-oncogene B-Raf) (p94) (v-Raf murine sarcoma viral '
-        'oncogene homolog B1)'),
-    'Organism ID': '9606'}
+    row = {'Entry': 'P15056',
+           'Gene names  (primary )': 'BRAF',
+           'Gene names  (synonym )': 'BRAF1 RAFB1',
+           'Protein names':
+               ('Serine/threonine-protein kinase B-raf '
+                '(EC 2.7.11.1) (Proto-oncogene B-Raf) (p94) '
+                '(v-Raf murine sarcoma viral oncogene homolog B1)'),
+           'Organism ID': '9606'}
     terms = get_terms_from_uniprot_row(row)
     assert len(terms) == 7, terms
     assert all(term.db == 'HGNC' for term in terms), terms
+
+
+def test_get_terms_multi_gene_human():
+    row = {'Entry': 'P62805',
+           'Gene names  (primary )':
+               ('H4C1; H4C2; H4C3; H4C4; H4C5; H4C6; H4C8;'
+                ' H4C9; H4C11; H4C12; H4C13; H4C14; H4C15; H4-16'),
+           'Gene names  (synonym )': ('H4/A H4FA HIST1H4A; H4/I H4FI HIST1H4B; '
+                                      'H4/G H4FG HIST1H4C; H4/B H4FB HIST1H4D; '
+                                      'H4/J H4FJ HIST1H4E; H4/C H4FC HIST1H4F; '
+                                      'H4/H H4FH HIST1H4H; H4/M H4FM HIST1H4I; '
+                                      'H4/E H4FE HIST1H4J; H4/D H4FD HIST1H4K; '
+                                      'H4/K H4FK HIST1H4L; H4/N H4F2 H4FN '
+                                      'HIST2H4 HIST2H4A; H4/O H4FO HIST2H4B; '
+                                      'HIST4H4'),
+           'Protein names': 'Histone H4',
+           'Organism ID': '9606'}
+    terms = get_terms_from_uniprot_row(row)
+    assert len(terms) == 1, terms
+    assert terms[0].db == 'UP'
+    assert terms[0].text == 'Histone H4'

--- a/gilda/tests/test_generate_terms.py
+++ b/gilda/tests/test_generate_terms.py
@@ -1,6 +1,6 @@
 from gilda.term import Term
 from gilda.generate_terms import parse_uniprot_synonyms, \
-    filter_out_duplicates
+    filter_out_duplicates, get_terms_from_uniprot_row
 
 
 def test_parse_embedded_parentheses_uniprot():
@@ -55,3 +55,15 @@ def test_filter_priority():
     assert len(terms) == 1
     term = terms[0]
     assert term.status == 'synonym'
+
+
+def test_get_terms_simple():
+    row = {'Entry': 'P15056', 'Gene names  (primary )': 'BRAF',
+    'Gene names  (synonym )': 'BRAF1 RAFB1',
+    'Protein names': ('Serine/threonine-protein kinase B-raf (EC 2.7.11.1) '
+        '(Proto-oncogene B-Raf) (p94) (v-Raf murine sarcoma viral '
+        'oncogene homolog B1)'),
+    'Organism ID': '9606'}
+    terms = get_terms_from_uniprot_row(row)
+    assert len(terms) == 7, terms
+    assert all(term.db == 'HGNC' for term in terms), terms

--- a/gilda/tests/test_generate_terms.py
+++ b/gilda/tests/test_generate_terms.py
@@ -90,3 +90,16 @@ def test_get_terms_multi_gene_human():
     assert len(terms) == 1, terms
     assert terms[0].db == 'UP'
     assert terms[0].text == 'Histone H4'
+
+
+def test_get_terms_multi_gene_nonhuman():
+    row = {'Entry': 'P62784',
+           'Gene names  (primary )': ('his-1; his-5; his-10; his-14; his-18; '
+                                      'his-26; his-28; his-31; his-37; his-38; '
+                                      'his-46; his-50; his-56; his-60; '
+                                      'his-64; his-67'),
+           'Gene names  (synonym )': '; ; ; ; ; ; ; ; ; ; ; ; ; ; ; ',
+           'Protein names': 'Histone H4',
+           'Organism ID': '6239'}
+    terms = get_terms_from_uniprot_row(row)
+    assert len(terms) == 17

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,9 @@ setup(name='gilda',
       classifiers=[
           'Development Status :: 4 - Beta',
           'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7'
+          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
       ],
       packages=find_packages(),
       install_requires=['regex', 'adeft>=0.11.0', 'boto3', 'flask',


### PR DESCRIPTION
This PR does another round of improvements on extracting names/synonyms from UniProt:
- Refactor processing code to make unit testing easier
- Remove EC-code synonyms that were inadvertently reintroduced in a previous PR
- Improve the handling of gene names and synonyms, including for cases where there are multiple corresponding genes listed