### PR TITLE
Expose all groundings and namespaces, and allow filtering

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,6 +40,7 @@ release = gilda_version
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx_autodoc_typehints',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.coverage',

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 sphinx
+sphinx_autodoc_typehints
 sphinx_rtd_theme
 mock
 boto3

--- a/gilda/api.py
+++ b/gilda/api.py
@@ -12,9 +12,11 @@ class GrounderInstance(object):
             self.grounder = Grounder()
         return self.grounder
 
-    def ground(self, text, context=None, organisms=None):
+    def ground(self, text, context=None, organisms=None,
+               namespaces=None):
         return self.get_grounder().ground(text, context=context,
-                                          organisms=organisms)
+                                          organisms=organisms,
+                                          namespaces=namespaces)
 
     def get_models(self):
         return self.get_grounder().get_models()
@@ -28,7 +30,7 @@ class GrounderInstance(object):
 grounder = GrounderInstance()
 
 
-def ground(text, context=None, organisms=None):
+def ground(text, context=None, organisms=None, namespaces=None):
     """Return a list of scored matches for a text to ground.
 
     Parameters
@@ -39,6 +41,12 @@ def ground(text, context=None, organisms=None):
         Any additional text that serves as context for disambiguating the
         given entity text, used if a model exists for disambiguating the
         given text.
+    organisms : Optional[List[str]]
+        A list of taxonomy identifiers to use as a priority list
+        when surfacing matches for proteins/genes from multiple organisms.
+    namespaces : Optional[List[str]]
+        A list of namespaces to restrict the matches to. By default, no
+        restriction is applied.
 
     Returns
     -------

--- a/gilda/app/templates/matches.html
+++ b/gilda/app/templates/matches.html
@@ -8,7 +8,14 @@
     <p>
         Results for <code>{{ text }}</code>
         {% if context %} with context
-        <i>{{ context }}</i>{% endif %}
+        <i>{{ context }}</i>{% endif %}.
+
+
+        The table below contains the retrieved Groundings ordered by descreasing
+        score. The standard name for the entry is given in the Name column.
+        Additional groundings are provided for some entries where a match was
+        found to an equivalent term in a namespace different from the primary
+        grounding's.
     </p>
 </div>
 <table class="table table-striped table-hover">

--- a/gilda/app/templates/matches.html
+++ b/gilda/app/templates/matches.html
@@ -18,6 +18,7 @@
         <th>Identifier</th>
         <th>Name</th>
         <th>Score</th>
+        <th>Groundings</th>
     </tr>
     </thead>
     <tbody>
@@ -27,6 +28,15 @@
         <td><a href="{{ match['url'] }}">{{ match['term']['id'] }}</a></td>
         <td>{{ match['term']['entry_name'] }}</td>
         <td class="text-right">{{ match['score'] | round(4)}}</td>
+        <td>
+            {% for xref_ns, xref_id in match.get_groundings() %}
+            {% if xref_ns != match.term.db and xref_id != match.term.id %}
+            <a class="badge badge-light" href="https://bioregistry.io/{{ xref_ns }}:{{ xref_id }}">
+                {{ xref_ns }}:{{ xref_id }}
+            </a>
+            {% endif %}
+            {% endfor %}
+        </td>
     </tr>
     {% endfor %}
     </tbody>

--- a/gilda/app/templates/matches.html
+++ b/gilda/app/templates/matches.html
@@ -14,24 +14,26 @@
 <table class="table table-striped table-hover">
     <thead>
     <tr>
-        <th>Database</th>
-        <th>Identifier</th>
+        <th>Grounding</th>
         <th>Name</th>
         <th>Score</th>
-        <th>Groundings</th>
+        <th>Additional Groundings</th>
     </tr>
     </thead>
     <tbody>
     {% for match in matches %}
     <tr>
-        <td>{{ match['term']['db'] }}</td>
-        <td><a href="{{ match['url'] }}">{{ match['term']['id'] }}</a></td>
+        <td>
+            <a class="label label-primary" href="{{ match['url'] }}">
+                {{ match.term.get_identifiers_curie() }}
+            </a>
+        </td>
         <td>{{ match['term']['entry_name'] }}</td>
         <td class="text-right">{{ match['score'] | round(4)}}</td>
         <td>
             {% for xref_ns, xref_id in match.get_groundings() %}
             {% if xref_ns != match.term.db and xref_id != match.term.id %}
-            <a class="badge badge-light" href="https://bioregistry.io/{{ xref_ns }}:{{ xref_id }}">
+            <a class="label label-info" href="https://bioregistry.io/{{ xref_ns }}:{{ xref_id }}">
                 {{ xref_ns }}:{{ xref_id }}
             </a>
             {% endif %}

--- a/gilda/app/templates/matches.html
+++ b/gilda/app/templates/matches.html
@@ -25,7 +25,7 @@
     <tr>
         <td>
             <a class="label label-primary" href="{{ match['url'] }}">
-                {{ match.term.get_identifiers_curie() }}
+                {{ match.term.get_curie() }}
             </a>
         </td>
         <td>{{ match['term']['entry_name'] }}</td>

--- a/gilda/app/templates/matches.html
+++ b/gilda/app/templates/matches.html
@@ -9,8 +9,8 @@
         Results for <code>{{ text }}</code>
         {% if context %} with context
         <i>{{ context }}</i>{% endif %}.
-
-
+    </p>
+    <p>
         The table below contains the retrieved Groundings ordered by descreasing
         score. The standard name for the entry is given in the Name column.
         Additional groundings are provided for some entries where a match was

--- a/gilda/app/templates/matches.html
+++ b/gilda/app/templates/matches.html
@@ -23,18 +23,19 @@
     <tbody>
     {% for match in matches %}
     <tr>
+    {% set match_curie = match.term.get_curie() %}
         <td>
             <a class="label label-primary" href="{{ match['url'] }}">
-                {{ match.term.get_curie() }}
+                {{ match_curie }}
             </a>
         </td>
         <td>{{ match['term']['entry_name'] }}</td>
         <td class="text-right">{{ match['score'] | round(4)}}</td>
         <td>
-            {% for xref_ns, xref_id in match.get_groundings() %}
-            {% if xref_ns != match.term.db and xref_id != match.term.id %}
-            <a class="label label-info" href="https://bioregistry.io/{{ xref_ns }}:{{ xref_id }}">
-                {{ xref_ns }}:{{ xref_id }}
+            {% for xref_curie, xref_url in match.get_grounding_dict().items() %}
+            {% if xref_curie != match_curie %}
+            <a class="label label-info" href="{{ xref_url }}">
+                {{ xref_curie }}
             </a>
             {% endif %}
             {% endfor %}

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -5,11 +5,11 @@ import pickle
 import logging
 import itertools
 from collections import defaultdict
-from typing import Set, Tuple
+from typing import Mapping, Set, Tuple
 from adeft.disambiguate import load_disambiguator
 from adeft.modeling.classify import load_model_info
 from adeft import available_shortforms as available_adeft_models
-from .term import Term
+from .term import Term, get_identifiers_curie, get_identifiers_url
 from .process import normalize, replace_dashes, replace_greek_uni, \
     replace_greek_latin, replace_greek_spelled_out, depluralize, \
     replace_roman_arabic
@@ -394,6 +394,13 @@ class ScoredMatch(object):
             for sub_term in self.subsumed_terms:
                 term_groundings |= sub_term.get_groundings()
         return term_groundings
+
+    def get_grounding_dict(self) -> Mapping[str, str]:
+        """Get the groundings as CURIEs and URLs."""
+        return {
+            get_identifiers_curie(db, db_id): get_identifiers_url(db, db_id)
+            for db, db_id in self.get_groundings()
+        }
 
 
 def load_terms_file(terms_file):

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -1,4 +1,3 @@
-import copy
 import csv
 import json
 import gzip
@@ -116,6 +115,12 @@ class Grounder(object):
             ranking among organisms, if genes/proteins from multiple
             organisms match the input. If not provided, the default
             ['9606'] i.e., human is used.
+        namespaces : Optional[List[str]]
+            A list of namespaces to restrict matches to. This will apply to
+            both the primary namespace of a matched term, to any subsumed
+            matches, and to the source namespaces of terms if they were
+            created using cross-reference mappings. By default, no
+            restriction is applied.
 
         Returns
         -------

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -358,9 +358,32 @@ class ScoredMatch(object):
         self.score = self.score * value
 
     def get_namespaces(self) -> Set[str]:
+        """Return all namespaces for this match including from mapped and
+        subsumed terms.
+
+        Returns
+        -------
+        :
+            A set of strings representing namespaces for terms involved in
+            this match, including the namespace for the primary term as well
+            as any subsumed terms, and groundings that come from having
+            mapped an original source grounding during grounding resource
+            construction.
+        """
         return {ns for ns, _ in self.get_groundings()}
 
     def get_groundings(self) -> Set[Tuple[str, str]]:
+        """Return all groundings for this match including from mapped and
+        subsumed terms.
+
+        Returns
+        -------
+        :
+            A set of tuples representing groundings for this match including
+            the grounding for the primary term as well as any subsumed
+            terms, and groundings that come from having mapped an original
+            source grounding during grounding resource construction.
+        """
         term_groundings = self.term.get_groundings()
         if self.subsumed_terms:
             for sub_term in self.subsumed_terms:

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -6,6 +6,7 @@ import pickle
 import logging
 import itertools
 from collections import defaultdict
+from typing import Set, Tuple
 from adeft.disambiguate import load_disambiguator
 from adeft.modeling.classify import load_model_info
 from adeft import available_shortforms as available_adeft_models
@@ -356,12 +357,15 @@ class ScoredMatch(object):
                      % (self.term.entry_name, value))
         self.score = self.score * value
 
-    def get_namespaces(self):
-        term_ns = self.term.get_namespaces()
+    def get_namespaces(self) -> Set[str]:
+        return {ns for ns, _ in self.get_groundings()}
+
+    def get_groundings(self) -> Set[Tuple[str, str]]:
+        term_groundings = self.term.get_groundings()
         if self.subsumed_terms:
             for sub_term in self.subsumed_terms:
-                term_ns |= sub_term.get_namespaces()
-        return term_ns
+                term_groundings |= sub_term.get_groundings()
+        return term_groundings
 
 
 def load_terms_file(terms_file):

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -82,7 +82,8 @@ class Term(object):
                 self.entry_name, self.status, self.source,
                 self.organism, self.source_db, self.source_id]
 
-    def get_identifiers_curie(self):
+    def get_curie(self) -> str:
+        """Get the compact URI for this term."""
         return get_identifiers_curie(self.db, self.id)
 
     def get_idenfiers_url(self):

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -82,6 +82,12 @@ class Term(object):
     def get_idenfiers_url(self):
         return get_identifiers_url(self.db, self.id)
 
+    def get_namespaces(self):
+        namespaces = {self.db}
+        if self.source_db:
+            namespaces.add(self.source_db)
+        return namespaces
+
 
 def get_identifiers_url(db, id):
     url_pattern = 'https://identifiers.org/{db}:{id}'

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -1,3 +1,6 @@
+from typing import Set, Tuple
+
+
 class Term(object):
     """Represents a text entry corresponding to a grounded term.
 
