### PR TITLE
Split disambiguation evaluation

### DIFF
--- a/benchmarks/bioid_evaluation.py
+++ b/benchmarks/bioid_evaluation.py
@@ -261,9 +261,7 @@ class BioIDBenchmarker:
                 progress_apply(self._get_row_grounding_list, axis=1)
         elif not context and species:
             df.loc[:, 'groundings'] = df.text. \
-                progress_apply(
-                self._build_grounding_function(context=context, species=species)
-            )
+                progress_apply(self._get_row_grounding_list_no_model, axis=1)
         elif context and not species:
             raise NotImplementedError
         else:
@@ -279,16 +277,11 @@ class BioIDBenchmarker:
             organisms=self._get_organism_priority(row.don_article),
         )
 
-    def _build_grounding_function(self, context: bool = True, species: bool = True):
-        def _f(row):
-            context = self._get_plaintext(row.don_article) if context else None
-            organisms=self._get_organism_priority(row.don_article) if species else None
-            return self._get_grounding_list(
-                row.text,
-                context=context,
-                organisms=organisms,
-            )
-        return _f
+    def _get_row_grounding_list_no_model(self, row):
+        return self._get_grounding_list(
+            row.text,
+            organisms=self._get_organism_priority(row.don_article),
+        )
 
     @lru_cache(maxsize=None)
     def _get_plaintext(self, don_article: str) -> str:

--- a/benchmarks/bioid_evaluation.py
+++ b/benchmarks/bioid_evaluation.py
@@ -410,7 +410,7 @@ class BioIDBenchmarker:
             xref_prefix, xref_id = xref_curie.split(':', maxsplit=1)
             if (prefix, xref_prefix) not in BO_MISSING_XREFS:
                 BO_MISSING_XREFS.add((prefix, xref_prefix))
-                tqdm.write(f'Bioontology is missing mappings from {prefix} to {xref_prefix}')
+                tqdm.write(f'Bioontology v{bio_ontology.version} is missing mappings from {prefix} to {xref_prefix}')
             output.add(xref_curie)
 
         if prefix == 'NCBI gene':
@@ -798,6 +798,11 @@ def main(data: str, results: str, no_model_disambiguation: bool, no_species_disa
     print("Constructing results table...")
     counts, precision_recall, disamb_table = \
         benchmarker.get_results_tables(match='strict')
+    print(
+        f"Gilda v{__version__}, Bio-ontology v{bio_ontology.version},"
+        f" model-based disambiguation={not no_model_disambiguation},"
+        f" species-based disambiguation={not no_species_disambiguation}"
+    )
     print(precision_recall.to_markdown(index=False))
     time = datetime.now().strftime('%y%m%d-%H%M%S')
     if no_model_disambiguation and no_species_disambiguation:


### PR DESCRIPTION
This PR makes it possible to turn off context-based disambiguation but keep species-based disambiguation. It also adds a little extra documentation to the output to remind what gilda and bio-ontology version were used, so you can run

```shell
$ python bioid_evaluation.py
$ python bioid_evaluation.py --no-model-disambiguation
```
and get the two different outputs

## Potential TODOs

- generalize the diff script to make a diff table in the results