### PR TITLE
Add HGNC alias names as synonyms

### DIFF
--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.8.2'
+__version__ = '0.8.3'
 import logging
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -60,6 +60,8 @@ def generate_hgnc_terms():
     url += '&'.join(['status=%s' % s for s in statuses]) + '&'
     url += '&'.join(['%s=%s' % (k, v) for k, v in params.items()])
 
+    # Download the file
+    logger.info('Downloading HGNC resource file')
     res = requests.get(url)
     with open(fname, 'w') as fh:
         fh.write(res.text)

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -119,11 +119,11 @@ def generate_hgnc_terms():
                 all_term_args[term_args] = None
 
         if row['Alias names']:
-            for name in extract_hgnc_alias_names(row['Alias names']):
-                name = name.strip()
+            for alias_name in extract_hgnc_alias_names(row['Alias names']):
+                alias_name = alias_name.strip()
                 # There are double quotes and sometimes spurious extra spaces
-                term_args = (normalize(name), name, db, id, name, 'synonym',
-                             'hgnc_alias', organism)
+                term_args = (normalize(alias_name), alias_name, db, id, name,
+                             'synonym', 'synonym', organism)
                 all_term_args[term_args] = None
 
     terms = [Term(*args) for args in all_term_args.keys()]

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -191,3 +191,8 @@ def test_subsumed_terms():
     assert len(match.subsumed_terms) == 1
     assert match.subsumed_terms[0].db == 'GO', match.subsumed_terms[0]
     assert match.subsumed_terms[0].source_db == 'MESH', match.subsumed_terms[0]
+
+
+def test_hgnc_alias_names():
+    matches = gr.ground("FP prostanoid receptor")
+    assert ('HGNC', '9600') in {(m.term.db, m.term.id) for m in matches}


### PR DESCRIPTION
Resolves #78. This PR adds alias names from HGNC for human genes. It also changes the implementation of getting HGNC synonyms to use a direct download rather than a resource file from INDRA.