@@ -82,7 +85,13 @@ class Term(object):
     def get_idenfiers_url(self):
         return get_identifiers_url(self.db, self.id)
 
-    def get_namespaces(self):
+    def get_groundings(self) -> Set[Tuple[str, str]]:
+        groundings = {(self.db, self.id)}
+        if self.source_db:
+            groundings.add((self.source_db, self.source_id))
+        return groundings
+
+    def get_namespaces(self) -> Set[str]:
         namespaces = {self.db}
         if self.source_db:
             namespaces.add(self.source_db)

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -1,4 +1,4 @@
-from typing import Set, Tuple
+from typing import Optional, Set, Tuple
 
 
 class Term(object):
@@ -82,6 +82,9 @@ class Term(object):
                 self.entry_name, self.status, self.source,
                 self.organism, self.source_db, self.source_id]
 
+    def get_identifiers_curie(self):
+        return get_identifiers_curie(self.db, self.id)
+
     def get_idenfiers_url(self):
         return get_identifiers_url(self.db, self.id)
 
@@ -116,12 +119,18 @@ class Term(object):
         return namespaces
 
 
-def get_identifiers_url(db, id):
-    url_pattern = 'https://identifiers.org/{db}:{id}'
+def get_identifiers_curie(db, id) -> Optional[str]:
+    curie_pattern = '{db}:{id}'
     if db == 'UP':
         db = 'uniprot'
     id_parts = id.split(':')
     if len(id_parts) == 1:
