### PR TITLE
Exclude entity synonyms for activity processes

### DIFF
--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -207,6 +207,13 @@ def generate_go_terms():
         # Next look at synonyms, sometimes those match the name so we
         # deduplicate
         for synonym in set(entry.get('synonyms', [])) - {name}:
+            # GO includes around 40k synonyms for terms that represent
+            # activity out of which around 5k are actually
+            # synonyms for entities. One example is "EGFR" as a synonym
+            # for "epidermal growth factor-activated receptor activity".
+            # We skip these according to the following logic.
+            if 'activity' in name and 'activity' not in synonym:
+                continue
             term = Term(normalize(synonym), synonym, 'GO', go_id, name,
                         'synonym', 'go')
             terms.append(term)

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -156,3 +156,8 @@ def test_roman_arabic_ground():
     for term in ['neurexin II', 'neurexin 2', 'neurexin-2', 'neurexin-ii']:
         matches = gr.ground(term)
         assert any((m.term.db, m.term.id) == ('HGNC', '8009') for m in matches)
+
+
+def test_ground_go_activity():
+    matches = gr.ground('EGFR')
+    assert 'GO' not in {m.term.db for m in matches}, matches


### PR DESCRIPTION
This PR excludes entity synonyms from GO for activity processes, e.g., "EGFR" for "epidermal growth factor-activated receptor activity" to avoid spurious matches.