### PR TITLE
Improve traceability of matches

### DIFF
--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.8.1'
+__version__ = '0.8.2'
 import logging
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -119,7 +119,16 @@ term_model = api.model(
                      'the taxonomy identifier of the species to which '
                      'it belongs.',
          example='9606'
-     )}
+     ),
+     'source_db': fields.String(
+         description='In some cases the term\'s db/id was mapped from another '
+                     'db/id pair given in the original source. If this is the '
+                     'case, this field provides the original source db.'),
+     'source_id': fields.String(
+         description='In some cases the term\'s db/id was mapped from another '
+                     'db/id pair given in the original source. If this is the '
+                     'case, this field provides the original source ID.')
+    }
 )
 
 scored_match_model = api.model(
@@ -136,7 +145,15 @@ scored_match_model = api.model(
      ),
      'match': fields.Nested(api.model('Match', {}),
          description='Additional metadata about the nature of the match.'
-     )}
+     ),
+     'subsumed_terms': fields.List(fields.Nested(term_model),
+         description='In some cases multiple terms with the same db/id '
+                     'matched the input string, potentially with different '
+                     'scores, and only the first one is exposed in the '
+                     'scored match\'s term attribute (see above). This field '
+                     'provides additional terms with the same db/id that '
+                     'matched the input for additional traceability.')
+     }
 )
 
 