-        return url_pattern.format(db=db.lower(), id=id)
+        return curie_pattern.format(db=db.lower(), id=id)
     elif len(id_parts) == 2:
-        return url_pattern.format(db=id_parts[0].upper(), id=id_parts[-1])
+        return curie_pattern.format(db=id_parts[0].upper(), id=id_parts[-1])
+
+
+def get_identifiers_url(db, id):
+    curie = get_identifiers_curie(db, id)
+    if curie is not None:
+        return f'https://identifiers.org/{curie}'

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -86,12 +86,30 @@ class Term(object):
         return get_identifiers_url(self.db, self.id)
 
     def get_groundings(self) -> Set[Tuple[str, str]]:
+        """Return all groundings for this term, including from a mapped source.
+
+        Returns
+        -------
+        :
+            A set of tuples representing the main grounding for this term,
+            as well as any source grounding from which the main grounding
+            was mapped.
+        """
         groundings = {(self.db, self.id)}
         if self.source_db:
             groundings.add((self.source_db, self.source_id))
         return groundings
 
     def get_namespaces(self) -> Set[str]:
+        """Return all namespaces for this term, including from a mapped source.
+
+        Returns
+        -------
+        :
+            A set of strings including the main namespace for this term,
+            as well as any source namespace from which the main grounding
+            was mapped.
+        """
         namespaces = {self.db}
         if self.source_db:
             namespaces.add(self.source_db)

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -192,6 +192,12 @@ def test_subsumed_terms():
     assert match.subsumed_terms[0].db == 'GO', match.subsumed_terms[0]
     assert match.subsumed_terms[0].source_db == 'MESH', match.subsumed_terms[0]
 
