### PR TITLE
Add more information to web UI via modals

### DIFF
--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -24,10 +24,10 @@ class GroundForm(FlaskForm):
         'Text',
         validators=[DataRequired()],
         description=dedent("""\
-            Input the entity text (e.g., <code>k-ras</code>) to ground. Click
-            <a type="button" href="#" data-toggle="modal" data-target="#text-modal">
-            here <i class="far fa-question-circle">
-            </i></a> for more information."""
+            Input the entity text (e.g., <code>k-ras</code>) to ground."""
+            #Click <a type="button" href="#" data-toggle="modal" data-target="#text-modal">
+            #here <i class="far fa-question-circle">
+            #</i></a> for more information
         ),
     )
     context = TextAreaField(
@@ -45,12 +45,10 @@ class GroundForm(FlaskForm):
         id='organism-select',
         description=dedent("""\
             Optionally select one or more taxonomy
-            species IDs to define a species priority list which is applied
-            in case matches are found to proteins from multiple species (human,
-            mouse, yeast, etc). Click
+            species IDs to define a species priority list.  Click
             <a type="button" href="#" data-toggle="modal" data-target="#species-modal">
             here <i class="far fa-question-circle">
-            </i></a> for more information about species disambiguation.
+            </i></a> for more details.
         """),
     )
     submit = SubmitField('Submit')

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -15,6 +15,7 @@ from gilda.resources import popular_organisms
 app = Flask(__name__)
 app.config['RESTX_MASK_SWAGGER'] = False
 app.config['WTF_CSRF_ENABLED'] = False
+app.config['SWAGGER_UI_DOC_EXPANSION'] = 'list'
 Bootstrap(app)
 
 

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -10,7 +10,7 @@ from wtforms.validators import DataRequired
 
 from gilda.api import *
 from gilda import __version__ as version
-from gilda.resources import popular_organisms
+from gilda.resources import popular_organisms, organism_labels
 
 app = Flask(__name__)
 app.config['RESTX_MASK_SWAGGER'] = False
@@ -33,20 +33,19 @@ class GroundForm(FlaskForm):
     context = TextAreaField(
         'Context (optional)',
         description=dedent("""\
-            Provide additional context (e.g., the sentence or paragraph
-            in which the entity text appeared) to help disambiguation. Click
+            Optionally provide additional text context to help disambiguation. Click
             <a type="button" href="#" data-toggle="modal" data-target="#context-modal">
             here <i class="far fa-question-circle">
-            </i></a> for more information about context disambiguation.
+            </i></a> for more details.
         """)
     )
     organisms = SelectMultipleField(
         'Species priority (optional)',
-        choices=[(org, org) for org in popular_organisms],
+        choices=[(org, organism_labels[org]) for org in popular_organisms],
         id='organism-select',
         description=dedent("""\
-            You can also optionally select one or more taxonomy
-            species IDs to define a species priority list which is applied in
+            Optionally select one or more taxonomy
+            species IDs to define a species priority list which is applied
             in case matches are found to proteins from multiple species (human,
             mouse, yeast, etc). Click
             <a type="button" href="#" data-toggle="modal" data-target="#species-modal">

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -1,3 +1,5 @@
+from textwrap import dedent
+
 from flask import Flask, Response, abort, jsonify, render_template, request
 from flask_bootstrap import Bootstrap
 from flask_restx import Api, Resource, fields
@@ -17,12 +19,40 @@ Bootstrap(app)
 
 
 class GroundForm(FlaskForm):
-    text = StringField('Text', validators=[DataRequired()])
-    context = TextAreaField('Context (optional)')
-    organisms = SelectMultipleField('Species priority (optional)',
-                                    choices=[(org, org)
-                                             for org in popular_organisms],
-                                    id='organism-select')
+    text = StringField(
+        'Text',
+        validators=[DataRequired()],
+        description=dedent("""\
+            Input the entity text to ground, e.g., <a>k-ras</a>. Click
+            <a type="button" href="#" data-toggle="modal" data-target="#text-modal">
+            here <i class="far fa-question-circle">
+            </i></a> for more information."""
+        ),
+    )
+    context = TextAreaField(
+        'Context (optional)',
+        description=dedent("""\
+            Provide additional context (e.g., the sentence or paragraph
+            in which the entity text appeared) to help disambiguation. Click
+            <a type="button" href="#" data-toggle="modal" data-target="#context-modal">
+            here <i class="far fa-question-circle">
+            </i></a> for more information about context disambiguation.
+        """)
+    )
+    organisms = SelectMultipleField(
+        'Species priority (optional)',
+        choices=[(org, org) for org in popular_organisms],
+        id='organism-select',
+        description=dedent("""\
+            You can also optionally select one or more taxonomy
+            species IDs to define a species priority list which is applied in
+            in case matches are found to proteins from multiple species (human,
+            mouse, yeast, etc). Click
+            <a type="button" href="#" data-toggle="modal" data-target="#species-modal">
+            here <i class="far fa-question-circle">
+            </i></a> for more information about species disambiguation.
+        """),
+    )
     submit = SubmitField('Submit')
 
     def get_matches(self):

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -87,7 +87,9 @@ api = Api(app,
           description="A service for grounding entity strings",
           version=version,
           license="Code available under the BSD 2-Clause License",
-          contact="benjamin_gyori@hms.harvard.edu",
+          contact="INDRA labs",
+          contact_email="indra.sysbio@gmail.com",
+          contact_url="https://indralab.github.io",
           doc='/apidocs',
           )
 

--- a/gilda/app/app.py
+++ b/gilda/app/app.py
@@ -23,7 +23,7 @@ class GroundForm(FlaskForm):
         'Text',
         validators=[DataRequired()],
         description=dedent("""\
-            Input the entity text to ground, e.g., <a>k-ras</a>. Click
+            Input the entity text (e.g., <code>k-ras</code>) to ground. Click
             <a type="button" href="#" data-toggle="modal" data-target="#text-modal">
             here <i class="far fa-question-circle">
             </i></a> for more information."""

--- a/gilda/app/templates/base.html
+++ b/gilda/app/templates/base.html
@@ -4,6 +4,11 @@
 {% import "bootstrap/fixes.html" as fixes %}
 {% import "bootstrap/utils.html" as util %}
 
+{% block head %}
+    {{ super() }}
+    <script src="https://kit.fontawesome.com/4c86883252.js" crossorigin="anonymous"></script>
+{% endblock %}
+
 {% block content %}
 
 <div class="container" style="margin-top: 30px;">
@@ -14,18 +19,10 @@
       </div>
       <div class="panel-body">
         <p>
-          This is version {{ version }} of the Gilda grounding service.
-        For interactive use, enter an entity text (example: k-ras)
-        to ground in the form below. You can optionally provide additional
-        context (e.g., the sentence in which the entity text appeared) to help
-        disambiguation. You can also optionally select one or more taxonomy
-        species IDs to define a species priority list which is applied in
-        in case matches are found to proteins from multiple species (human,
-        mouse, yeast, etc).
-      </p>
-      <p>
+            The Gilda grounding service (v{{ version }}) can be used to
+            identify structured identifiers for entity names like <code>k-ras</code>.
         For programmatic access, POST requests to the <code>/ground</code>
-        endpoint. See the <a href="apidocs">API documentation</a>.
+        endpoint. See the <a href="apidocs">API documentation</a>
         or the <a href="https://github.com/indralab/gilda/blob/master/README.md">user guide</a>
         for more information.
       </p>
@@ -44,7 +41,6 @@
       Point of contact: Benjamin M. Gyori (benjamin_gyori [AT]
       hms.harvard.edu).
       </p>
-    </small>
     </div>
   </div>
 </div>

--- a/gilda/app/templates/base.html
+++ b/gilda/app/templates/base.html
@@ -20,10 +20,9 @@
       <div class="panel-body">
         <p>
             The Gilda grounding service (v{{ version }}) can be used to
-            identify structured identifiers for entity names like <code>k-ras</code>.
-        For programmatic access, POST requests to the <code>/ground</code>
-        endpoint. See the <a href="apidocs">API documentation</a>
-        or the <a href="https://github.com/indralab/gilda/blob/master/README.md">user guide</a>
+            identify structured identifiers for entity names.</p><p>
+        For programmatic access, see the <a href="apidocs">API documentation</a>
+        and the <a href="https://github.com/indralab/gilda/blob/master/README.md">user guide</a>
         for more information.
       </p>
       </div>

--- a/gilda/app/templates/home.html
+++ b/gilda/app/templates/home.html
@@ -62,7 +62,7 @@
             </div>
             <div class="modal-body">
                 <p>
-                    Context modal main text
+                    There is no hard requirement for how much context should be (optionally) provided for disambiguation. In practice, the context provided could be a sentence, a paragraph, or even an entire article. While it is not required that the context contain the entity text being grounded, in practice, context usually consists of text surrounding and including the entity. Overall, given that disambiguation models integrated from Adeft as well as the models made available independently by Gilda rely on word frequency-derived features, it is generally helpful if context text contains terms characteristic to the given sense of the ambiguous string. Additionally, since Adeft models have the ability to recognize defining patterns (i.e., an explicit spelled out definition of an ambiguous acronym), any context text containing such patterns is useful.
                 </p>
             </div>
         </div>

--- a/gilda/app/templates/home.html
+++ b/gilda/app/templates/home.html
@@ -55,7 +55,7 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="contextModalLabel">Context Modal Header</h5>
+                <h5 class="modal-title" id="contextModalLabel">Context text</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -73,14 +73,18 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="speciesModalLabel">Species Modal Header</h5>
+                <h5 class="modal-title" id="speciesModalLabel">Species prioritization</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
             <div class="modal-body">
                 <p>
-                    Species modal main text
+                    Species prioritization is applied in case matches are found to proteins from multiple species (human,
+                    mouse, yeast, etc). In case of matches to multiple species for a given input,
+                    this (optional) input list is used to prioritize matches. The priority list can be determined
+                    based on the user case or knowledge about the context in which the given entity text
+                    appeared. The species list is adopted from UniProt's "popular organisms" list (https://www.uniprot.org/help/filter_options).
                 </p>
             </div>
         </div>

--- a/gilda/app/templates/home.html
+++ b/gilda/app/templates/home.html
@@ -1,7 +1,17 @@
 {% extends "base.html" %}
+
+{% block head %}
+    {{ super() }}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
+    <style>
+        div.choices {
+            margin-bottom: 0;
+        }
+    </style>
+{% endblock %}
+
 {% block gcontent %}
 <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
 <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
 
 <script>
@@ -21,5 +31,59 @@
     {{ wtf.form_field(form.organisms, class_="form-control") }}
     {{ wtf.form_field(form.submit, class="btn btn-primary")}}
     </form>
+</div>
+
+<div class="modal fade" id="text-modal" tabindex="-1" role="dialog" aria-labelledby="textModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="textModalLabel">Text Modal Header</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p>
+                    Text modal main text
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="context-modal" tabindex="-1" role="dialog" aria-labelledby="contextModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="contextModalLabel">Context Modal Header</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p>
+                    Context modal main text
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="species-modal" tabindex="-1" role="dialog" aria-labelledby="speciesModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="speciesModalLabel">Species Modal Header</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p>
+                    Species modal main text
+                </p>
+            </div>
+        </div>
+    </div>
 </div>
 {% endblock %}

--- a/gilda/resources/__init__.py
+++ b/gilda/resources/__init__.py
@@ -22,6 +22,22 @@ popular_organisms = ['9606', '10090', '10116', '9913', '7955', '7227',
                      '6239', '44689', '3702', '39947', '83333', '224308',
                      '559292']
 
+organism_labels = {
+    '9606': 'Homo sapiens',
+    '10090': 'Mus musculus',
+    '10116': 'Rattus norvegicus',
+    '9913': 'Bos taurus',
+    '7955': 'Danio rerio',
+    '7227': 'Drosophila melanogaster',
+    '6239': 'Caenorhabditis elegans',
+    '44689': 'Dictyostelium discoideum',
+    '3702': 'Arabidopsis thaliana',
+    '39947': 'Oryza sativa',
+    '83333': 'Escherichia coli',
+    '224308': 'Bacillus subtilis',
+    '559292': 'Saccharomyces cerevisiae',
+}
+
 # NOTE: these are not all exact mappings..
 # Several mappings here are to the closest match which works correctly
 # in this setting but isn't generally speaking a valid xref.


### PR DESCRIPTION
This PR uses the `description` field in WTForms to add some extra information below each form field. I moved some of the text from the header in there and added stubs for the modals were we can add much more detailed information.

Note that tests will continue failing until #80 is merged since it updated the data model and uploaded new data files to S3.