@@ -182,7 +199,7 @@ models_model = fields.List(
 @base_ns.route('/ground', methods=['POST'])
 class Ground(Resource):
     # NOTE: formally this response should be a list
-    @base_ns.response(200, "Grounding results", scored_match_model)
+    @base_ns.response(200, "Grounding results", [scored_match_model])
     @base_ns.expect(grounding_input_model)
     def post(self):
         """Return a list of scored grounding matches for a given entity text.

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -164,6 +164,7 @@ def generate_mesh_terms(ignore_mappings=False):
                        'mesh_supp_id_label_mappings.tsv']
     terms = []
     for fname in mesh_name_files:
+        logger.info('Loading %s' % fname)
         mesh_names_file = os.path.join(indra_resources, fname)
         for row in read_csv(mesh_names_file, header=False, delimiter='\t'):
             db_id = row[0]
@@ -298,6 +299,7 @@ def generate_uniprot_terms(download=False, organisms=None):
         with open(path, 'w') as fh:
             fh.write(res.text)
     terms = []
+    logger.info('Loading %s' % path)
     for row in read_csv(path, delimiter='\t', header=True):
         terms += get_terms_from_uniprot_row(row)
 
@@ -308,6 +310,11 @@ def get_terms_from_uniprot_row(row):
     terms = []
     up_id = row['Entry']
     organism = row['Organism ID']
+
+    # As of 3/2/2022 there is an error in UniProt data that we need to manually
+    # patch here
+    if up_id == 'Q2QKR2':
+        row['Protein names'] = row['Protein names'][:-1]
     protein_names = parse_uniprot_synonyms(row['Protein names'])
 
     # These two lists are aligned and each separated by "; " if there

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -300,6 +300,12 @@ class ScoredMatch(object):
         The Match object characterizing the match to the Term.
     disambiguation : Optional[dict]
         Meta-information about disambiguation, when available.
+    subsumed_terms : Optional[list[gilda.grounder.Term]]
+        A list of additional Term objects that also matched, have the same
+        db/id value as the term associated with the match, but were further
+        down the score ranking. In some cases examining the subsumed terms
+        associated with a match can provide additional metadata in
+        downstream applications.
     """
     def __init__(self, term, score, match, disambiguation=None,
                  subsumed_terms=None):

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -1,3 +1,4 @@
+import copy
 import csv
 import json
 import gzip
@@ -237,7 +238,10 @@ class Grounder(object):
         for _, entry_group in entry_groups:
             entries = sorted(list(entry_group), key=lambda x: x.score,
                              reverse=True)
-            unique_entries.append(entries[0])
+            first_entry = copy.deepcopy(entries[0])
+            first_entry.subsumed_terms = [copy.deepcopy(e.term)
+                                          for e in entries[1:]]
+            unique_entries.append(first_entry)
         # Return the list of unique entries
         return unique_entries
 
@@ -297,12 +301,14 @@ class ScoredMatch(object):
     disambiguation : Optional[dict]
         Meta-information about disambiguation, when available.
     """
-    def __init__(self, term, score, match, disambiguation=None):
+    def __init__(self, term, score, match, disambiguation=None,
+                 subsumed_terms=None):
         self.term = term
         self.url = term.get_idenfiers_url()
         self.score = score
         self.match = match
         self.disambiguation = disambiguation
+        self.subsumed_terms = subsumed_terms if subsumed_terms else None
 
     def __str__(self):
         disamb_str = '' if self.disambiguation is None else \
@@ -322,6 +328,9 @@ class ScoredMatch(object):
         }
         if self.disambiguation is not None:
             js['disambiguation'] = self.disambiguation
+        if self.subsumed_terms:
+            js['subsumed_terms'] = [term.to_json()
+                                    for term in self.subsumed_terms]
         return js
 
     def multiply(self, value):

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -21,6 +21,14 @@ class Term(object):
         When the term represents a protein, this attribute provides the
         taxonomy code of the species for the protein.
         For non-proteins, not provided. Default: None
+    source_db : Optional[str]
+        If the term's db/id was mapped from a different, original db/id
+        from a given source, this attribute provides the original db value
+        before mapping.
+    source_id : Optional[str]
+        If the term's db/id was mapped from a different, original db/id
+        from a given source, this attribute provides the original ID value
+        before mapping.
     """
     def __init__(self, norm_text, text, db, id, entry_name, status, source,
                  organism=None, source_db=None, source_id=None):

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -23,7 +23,7 @@ class Term(object):
         For non-proteins, not provided. Default: None
     """
     def __init__(self, norm_text, text, db, id, entry_name, status, source,
-                 organism=None):
+                 organism=None, source_db=None, source_id=None):
         if not text:
             raise ValueError('Text for Term cannot be empty')
         self.norm_text = norm_text
@@ -34,11 +34,14 @@ class Term(object):
         self.status = status
         self.source = source
         self.organism = organism
+        self.source_db = source_db
+        self.source_id = source_id
 
     def __str__(self):
-        return 'Term(%s,%s,%s,%s,%s,%s,%s,%s)' % (
+        return 'Term(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)' % (
             self.norm_text, self.text, self.db, self.id, self.entry_name,
-            self.status, self.source, self.organism)
+            self.status, self.source, self.organism, self.source_db,
+            self.source_id)
 
     def __repr__(self):
         return str(self)
@@ -56,13 +59,17 @@ class Term(object):
         }
         if self.organism:
             js['organism'] = self.organism
+        if self.source_db:
+            js['source_db'] = self.source_db
+        if self.source_id:
+            js['source_id'] = self.source_id
         return js
 
     def to_list(self):
         """Return the term serialized into a list of strings."""
         return [self.norm_text, self.text, self.db, self.id,
                 self.entry_name, self.status, self.source,
-                self.organism]
+                self.organism, self.source_db, self.source_id]
 
     def get_idenfiers_url(self):
         return get_identifiers_url(self.db, self.id)

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -180,3 +180,14 @@ def test_unidecode():
         assert len(matches) == 1
         assert (matches[0].term.db, matches[0].term.id) == \
             ('MESH', 'C000605741')
+
+
+def test_subsumed_terms():
+    txt = 'mitochondria'
+    matches = gr.ground(txt)
+    assert len(matches) == 1
+    match = matches[0]
+    assert match.term.db == 'GO'
+    assert len(match.subsumed_terms) == 1
+    assert match.subsumed_terms[0].db == 'GO', match.subsumed_terms[0]
+    assert match.subsumed_terms[0].source_db == 'MESH', match.subsumed_terms[0]

--- a/gilda/tests/test_term.py
+++ b/gilda/tests/test_term.py
@@ -15,3 +15,10 @@ def test_term_get_url():
                 norm_text='x', text='X', source='test', status='name')
     assert term.get_idenfiers_url() == \
         'https://identifiers.org/CHEBI:12345'
+
+
+def test_term_source_db_id():
+    term = Term('mitochondria', 'Mitochondria', 'GO', 'GO:0005739',
+                'mitochondrion', 'synonym', 'mesh', None, 'MESH', 'D008928')
+    assert term.source_db == 'MESH'
+    assert term.source_id == 'D008928'


### PR DESCRIPTION
This PR improves the traceability of matches to source data in two ways:
- First, Terms are sometimes constructed in a way that their namespace and ID are mapped from the original source (e.g., MeSH IDs are sometimes normalized to equivalent GO IDs). These original namespaces and IDs can now be preserved explicitly in the Term as attributes and can be made use of downstream.
- Second, when there are multiple terms that match to a given namespace and ID during grounding (potentially with different scores), we choose the highest scoring match and don't expose the rest of the redundant matches to the same namespace/ID. This PR adds a new slot for ScoredMatch objects to expose these subsumed terms that were also matched.

These two changes allow downstream applications to trace matches back to the original source data in more sophisticated ways.