+    assert match.get_groundings() == {(match.term.db, match.term.id),
+                                      (match.subsumed_terms[0].source_db,
+                                       match.subsumed_terms[0].source_id)}
+    assert match.get_namespaces() == {match.term.db,
+                                      match.subsumed_terms[0].source_db}
+
 
 def test_hgnc_alias_names():
     matches = gr.ground("FP prostanoid receptor")

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -196,3 +196,10 @@ def test_subsumed_terms():
 def test_hgnc_alias_names():
     matches = gr.ground("FP prostanoid receptor")
     assert ('HGNC', '9600') in {(m.term.db, m.term.id) for m in matches}
+
+
+def test_namespaces():
+    matches = gr.ground('KRAS', namespaces=['CHEBI'])
+    assert not matches
+    matches = gr.ground('KRAS', namespaces=['HGNC'])
+    assert matches

--- a/gilda/tests/test_term.py
+++ b/gilda/tests/test_term.py
@@ -17,6 +17,8 @@ def test_term_get_url():
            'CHEBI:12345'
     assert term.get_idenfiers_url() == \
         'https://identifiers.org/CHEBI:12345'
+    assert term.get_groundings() == {(term.db, term.id)}
+    assert term.get_namespaces() == {term.db}
 
 
 def test_term_source_db_id():
@@ -24,3 +26,7 @@ def test_term_source_db_id():
                 'mitochondrion', 'synonym', 'mesh', None, 'MESH', 'D008928')
     assert term.source_db == 'MESH'
     assert term.source_id == 'D008928'
+    assert term.get_groundings() == {(term.db, term.id),
+                                     (term.source_db, term.source_id)}
+
+    assert term.get_namespaces() == {term.db, term.source_db}

--- a/gilda/tests/test_term.py
+++ b/gilda/tests/test_term.py
@@ -13,6 +13,8 @@ def test_standalone_get_url():
 def test_term_get_url():
     term = Term(db='CHEBI', id='CHEBI:12345', entry_name='X',
                 norm_text='x', text='X', source='test', status='name')
+    assert term.get_identifiers_curie() == \
+           'CHEBI:12345'
     assert term.get_idenfiers_url() == \
         'https://identifiers.org/CHEBI:12345'
 

--- a/gilda/tests/test_term.py
+++ b/gilda/tests/test_term.py
@@ -13,7 +13,7 @@ def test_standalone_get_url():
 def test_term_get_url():
     term = Term(db='CHEBI', id='CHEBI:12345', entry_name='X',
                 norm_text='x', text='X', source='test', status='name')
-    assert term.get_identifiers_curie() == \
+    assert term.get_curie() == \
            'CHEBI:12345'
     assert term.get_idenfiers_url() == \
         'https://identifiers.org/CHEBI:12345'


### PR DESCRIPTION
This PR adds new methods for the `Term` and `ScoredMatch` classes that allow easily getting all the namespaces and groundings represented by the given term or match. This facilitates filtering to terms/matches with a given namespace of interest. A namespace argument is then exposed ad different levels of the grounding API to allow filtering matches to a given list of namespaces.