### PR TITLE
Generalizations to benchmarks

### DIFF
--- a/benchmarks/bioid_evaluation.py
+++ b/benchmarks/bioid_evaluation.py
@@ -413,6 +413,11 @@ class BioIDBenchmarker:
                 tqdm.write(f'Bioontology v{bio_ontology.version} is missing mappings from {prefix} to {xref_prefix}')
             output.add(xref_curie)
 
+        if prefix == 'UBERON':
+            ub_curie = f'{prefix}:{identifier}'
+            if ub_curie in uberon_mesh_mappings:
+                output.add(uberon_mesh_mappings[ub_curie])
+
         if prefix == 'NCBI gene':
             hgnc_id = get_hgnc_from_entrez(identifier)
             if hgnc_id is not None:
@@ -737,6 +742,24 @@ def get_famplex_members():
 
 
 fplx_members = get_famplex_members()
+
+
+def get_uberon_mesh_mappings():
+    import obonet
+    from indra.databases import mesh_client
+    g = obonet.read_obo('/Users/ben/src/uberon/src/ontology/uberon-edit.obo')
+    mappings = {}
+    for node, data in g.nodes(data=True):
+        xrefs = [x[5:] for x in data.get('xref', []) if x.startswith('MESH')]
+        if len(xrefs) != 1:
+            continue
+        xref = xrefs[0]
+        if mesh_client.get_mesh_name(xref, offline=True):
+            mappings[node] = 'MESH:%s' % xref
+    return mappings
+
+
+uberon_mesh_mappings = get_uberon_mesh_mappings()
 
 
 def get_display_name(ns: str) -> str:

--- a/benchmarks/bioid_evaluation.py
+++ b/benchmarks/bioid_evaluation.py
@@ -424,7 +424,7 @@ class BioIDBenchmarker:
         if prefix == 'PubChem':
             chebi_id = get_chebi_id_from_pubchem(identifier)
             if chebi_id is not None:
-                output.add(f'CHEBI:CHEBI:{chebi_id}')
+                output.add(f'CHEBI:{chebi_id}')
         return output
 
     @staticmethod

--- a/benchmarks/bioid_evaluation.py
+++ b/benchmarks/bioid_evaluation.py
@@ -413,14 +413,6 @@ class BioIDBenchmarker:
                 tqdm.write(f'Bioontology v{bio_ontology.version} is missing mappings from {prefix} to {xref_prefix}')
             output.add(xref_curie)
 
-        if prefix == 'UBERON':
-            ub_curie = f'{prefix}:{identifier}'
-            if ub_curie in uberon_mesh_mappings:
-                output.add(uberon_mesh_mappings[ub_curie])
-        if prefix == 'CL':
-            cl_curie = f'{prefix}:{identifier}'
-            if cl_curie in cl_mesh_mappings:
-                output.add(cl_mesh_mappings[cl_curie])
         if prefix == 'NCBI gene':
             hgnc_id = get_hgnc_from_entrez(identifier)
             if hgnc_id is not None:
@@ -747,6 +739,7 @@ def get_famplex_members():
 fplx_members = get_famplex_members()
 
 
+# NOTE: these mappings are already integrated into equivalences.json
 def get_uberon_mesh_mappings():
     import obonet
     from indra.databases import mesh_client
@@ -762,6 +755,7 @@ def get_uberon_mesh_mappings():
     return mappings
 
 
+# NOTE: these mappings are already integrated into equivalences.json
 def get_cl_mesh_mappings():
     import re
     classdef_prefix = "# Class: obo:"
@@ -777,10 +771,6 @@ def get_cl_mesh_mappings():
             if node and len(mesh_ids) == 1:
                 mappings[node] = list(mesh_ids)[0]
     return mappings
-
-
-uberon_mesh_mappings = get_uberon_mesh_mappings()
-cl_mesh_mappings = get_cl_mesh_mappings()
 
 
 def get_display_name(ns: str) -> str:

--- a/benchmarks/bioid_evaluation.py
+++ b/benchmarks/bioid_evaluation.py
@@ -417,7 +417,10 @@ class BioIDBenchmarker:
             ub_curie = f'{prefix}:{identifier}'
             if ub_curie in uberon_mesh_mappings:
                 output.add(uberon_mesh_mappings[ub_curie])
-
+        if prefix == 'CL':
+            cl_curie = f'{prefix}:{identifier}'
+            if cl_curie in cl_mesh_mappings:
+                output.add(cl_mesh_mappings[cl_curie])
         if prefix == 'NCBI gene':
             hgnc_id = get_hgnc_from_entrez(identifier)
             if hgnc_id is not None:
@@ -759,7 +762,25 @@ def get_uberon_mesh_mappings():
     return mappings
 
 
+def get_cl_mesh_mappings():
+    import re
+    classdef_prefix = "# Class: obo:"
+    mesh_id_pattern = re.compile(r'MESH:[CD][0-9]+')
+    mappings = {}
+    with open('/Users/ben/src/cell-ontology/src/ontology/cl-edit.owl', 'r') as fh:
+        node = None
+        for line in fh:
+            if line.startswith(classdef_prefix):
+                node_owl = line[len(classdef_prefix):len(classdef_prefix) + 10]
+                node = node_owl.replace('_', ':')
+            mesh_ids = set(mesh_id_pattern.findall(line))
+            if node and len(mesh_ids) == 1:
+                mappings[node] = list(mesh_ids)[0]
+    return mappings
+
+
 uberon_mesh_mappings = get_uberon_mesh_mappings()
+cl_mesh_mappings = get_cl_mesh_mappings()
 
 
 def get_display_name(ns: str) -> str:

--- a/benchmarks/data/equivalences.json
+++ b/benchmarks/data/equivalences.json
@@ -1,0 +1,19544 @@
+{
+ "NCBI gene:4137": [
+  "UP:P10636"
+ ],
+ "NCBI gene:17762": [
+  "UP:P10637"
+ ],
+ "NCBI gene:16411": [
+  "UP:Q9QXH4"
+ ],
+ "NCBI gene:15200": [
+  "UP:Q06186"
+ ],
+ "NCBI gene:19374": [
+  "UP:P21784"
+ ],
+ "NCBI gene:16186": [
+  "UP:P34902"
+ ],
+ "NCBI gene:20304": [
+  "UP:P30882"
+ ],
+ "NCBI gene:17329": [
+  "UP:P18340"
+ ],
+ "NCBI gene:15945": [
+  "UP:P17515"
+ ],
+ "NCBI gene:83430": [
+  "UP:Q9EQ14"
+ ],
+ "NCBI gene:12981": [
+  "UP:P01587"
+ ],
+ "NCBI gene:20296": [
+  "UP:P10148"
+ ],
+ "NCBI gene:20297": [
+  "UP:O89093"
+ ],
+ "NCBI gene:4615": [
+  "UP:Q99836"
+ ],
+ "NCBI gene:81622": [
+  "UP:Q9H1C4"
+ ],
+ "NCBI gene:51311": [
+  "UP:Q9NR97"
+ ],
+ "NCBI gene:4790": [
+  "UP:P19838"
+ ],
+ "NCBI gene:2589": [
+  "UP:Q10472"
+ ],
+ "NCBI gene:2590": [
+  "UP:Q10471"
+ ],
+ "NCBI gene:2591": [
+  "UP:Q14435"
+ ],
+ "NCBI gene:829480": [
+  "UP:Q94F62"
+ ],
+ "NCBI gene:1183025": [
+  "UP:Q887C1"
+ ],
+ "NCBI gene:815949": [
+  "UP:P33154"
+ ],
+ "NCBI gene:348": [
+  "UP:P02649"
+ ],
+ "NCBI gene:170731": [
+  "UP:Q80U63"
+ ],
+ "NCBI gene:12064": [
+  "UP:P21237"
+ ],
+ "NCBI gene:20614": [
+  "UP:P60879"
+ ],
+ "NCBI gene:12890": [
+  "UP:P84086"
+ ],
+ "NCBI gene:15357": [
+  "UP:Q01237"
+ ],
+ "NCBI gene:14137": [
+  "UP:P53798"
+ ],
+ "NCBI gene:7003": [
+  "UP:P28347"
+ ],
+ "NCBI gene:8463": [
+  "UP:Q15562"
+ ],
+ "NCBI gene:7005": [
+  "UP:Q99594"
+ ],
+ "NCBI gene:7004": [
+  "UP:Q15561"
+ ],
+ "NCBI gene:10413": [
+  "UP:P46937"
+ ],
+ "NCBI gene:8239": [
+  "UP:Q93008"
+ ],
+ "NCBI gene:9113": [
+  "UP:O95835"
+ ],
+ "NCBI gene:1490": [
+  "UP:P29279"
+ ],
+ "NCBI gene:51421": [
+  "UP:Q9Y2J4"
+ ],
+ "NCBI gene:7314": [
+  "UP:P0CG47"
+ ],
+ "NCBI gene:7316": [
+  "UP:P0CG48"
+ ],
+ "NCBI gene:7311": [
+  "UP:P62987"
+ ],
+ "NCBI gene:6233": [
+  "UP:P62979"
+ ],
+ "NCBI gene:16798": [
+  "UP:Q8BYR2"
+ ],
+ "NCBI gene:50523": [
+  "UP:Q7TSJ6"
+ ],
+ "NCBI gene:378430": [
+  "UP:P60322"
+ ],
+ "NCBI gene:373863": [
+  "UP:Q8IYX4"
+ ],
+ "NCBI gene:339345": [
+  "UP:P60321"
+ ],
+ "NCBI gene:342977": [
+  "UP:P60323"
+ ],
+ "NCBI gene:340719": [
+  "UP:Q8WY41"
+ ],
+ "NCBI gene:9698": [
+  "UP:Q14671"
+ ],
+ "NCBI gene:23369": [
+  "UP:Q8TB72"
+ ],
+ "NCBI gene:213236": [
+  "UP:Q6VY05"
+ ],
+ "NCBI gene:5799": [
+  "UP:Q92932"
+ ],
+ "NCBI gene:23236": [
+  "UP:Q9NQ66"
+ ],
+ "NCBI gene:8394": [
+  "UP:Q99755"
+ ],
+ "NCBI gene:8395": [
+  "UP:O14986"
+ ],
+ "NCBI gene:23396": [
+  "UP:O60331"
+ ],
+ "NCBI gene:1072": [
+  "UP:P23528"
+ ],
+ "NCBI gene:7422": [
+  "UP:P15692"
+ ],
+ "NCBI gene:2332": [
+  "UP:Q06787"
+ ],
+ "NCBI gene:8087": [
+  "UP:P51114"
+ ],
+ "NCBI gene:9513": [
+  "UP:P51116"
+ ],
+ "NCBI gene:2334": [
+  "UP:P51816"
+ ],
+ "NCBI gene:2543084": [
+  "UP:O14114"
+ ],
+ "NCBI gene:2541355": [
+  "UP:O94267"
+ ],
+ "NCBI gene:2540750": [
+  "UP:O60159"
+ ],
+ "NCBI gene:2540219": [
+  "UP:P87314"
+ ],
+ "NCBI gene:2540051": [
+  "UP:P10989"
+ ],
+ "NCBI gene:2538768": [
+  "UP:P14965"
+ ],
+ "NCBI gene:2541932": [
+  "UP:P0CT33"
+ ],
+ "NCBI gene:2538734": [
+  "UP:P15567"
+ ],
+ "NCBI gene:2540825": [
+  "UP:O60016"
+ ],
+ "NCBI gene:2538902": [
+  "UP:P00332"
+ ],
+ "NCBI gene:2541088": [
+  "UP:O94529"
+ ],
+ "NCBI gene:2541633": [
+  "UP:P40381"
+ ],
+ "NCBI gene:60568": [
+  "UP:O08835"
+ ],
+ "NCBI gene:79264": [
+  "UP:Q6S5J6"
+ ],
+ "NCBI gene:16600": [
+  "UP:Q60793"
+ ],
+ "NCBI gene:889": [
+  "UP:O00522"
+ ],
+ "NCBI gene:9314": [
+  "UP:O43474"
+ ],
+ "NCBI gene:20198": [
+  "UP:P07091"
+ ],
+ "NCBI gene:15901": [
+  "UP:Q6GTZ3"
+ ],
+ "NCBI gene:20238": [
+  "UP:P54254"
+ ],
+ "NCBI gene:12562": [
+  "UP:P55284"
+ ],
+ "NCBI gene:12741": [
+  "UP:O54942"
+ ],
+ "NCBI gene:12161": [
+  "UP:P20722"
+ ],
+ "NCBI gene:23939": [
+  "UP:Q9WVS8"
+ ],
+ "NCBI gene:17258": [
+  "UP:Q60929"
+ ],
+ "NCBI gene:17261": [
+  "UP:Q63943"
+ ],
+ "NCBI gene:17260": [
+  "UP:Q8CFN5"
+ ],
+ "NCBI gene:26406": [
+  "UP:Q61084"
+ ],
+ "NCBI gene:23938": [
+  "UP:Q9WVS7"
+ ],
+ "NCBI gene:10243": [
+  "UP:Q9NQX3"
+ ],
+ "NCBI gene:38001": [
+  "UP:Q99323"
+ ],
+ "NCBI gene:31332": [
+  "UP:P48555"
+ ],
+ "NCBI gene:43383": [
+  "UP:P14734"
+ ],
+ "NCBI gene:855828": [
+  "UP:P04386"
+ ],
+ "NCBI gene:44115": [
+  "UP:Q86BI2",
+  "UP:Q9U4U5",
+  "UP:M9PCE9"
+ ],
+ "NCBI gene:42850": [
+  "UP:Q9VCE1"
+ ],
+ "NCBI gene:33563": [
+  "UP:Q9VQQ9"
+ ],
+ "NCBI gene:42499": [
+  "UP:Q9VDE6"
+ ],
+ "NCBI gene:39940": [
+  "UP:Q9VVG4"
+ ],
+ "NCBI gene:40712": [
+  "UP:Q9VNH6"
+ ],
+ "NCBI gene:43163": [
+  "UP:Q7KRZ3",
+  "UP:Q9VBI4"
+ ],
+ "NCBI gene:43161": [
+  "UP:P13098"
+ ],
+ "NCBI gene:37038": [
+  "UP:P13002"
+ ],
+ "NCBI gene:31293": [
+  "UP:P07207"
+ ],
+ "NCBI gene:673": [
+  "UP:P15056"
+ ],
+ "NCBI gene:109880": [
+  "UP:P28028"
+ ],
+ "NCBI gene:2099": [
+  "UP:P03372"
+ ],
+ "NCBI gene:2100": [
+  "UP:Q92731"
+ ],
+ "NCBI gene:15461": [
+  "UP:Q61411"
+ ],
+ "NCBI gene:27154": [
+  "UP:Q9ULD4"
+ ],
+ "NCBI gene:7862": [
+  "UP:P55201"
+ ],
+ "NCBI gene:11143": [
+  "UP:O95251"
+ ],
+ "NCBI gene:4173": [
+  "UP:P33991"
+ ],
+ "NCBI gene:84823": [
+  "UP:Q03252"
+ ],
+ "NCBI gene:7010": [
+  "UP:Q02763"
+ ],
+ "NCBI gene:7075": [
+  "UP:P35590"
+ ],
+ "NCBI gene:11601": [
+  "UP:O35608"
+ ],
+ "NCBI gene:284": [
+  "UP:Q15389"
+ ],
+ "NCBI gene:22339": [
+  "UP:Q00731"
+ ],
+ "NCBI gene:155871": [
+  "UP:P04608"
+ ],
+ "NCBI gene:13051": [
+  "UP:Q9Z0D9"
+ ],
+ "NCBI gene:11816": [
+  "UP:P08226"
+ ],
+ "NCBI gene:14103": [
+  "UP:P41047"
+ ],
+ "NCBI gene:14102": [
+  "UP:P25446"
+ ],
+ "NCBI gene:16193": [
+  "UP:P08505"
+ ],
+ "NCBI gene:351": [
+  "UP:P05067"
+ ],
+ "NCBI gene:17309": [
+  "UP:Q5RKT9"
+ ],
+ "NCBI gene:260302": [
+  "UP:Q8BMI3"
+ ],
+ "NCBI gene:23821": [
+  "UP:P56818"
+ ],
+ "NCBI gene:21415": [
+  "UP:Q9Z1J1"
+ ],
+ "NCBI gene:15376": [
+  "UP:P35583"
+ ],
+ "NCBI gene:13813": [
+  "UP:O54839"
+ ],
+ "NCBI gene:16598": [
+  "UP:Q60843"
+ ],
+ "NCBI gene:15242": [
+  "UP:P43120"
+ ],
+ "NCBI gene:12767": [
+  "UP:P70658"
+ ],
+ "NCBI gene:20671": [
+  "UP:Q61473"
+ ],
+ "NCBI gene:12387": [
+  "UP:Q02248"
+ ],
+ "NCBI gene:17869": [
+  "UP:P01108"
+ ],
+ "NCBI gene:18109": [
+  "UP:P03966"
+ ],
+ "NCBI gene:22642": [
+  "UP:Q60821"
+ ],
+ "NCBI gene:10664": [
+  "UP:P49711"
+ ],
+ "NCBI gene:5885": [
+  "UP:O60216"
+ ],
+ "NCBI gene:8243": [
+  "UP:Q14683"
+ ],
+ "NCBI gene:7157": [
+  "UP:P04637"
+ ],
+ "NCBI gene:4193": [
+  "UP:Q00987"
+ ],
+ "NCBI gene:1026": [
+  "UP:P38936"
+ ],
+ "NCBI gene:84552": [
+  "UP:Q9BYG4"
+ ],
+ "NCBI gene:400916": [
+  "UP:Q8WYQ3"
+ ],
+ "NCBI gene:91607": [
+  "UP:Q7Z7L1"
+ ],
+ "NCBI gene:6117": [
+  "UP:P27694"
+ ],
+ "NCBI gene:4361": [
+  "UP:P49959"
+ ],
+ "NCBI gene:5932": [
+  "UP:Q99708"
+ ],
+ "NCBI gene:12483": [
+  "UP:P35329"
+ ],
+ "NCBI gene:19264": [
+  "UP:S4R1S4",
+  "UP:S4R1M0",
+  "UP:S4R2V1",
+  "UP:Q8C6Q7"
+ ],
+ "NCBI gene:826616": [
+  "UP:Q38806"
+ ],
+ "NCBI gene:820438": [
+  "UP:Q9LHA8"
+ ],
+ "NCBI gene:817155": [
+  "UP:O80982"
+ ],
+ "NCBI gene:820121": [
+  "UP:Q1PER6"
+ ],
+ "NCBI gene:836093": [
+  "UP:P19037"
+ ],
+ "NCBI gene:830841": [
+  "UP:P53492"
+ ],
+ "NCBI gene:7942": [
+  "UP:P19484"
+ ],
+ "NCBI gene:23435": [
+  "UP:Q13148"
+ ],
+ "NCBI gene:2475": [
+  "UP:P42345"
+ ],
+ "NCBI gene:57521": [
+  "UP:Q8N122"
+ ],
+ "NCBI gene:10325": [
+  "UP:Q5VZM2"
+ ],
+ "NCBI gene:1031": [
+  "UP:P42773"
+ ],
+ "NCBI gene:3064": [
+  "UP:P42858"
+ ],
+ "NCBI gene:9474": [
+  "UP:Q9H1Y0"
+ ],
+ "NCBI gene:1639": [
+  "UP:Q14203"
+ ],
+ "NCBI gene:37781": [
+  "UP:Q9W1I0",
+  "UP:Q8SXP8"
+ ],
+ "NCBI gene:31543": [
+  "UP:Q9W437"
+ ],
+ "NCBI gene:94178": [
+  "UP:Q99J21"
+ ],
+ "NCBI gene:12028": [
+  "UP:Q07813"
+ ],
+ "NCBI gene:12018": [
+  "UP:O08734"
+ ],
+ "NCBI gene:6663": [
+  "UP:P56693"
+ ],
+ "NCBI gene:4286": [
+  "UP:O75030"
+ ],
+ "NCBI gene:6901": [
+  "UP:Q16635"
+ ],
+ "NCBI gene:27063": [
+  "UP:Q15327"
+ ],
+ "NCBI gene:3491": [
+  "UP:O00622"
+ ],
+ "NCBI gene:7016": [
+  "UP:Q15569"
+ ],
+ "NCBI gene:890": [
+  "UP:P20248"
+ ],
+ "NCBI gene:8900": [
+  "UP:P78396"
+ ],
+ "NCBI gene:9133": [
+  "UP:O95067"
+ ],
+ "NCBI gene:983": [
+  "UP:P06493"
+ ],
+ "NCBI gene:4801": [
+  "UP:P25208"
+ ],
+ "NCBI gene:12428": [
+  "UP:P51943"
+ ],
+ "NCBI gene:12427": [
+  "UP:Q61456"
+ ],
+ "NCBI gene:12442": [
+  "UP:P30276"
+ ],
+ "NCBI gene:22791": [
+  "UP:P54103"
+ ],
+ "NCBI gene:12550": [
+  "UP:P09803"
+ ],
+ "NCBI gene:18999": [
+  "UP:P20263"
+ ],
+ "NCBI gene:18508": [
+  "UP:P63015"
+ ],
+ "NCBI gene:20664": [
+  "UP:P53783"
+ ],
+ "NCBI gene:50913": [
+  "UP:Q9EQW6"
+ ],
+ "NCBI gene:15407": [
+  "UP:P17919"
+ ],
+ "NCBI gene:20997": [
+  "UP:P20293"
+ ],
+ "NCBI gene:27000": [
+  "UP:Q99543"
+ ],
+ "NCBI gene:18424": [
+  "UP:Q8VD35",
+  "UP:Q8R0B5"
+ ],
+ "NCBI gene:20677": [
+  "UP:Q06831"
+ ],
+ "NCBI gene:20666": [
+  "UP:Q7M6Y2"
+ ],
+ "NCBI gene:13982": [
+  "UP:P19785"
+ ],
+ "NCBI gene:13983": [
+  "UP:O08537"
+ ],
+ "NCBI gene:14460": [
+  "UP:P17679"
+ ],
+ "NCBI gene:11656": [
+  "UP:P08680"
+ ],
+ "NCBI gene:15129": [
+  "UP:P02088"
+ ],
+ "NCBI gene:13665": [
+  "UP:Q6ZWX6"
+ ],
+ "NCBI gene:73830": [
+  "UP:Q9DBZ5"
+ ],
+ "NCBI gene:12013": [
+  "UP:P97302"
+ ],
+ "NCBI gene:15368": [
+  "UP:P14901"
+ ],
+ "NCBI gene:10531": [
+  "UP:Q5JRX3"
+ ],
+ "NCBI gene:852041": [
+  "UP:P32898"
+ ],
+ "NCBI gene:69617": [
+  "UP:Q8K411"
+ ],
+ "NCBI gene:67414": [
+  "UP:Q811U4"
+ ],
+ "NCBI gene:257632": [
+  "UP:Q80SY9"
+ ],
+ "NCBI gene:7154475": [
+  "UP:A0A0H3MIQ3"
+ ],
+ "NCBI gene:18260": [
+  "UP:Q61146"
+ ],
+ "NCBI gene:21872": [
+  "UP:P39447"
+ ],
+ "NCBI gene:57533": [
+  "UP:Q9P2M4"
+ ],
+ "NCBI gene:27095": [
+  "UP:O43617"
+ ],
+ "NCBI gene:22878": [
+  "UP:Q9Y2L5"
+ ],
+ "NCBI gene:8766": [
+  "UP:P62491"
+ ],
+ "NCBI gene:5861": [
+  "UP:P62820"
+ ],
+ "NCBI gene:8408": [
+  "UP:O75385"
+ ],
+ "NCBI gene:81876": [
+  "UP:Q9H0U4"
+ ],
+ "NCBI gene:66826": [
+  "UP:I7HJS2",
+  "UP:Q91WF0",
+  "UP:Q810E8",
+  "UP:H3BK99"
+ ],
+ "NCBI gene:6389": [
+  "UP:P31040"
+ ],
+ "NCBI gene:117167": [
+  "UP:Q923B6"
+ ],
+ "NCBI gene:79689": [
+  "UP:Q687X5"
+ ],
+ "NCBI gene:468": [
+  "UP:P18848"
+ ],
+ "NCBI gene:11911": [
+  "UP:Q06507"
+ ],
+ "NCBI gene:440": [
+  "UP:P08243"
+ ],
+ "NCBI gene:23657": [
+  "UP:Q9UPY5"
+ ],
+ "NCBI gene:74068": [
+  "UP:Q8VD46"
+ ],
+ "NCBI gene:66152": [
+  "UP:Q8R1I1"
+ ],
+ "NCBI gene:851041": [
+  "UP:Q12114"
+ ],
+ "NCBI gene:855277": [
+  "UP:Q05029"
+ ],
+ "NCBI gene:854475": [
+  "UP:Q08754"
+ ],
+ "NCBI gene:853898": [
+  "UP:P36122"
+ ],
+ "NCBI gene:853346": [
+  "UP:P40955"
+ ],
+ "NCBI gene:852311": [
+  "UP:P29465"
+ ],
+ "NCBI gene:854271": [
+  "UP:Q12057"
+ ],
+ "NCBI gene:503710": [
+  "UP:Q5CZR5"
+ ],
+ "NCBI gene:20850": [
+  "UP:P42230"
+ ],
+ "NCBI gene:20851": [
+  "UP:P42232"
+ ],
+ "NCBI gene:17480": [
+  "UP:Q08351"
+ ],
+ "NCBI gene:14062": [
+  "UP:P30558"
+ ],
+ "NCBI gene:21937": [
+  "UP:P25118"
+ ],
+ "NCBI gene:17533": [
+  "UP:Q61830"
+ ],
+ "NCBI gene:7132": [
+  "UP:P19438"
+ ],
+ "NCBI gene:14605": [
+  "UP:Q9Z2S7"
+ ],
+ "NCBI gene:19252": [
+  "UP:P28563"
+ ],
+ "NCBI gene:20393": [
+  "UP:Q9WVC6"
+ ],
+ "NCBI gene:234724": [
+  "UP:Q8QZR1"
+ ],
+ "NCBI gene:10432": [
+  "UP:Q96PK6"
+ ],
+ "NCBI gene:55835": [
+  "UP:Q9HC77"
+ ],
+ "NCBI gene:6491": [
+  "UP:Q15468"
+ ],
+ "NCBI gene:163786": [
+  "UP:Q6UVJ0"
+ ],
+ "NCBI gene:116561": [
+  "UP:P08082"
+ ],
+ "NCBI gene:38146": [
+  "UP:P40792"
+ ],
+ "NCBI gene:42447": [
+  "UP:A0A0B4KH16",
+  "UP:A0A0B4KHT3",
+  "UP:Q9VDJ9"
+ ],
+ "NCBI gene:40221": [
+  "UP:Q9VWA1"
+ ],
+ "NCBI gene:35131": [
+  "UP:Q9VJ56",
+  "UP:X2JAW9",
+  "UP:B7YZX2"
+ ],
+ "NCBI gene:40835": [
+  "UP:P02833"
+ ],
+ "NCBI gene:998": [
+  "UP:P60953"
+ ],
+ "NCBI gene:23370": [
+  "UP:Q6ZSZ5"
+ ],
+ "NCBI gene:6654": [
+  "UP:Q07889"
+ ],
+ "NCBI gene:3265": [
+  "UP:P01112"
+ ],
+ "NCBI gene:2012": [
+  "UP:P54849"
+ ],
+ "NCBI gene:3297": [
+  "UP:Q00613"
+ ],
+ "NCBI gene:193740": [
+  "UP:Q61696"
+ ],
+ "NCBI gene:15507": [
+  "UP:P14602"
+ ],
+ "NCBI gene:105787": [
+  "UP:Q5EG47"
+ ],
+ "NCBI gene:108079": [
+  "UP:Q8BRK8"
+ ],
+ "NCBI gene:5562": [
+  "UP:Q13131"
+ ],
+ "NCBI gene:15499": [
+  "UP:P38532"
+ ],
+ "NCBI gene:581": [
+  "UP:Q07812"
+ ],
+ "NCBI gene:578": [
+  "UP:Q16611"
+ ],
+ "NCBI gene:598": [
+  "UP:Q07817"
+ ],
+ "NCBI gene:596": [
+  "UP:P10415"
+ ],
+ "NCBI gene:4170": [
+  "UP:Q07820"
+ ],
+ "NCBI gene:5788": [
+  "UP:P08575"
+ ],
+ "NCBI gene:80312": [
+  "UP:Q8NFU7"
+ ],
+ "NCBI gene:54790": [
+  "UP:Q6N021"
+ ],
+ "NCBI gene:10059": [
+  "UP:O00429"
+ ],
+ "NCBI gene:10733": [
+  "UP:O00444"
+ ],
+ "NCBI gene:5108": [
+  "UP:Q15154"
+ ],
+ "NCBI gene:820555": [
+  "UP:Q9LJD8"
+ ],
+ "NCBI gene:816436": [
+  "UP:O64483"
+ ],
+ "NCBI gene:828455": [
+  "UP:Q9SUS1"
+ ],
+ "NCBI gene:85431": [
+  "UP:Q924V1"
+ ],
+ "NCBI gene:289754": [
+  "UP:Q9R1S4"
+ ],
+ "NCBI gene:293820": [
+  "UP:Q68FU2"
+ ],
+ "NCBI gene:79255": [
+  "UP:Q9ES19"
+ ],
+ "NCBI gene:58835": [
+  "UP:O08651"
+ ],
+ "NCBI gene:25612": [
+  "UP:P49088"
+ ],
+ "NCBI gene:116509": [
+  "UP:P28572"
+ ],
+ "NCBI gene:50490": [
+  "UP:Q9JHI8"
+ ],
+ "NCBI gene:50507": [
+  "UP:Q9NPH5"
+ ],
+ "NCBI gene:17872": [
+  "UP:P17564"
+ ],
+ "NCBI gene:5501": [
+  "UP:P36873"
+ ],
+ "NCBI gene:171696": [
+  "UP:O76512"
+ ],
+ "NCBI gene:45587": [
+  "UP:A0A0B4LF37",
+  "UP:A1Z8J4",
+  "UP:A1Z8J3"
+ ],
+ "NCBI gene:32153": [
+  "UP:Q9VYS3"
+ ],
+ "NCBI gene:3043": [
+  "UP:P68871"
+ ],
+ "NCBI gene:26019": [
+  "UP:Q9HAU5"
+ ],
+ "NCBI gene:29889": [
+  "UP:Q13823"
+ ],
+ "NCBI gene:6396": [
+  "UP:P55735"
+ ],
+ "NCBI gene:5873": [
+  "UP:P51159"
+ ],
+ "NCBI gene:5874": [
+  "UP:O00194"
+ ],
+ "NCBI gene:10749": [
+  "UP:O43896"
+ ],
+ "NCBI gene:305967": [
+  "UP:Q70AM4"
+ ],
+ "NCBI gene:3799": [
+  "UP:P33176"
+ ],
+ "NCBI gene:310698": [
+  "UP:Q5MPA9"
+ ],
+ "NCBI gene:83825": [
+  "UP:O08875"
+ ],
+ "NCBI gene:363288": [
+  "UP:F1M4A4"
+ ],
+ "NCBI gene:288562": [
+  "UP:B2GUY2"
+ ],
+ "NCBI gene:24604": [
+  "UP:P07808"
+ ],
+ "NCBI gene:289397": [
+  "UP:F1M5N7"
+ ],
+ "NCBI gene:117548": [
+  "UP:O88658"
+ ],
+ "NCBI gene:113886": [
+  "UP:O35787"
+ ],
+ "NCBI gene:13175": [
+  "UP:Q9JLM8"
+ ],
+ "NCBI gene:362587": [
+  "UP:D3ZHV2"
+ ],
+ "NCBI gene:547": [
+  "UP:Q12756"
+ ],
+ "NCBI gene:901176": [
+  "UP:Q99ZW2"
+ ],
+ "NCBI gene:36760": [
+  "UP:Q7KN85",
+  "UP:A0A0B4LFH8",
+  "UP:E2QCF1"
+ ],
+ "NCBI gene:43928": [
+  "UP:Q9VM15",
+  "UP:M9NEW2"
+ ],
+ "NCBI gene:21687": [
+  "UP:Q02858"
+ ],
+ "NCBI gene:21821": [
+  "UP:Q61371"
+ ],
+ "NCBI gene:17857": [
+  "UP:P09922"
+ ],
+ "NCBI gene:16176": [
+  "UP:P10749"
+ ],
+ "NCBI gene:21926": [
+  "UP:P06804"
+ ],
+ "NCBI gene:21803": [
+  "UP:P04202"
+ ],
+ "NCBI gene:22329": [
+  "UP:Q3UPN1"
+ ],
+ "NCBI gene:20339": [
+  "UP:Q00690"
+ ],
+ "NCBI gene:18126": [
+  "UP:P29477"
+ ],
+ "NCBI gene:12514": [
+  "UP:P31996"
+ ],
+ "NCBI gene:21929": [
+  "UP:Q60769"
+ ],
+ "NCBI gene:14632": [
+  "UP:P47806"
+ ],
+ "NCBI gene:19206": [
+  "UP:Q61115"
+ ],
+ "NCBI gene:19207": [
+  "UP:O35595"
+ ],
+ "NCBI gene:64332": [
+  "UP:Q9BYH8"
+ ],
+ "NCBI gene:25984": [
+  "UP:Q9C075"
+ ],
+ "NCBI gene:4680": [
+  "UP:P40199"
+ ],
+ "NCBI gene:688": [
+  "UP:Q13887"
+ ],
+ "NCBI gene:4585": [
+  "UP:Q99102"
+ ],
+ "NCBI gene:7431": [
+  "UP:P08670"
+ ],
+ "NCBI gene:1999": [
+  "UP:P78545"
+ ],
+ "NCBI gene:6935": [
+  "UP:P37275"
+ ],
+ "NCBI gene:1366": [
+  "UP:O95471"
+ ],
+ "NCBI gene:101": [
+  "UP:P78325"
+ ],
+ "NCBI gene:1759": [
+  "UP:Q05193"
+ ],
+ "NCBI gene:1785": [
+  "UP:P50570"
+ ],
+ "NCBI gene:15277": [
+  "UP:O08528"
+ ],
+ "NCBI gene:11652": [
+  "UP:Q60823"
+ ],
+ "NCBI gene:15185": [
+  "UP:Q9Z2V5"
+ ],
+ "NCBI gene:230073": [
+  "UP:Q6Q899"
+ ],
+ "NCBI gene:25": [
+  "UP:P00519"
+ ],
+ "NCBI gene:5479": [
+  "UP:P23284"
+ ],
+ "NCBI gene:23961": [
+  "UP:Q60856"
+ ],
+ "NCBI gene:54123": [
+  "UP:P70434"
+ ],
+ "NCBI gene:13176": [
+  "UP:P70211"
+ ],
+ "NCBI gene:1630": [
+  "UP:P43146"
+ ],
+ "NCBI gene:9423": [
+  "UP:O95631"
+ ],
+ "NCBI gene:51726": [
+  "UP:Q9UBS4"
+ ],
+ "NCBI gene:22926": [
+  "UP:P18850"
+ ],
+ "NCBI gene:7494": [
+  "UP:P17861"
+ ],
+ "NCBI gene:7276": [
+  "UP:P02766"
+ ],
+ "NCBI gene:3309": [
+  "UP:P11021"
+ ],
+ "NCBI gene:240672": [
+  "UP:Q1HL35"
+ ],
+ "NCBI gene:12048": [
+  "UP:Q64373"
+ ],
+ "NCBI gene:16163": [
+  "UP:P20109"
+ ],
+ "NCBI gene:16189": [
+  "UP:P07750"
+ ],
+ "NCBI gene:14283": [
+  "UP:P48755"
+ ],
+ "NCBI gene:13666": [
+  "UP:Q9Z2B5"
+ ],
+ "NCBI gene:27103": [
+  "UP:Q9QZ05"
+ ],
+ "NCBI gene:7030": [
+  "UP:P19532"
+ ],
+ "NCBI gene:5530": [
+  "UP:Q08209"
+ ],
+ "NCBI gene:5532": [
+  "UP:P16298"
+ ],
+ "NCBI gene:57192": [
+  "UP:Q9GZU1"
+ ],
+ "NCBI gene:528": [
+  "UP:P21283"
+ ],
+ "NCBI gene:3073": [
+  "UP:P06865"
+ ],
+ "NCBI gene:7405": [
+  "UP:Q9P2Y5"
+ ],
+ "NCBI gene:1649": [
+  "UP:P35638"
+ ],
+ "NCBI gene:23645": [
+  "UP:O75807"
+ ],
+ "NCBI gene:6541": [
+  "UP:P30825"
+ ],
+ "NCBI gene:285362": [
+  "UP:Q8NBK3"
+ ],
+ "NCBI gene:79139": [
+  "UP:Q9BUN8"
+ ],
+ "NCBI gene:328": [
+  "UP:P27695"
+ ],
+ "NCBI gene:2876": [
+  "UP:P07203"
+ ],
+ "NCBI gene:21425": [
+  "UP:Q9R210"
+ ],
+ "NCBI gene:209446": [
+  "UP:Q64092"
+ ],
+ "NCBI gene:6300": [
+  "UP:P53778"
+ ],
+ "NCBI gene:5603": [
+  "UP:O15264"
+ ],
+ "NCBI gene:29857": [
+  "UP:O08911"
+ ],
+ "NCBI gene:26415": [
+  "UP:Q9Z1B7"
+ ],
+ "NCBI gene:21857": [
+  "UP:P12032"
+ ],
+ "NCBI gene:11475": [
+  "UP:P62737"
+ ],
+ "NCBI gene:12842": [
+  "UP:P11087"
+ ],
+ "NCBI gene:17105": [
+  "UP:P08905"
+ ],
+ "NCBI gene:12010": [
+  "UP:P01887"
+ ],
+ "NCBI gene:3562": [
+  "UP:P08700"
+ ],
+ "NCBI gene:1437": [
+  "UP:P04141"
+ ],
+ "NCBI gene:3725": [
+  "UP:P05412"
+ ],
+ "NCBI gene:19360": [
+  "UP:Q5SV02"
+ ],
+ "NCBI gene:225997": [
+  "UP:Q8CIR4"
+ ],
+ "NCBI gene:12394": [
+  "UP:G3UWD2",
+  "UP:Q3UM65",
+  "UP:Q8BQ09",
+  "UP:G3X9W7"
+ ],
+ "NCBI gene:23871": [
+  "UP:P27577"
+ ],
+ "NCBI gene:20290": [
+  "UP:P10146"
+ ],
+ "NCBI gene:16153": [
+  "UP:P18893"
+ ],
+ "NCBI gene:112398": [
+  "UP:Q96KS0"
+ ],
+ "NCBI gene:54583": [
+  "UP:Q9GZT9"
+ ],
+ "NCBI gene:112399": [
+  "UP:Q9H6Z9"
+ ],
+ "NCBI gene:22059": [
+  "UP:P02340"
+ ],
+ "NCBI gene:1432": [
+  "UP:Q16539"
+ ],
+ "NCBI gene:5600": [
+  "UP:Q15759"
+ ],
+ "NCBI gene:1647": [
+  "UP:P24522"
+ ],
+ "NCBI gene:27113": [
+  "UP:Q9BXH1",
+  "UP:Q96PG8"
+ ],
+ "NCBI gene:2071": [
+  "UP:P19447"
+ ],
+ "NCBI gene:83429": [
+  "UP:P57757"
+ ],
+ "NCBI gene:5663": [
+  "UP:P49768"
+ ],
+ "NCBI gene:16846": [
+  "UP:P41160"
+ ],
+ "NCBI gene:20528": [
+  "UP:P14142"
+ ],
+ "NCBI gene:11604": [
+  "UP:P56473"
+ ],
+ "NCBI gene:109648": [
+  "UP:P57774"
+ ],
+ "NCBI gene:18976": [
+  "UP:P01193"
+ ],
+ "NCBI gene:21938": [
+  "UP:P25119"
+ ],
+ "NCBI gene:337514": [
+  "UP:Q90XS6"
+ ],
+ "NCBI gene:677744": [
+  "UP:Q90YS5"
+ ],
+ "NCBI gene:114461": [
+  "UP:Q0PKX6"
+ ],
+ "NCBI gene:19055": [
+  "UP:P63328"
+ ],
+ "NCBI gene:56644": [
+  "UP:V9GXI5"
+ ],
+ "NCBI gene:17874": [
+  "UP:P22366"
+ ],
+ "NCBI gene:20963": [
+  "UP:P48025"
+ ],
+ "NCBI gene:81897": [
+  "UP:Q9EQU3"
+ ],
+ "NCBI gene:12229": [
+  "UP:P35991"
+ ],
+ "NCBI gene:12034": [
+  "UP:O35129"
+ ],
+ "NCBI gene:170484": [
+  "UP:Q91X05"
+ ],
+ "NCBI gene:16337": [
+  "UP:P15208"
+ ],
+ "NCBI gene:16001": [
+  "UP:Q60751"
+ ],
+ "NCBI gene:89795": [
+  "UP:Q8IVL0"
+ ],
+ "NCBI gene:70445": [
+  "UP:Q91V98"
+ ],
+ "NCBI gene:57124": [
+  "UP:Q9HCU0"
+ ],
+ "NCBI gene:59": [
+  "UP:P62736"
+ ],
+ "NCBI gene:1277": [
+  "UP:P02452"
+ ],
+ "NCBI gene:1278": [
+  "UP:P08123"
+ ],
+ "NCBI gene:16002": [
+  "UP:P09535"
+ ],
+ "NCBI gene:231474": [
+  "UP:Q6TCG8"
+ ],
+ "NCBI gene:152559": [
+  "UP:Q6TCH7"
+ ],
+ "NCBI gene:22863": [
+  "UP:Q6ZNE5"
+ ],
+ "NCBI gene:60": [
+  "UP:P60709"
+ ],
+ "NCBI gene:14265": [
+  "UP:E9QAT0",
+  "UP:E9QNF5",
+  "UP:Q8BPK8",
+  "UP:Q6AXB7",
+  "UP:Q547R0"
+ ],
+ "NCBI gene:37528": [
+  "UP:Q9NFU0"
+ ],
+ "NCBI gene:43193": [
+  "UP:O96690"
+ ],
+ "NCBI gene:7139": [
+  "UP:P45379"
+ ],
+ "NCBI gene:1482": [
+  "UP:P52952"
+ ],
+ "NCBI gene:4878": [
+  "UP:P01160"
+ ],
+ "NCBI gene:5308": [
+  "UP:Q99697"
+ ],
+ "NCBI gene:23493": [
+  "UP:Q9UBP5"
+ ],
+ "NCBI gene:50805": [
+  "UP:P78413"
+ ],
+ "NCBI gene:7025": [
+  "UP:P10589"
+ ],
+ "NCBI gene:7026": [
+  "UP:P24468"
+ ],
+ "NCBI gene:3741": [
+  "UP:P22460"
+ ],
+ "NCBI gene:3760": [
+  "UP:P48549"
+ ],
+ "NCBI gene:3762": [
+  "UP:P48544"
+ ],
+ "NCBI gene:5034": [
+  "UP:P07237"
+ ],
+ "NCBI gene:2923": [
+  "UP:P30101"
+ ],
+ "NCBI gene:3110": [
+  "UP:P50219"
+ ],
+ "NCBI gene:18453": [
+  "UP:P09103"
+ ],
+ "NCBI gene:14827": [
+  "UP:P27773"
+ ],
+ "NCBI gene:239789": [
+  "UP:Q3URY2"
+ ],
+ "NCBI gene:622408": [
+  "UP:Q3UZ45"
+ ],
+ "NCBI gene:15223": [
+  "UP:Q61660"
+ ],
+ "NCBI gene:57441": [
+  "UP:O88513"
+ ],
+ "NCBI gene:51053": [
+  "UP:O75496"
+ ],
+ "NCBI gene:1875": [
+  "UP:Q15329"
+ ],
+ "NCBI gene:7027": [
+  "UP:Q14186"
+ ],
+ "NCBI gene:22378": [
+  "UP:P97765"
+ ],
+ "NCBI gene:18667": [
+  "UP:Q00175"
+ ],
+ "NCBI gene:58234": [
+  "UP:Q4ACU6"
+ ],
+ "NCBI gene:13385": [
+  "UP:Q62108"
+ ],
+ "NCBI gene:999": [
+  "UP:P12830"
+ ],
+ "NCBI gene:991": [
+  "UP:Q12834"
+ ],
+ "NCBI gene:52679": [
+  "UP:Q6S7F2"
+ ],
+ "NCBI gene:108961": [
+  "UP:Q58FA4"
+ ],
+ "NCBI gene:26271": [
+  "UP:Q9UKT4"
+ ],
+ "NCBI gene:1294": [
+  "UP:Q02388"
+ ],
+ "NCBI gene:1308": [
+  "UP:Q9UMD9"
+ ],
+ "NCBI gene:1615": [
+  "UP:P14868"
+ ],
+ "NCBI gene:2597": [
+  "UP:P04406"
+ ],
+ "NCBI gene:54908": [
+  "UP:Q96EA4"
+ ],
+ "NCBI gene:6249": [
+  "UP:P30622"
+ ],
+ "NCBI gene:1062": [
+  "UP:Q02224"
+ ],
+ "NCBI gene:29899": [
+  "UP:P81274"
+ ],
+ "NCBI gene:8349": [
+  "UP:Q16778"
+ ],
+ "NCBI gene:5347": [
+  "UP:P53350"
+ ],
+ "NCBI gene:79682": [
+  "UP:Q71F23"
+ ],
+ "NCBI gene:5071": [
+  "UP:O60260"
+ ],
+ "NCBI gene:170826": [
+  "UP:Q8VHJ7"
+ ],
+ "NCBI gene:14825": [
+  "UP:P12850"
+ ],
+ "NCBI gene:12578": [
+  "UP:Q64364",
+  "UP:P51480"
+ ],
+ "NCBI gene:7014": [
+  "UP:Q15554"
+ ],
+ "NCBI gene:19744": [
+  "UP:Q921J2"
+ ],
+ "NCBI gene:20311": [
+  "UP:P50228"
+ ],
+ "NCBI gene:16322": [
+  "UP:Q04997"
+ ],
+ "NCBI gene:18227": [
+  "UP:Q06219"
+ ],
+ "NCBI gene:18024": [
+  "UP:Q60795"
+ ],
+ "NCBI gene:1387": [
+  "UP:Q92793"
+ ],
+ "NCBI gene:10524": [
+  "UP:Q92993"
+ ],
+ "NCBI gene:23522": [
+  "UP:Q8WYB5"
+ ],
+ "NCBI gene:339287": [
+  "UP:Q68DK7"
+ ],
+ "NCBI gene:110279": [
+  "UP:Q6PAJ1"
+ ],
+ "NCBI gene:11350": [
+  "UP:P00520"
+ ],
+ "NCBI gene:11352": [
+  "UP:B2RQ57",
+  "UP:F8VQH0"
+ ],
+ "NCBI gene:7273": [
+  "UP:Q8WZ42"
+ ],
+ "NCBI gene:4624": [
+  "UP:P13533"
+ ],
+ "NCBI gene:4625": [
+  "UP:P12883"
+ ],
+ "NCBI gene:70": [
+  "UP:P68032"
+ ],
+ "NCBI gene:22138": [
+  "UP:Q8BUC9",
+  "UP:Q3TZL3",
+  "UP:Q8BUJ6",
+  "UP:Q8C139",
+  "UP:Q3UT48",
+  "UP:Q8BUX4",
+  "UP:E9Q8N1",
+  "UP:Q8BUJ0"
+ ],
+ "NCBI gene:4154": [
+  "UP:Q9NR56"
+ ],
+ "NCBI gene:9733": [
+  "UP:Q15020"
+ ],
+ "NCBI gene:51319": [
+  "UP:Q96IZ7"
+ ],
+ "NCBI gene:12575": [
+  "UP:P39689"
+ ],
+ "NCBI gene:4118": [
+  "UP:P21145"
+ ],
+ "NCBI gene:1719": [
+  "UP:P00374"
+ ],
+ "NCBI gene:161253": [
+  "UP:Q8IYK8"
+ ],
+ "NCBI gene:221154": [
+  "UP:Q8IYU8"
+ ],
+ "NCBI gene:55611": [
+  "UP:Q96FW1"
+ ],
+ "NCBI gene:4893": [
+  "UP:P01111"
+ ],
+ "NCBI gene:3845": [
+  "UP:P01116"
+ ],
+ "NCBI gene:207": [
+  "UP:P31749"
+ ],
+ "NCBI gene:5604": [
+  "UP:Q02750"
+ ],
+ "NCBI gene:78560": [
+  "UP:Q91ZV8"
+ ],
+ "NCBI gene:12140": [
+  "UP:P51880"
+ ],
+ "NCBI gene:15208": [
+  "UP:P70120"
+ ],
+ "NCBI gene:13193": [
+  "UP:O88809"
+ ],
+ "NCBI gene:22152": [
+  "UP:Q9ERD7"
+ ],
+ "NCBI gene:19126": [
+  "UP:O54990"
+ ],
+ "NCBI gene:15251": [
+  "UP:Q61221"
+ ],
+ "NCBI gene:14433": [
+  "UP:P16858"
+ ],
+ "NCBI gene:13806": [
+  "UP:P17182"
+ ],
+ "NCBI gene:16828": [
+  "UP:P06151"
+ ],
+ "NCBI gene:170768": [
+  "UP:A2AUP5",
+  "UP:Q8BVM1",
+  "UP:A7UAK5",
+  "UP:A2AUP1",
+  "UP:A7UAK4",
+  "UP:A0A0A6YY64",
+  "UP:A7UAK8",
+  "UP:Q7TS91",
+  "UP:Q3U3S6"
+ ],
+ "NCBI gene:55226": [
+  "UP:Q9H0A0"
+ ],
+ "NCBI gene:8322": [
+  "UP:Q9ULV1"
+ ],
+ "NCBI gene:8476": [
+  "UP:Q5VT25"
+ ],
+ "NCBI gene:5287": [
+  "UP:O00750"
+ ],
+ "NCBI gene:57787": [
+  "UP:Q96L34"
+ ],
+ "NCBI gene:11461": [
+  "UP:P60710"
+ ],
+ "NCBI gene:193034": [
+  "UP:Q704Y3"
+ ],
+ "NCBI gene:22368": [
+  "UP:Q9WTR1"
+ ],
+ "NCBI gene:246788": [
+  "UP:Q8K424"
+ ],
+ "NCBI gene:63873": [
+  "UP:Q9EPK8"
+ ],
+ "NCBI gene:19017": [
+  "UP:O70343"
+ ],
+ "NCBI gene:19016": [
+  "UP:P37238"
+ ],
+ "NCBI gene:11556": [
+  "UP:P25962"
+ ],
+ "NCBI gene:22227": [
+  "UP:P12242"
+ ],
+ "NCBI gene:10891": [
+  "UP:Q9UBK2"
+ ],
+ "NCBI gene:12857": [
+  "UP:P19783"
+ ],
+ "NCBI gene:70673": [
+  "UP:A2A935"
+ ],
+ "NCBI gene:22228": [
+  "UP:P70406"
+ ],
+ "NCBI gene:16956": [
+  "UP:P11152"
+ ],
+ "NCBI gene:12491": [
+  "UP:Q08857"
+ ],
+ "NCBI gene:4091": [
+  "UP:O43541"
+ ],
+ "NCBI gene:17130": [
+  "UP:O35182"
+ ],
+ "NCBI gene:3654": [
+  "UP:P51617"
+ ],
+ "NCBI gene:7189": [
+  "UP:Q9Y4K3"
+ ],
+ "NCBI gene:57162": [
+  "UP:Q96FA3"
+ ],
+ "NCBI gene:3569": [
+  "UP:P05231"
+ ],
+ "NCBI gene:12322": [
+  "UP:P11798"
+ ],
+ "NCBI gene:20846": [
+  "UP:Q8C497",
+  "UP:A0A087WSP5",
+  "UP:Q8CFQ1",
+  "UP:Q8C8M3",
+  "UP:Q8C3V4",
+  "UP:Q99K94"
+ ],
+ "NCBI gene:20847": [
+  "UP:Q9QXJ2"
+ ],
+ "NCBI gene:16391": [
+  "UP:Q61179"
+ ],
+ "NCBI gene:17858": [
+  "UP:Q9WVP9"
+ ],
+ "NCBI gene:15977": [
+  "UP:P01575"
+ ],
+ "NCBI gene:595": [
+  "UP:P24385"
+ ],
+ "NCBI gene:12443": [
+  "UP:P25322"
+ ],
+ "NCBI gene:67914": [
+  "UP:Q8K1Z0"
+ ],
+ "NCBI gene:12850": [
+  "UP:P97478"
+ ],
+ "NCBI gene:67426": [
+  "UP:Q60936"
+ ],
+ "NCBI gene:52064": [
+  "UP:Q9CXI0"
+ ],
+ "NCBI gene:217707": [
+  "UP:Q8R1S0"
+ ],
+ "NCBI gene:792333": [
+  "UP:A5JNG8"
+ ],
+ "NCBI gene:30333": [
+  "UP:Q90270"
+ ],
+ "NCBI gene:326282": [
+  "UP:Q6NZT3"
+ ],
+ "NCBI gene:81538": [
+  "UP:O93548"
+ ],
+ "NCBI gene:4763": [
+  "UP:P21359"
+ ],
+ "NCBI gene:1654": [
+  "UP:O00571"
+ ],
+ "NCBI gene:22160": [
+  "UP:P26687"
+ ],
+ "NCBI gene:16653": [
+  "UP:P32883"
+ ],
+ "NCBI gene:1499": [
+  "UP:P35222"
+ ],
+ "NCBI gene:6925": [
+  "UP:P15884"
+ ],
+ "NCBI gene:8313": [
+  "UP:Q9Y2T1"
+ ],
+ "NCBI gene:4609": [
+  "UP:P01106"
+ ],
+ "NCBI gene:20848": [
+  "UP:P42227"
+ ],
+ "NCBI gene:68349": [
+  "UP:Q9DCT2"
+ ],
+ "NCBI gene:12702": [
+  "UP:O35718"
+ ],
+ "NCBI gene:17716": [
+  "UP:P03888"
+ ],
+ "NCBI gene:17719": [
+  "UP:P03911"
+ ],
+ "NCBI gene:17720": [
+  "UP:P03903"
+ ],
+ "NCBI gene:81879": [
+  "UP:Q3UNW5"
+ ],
+ "NCBI gene:12362": [
+  "UP:P29452"
+ ],
+ "NCBI gene:12363": [
+  "UP:P70343"
+ ],
+ "NCBI gene:16177": [
+  "UP:P13504"
+ ],
+ "NCBI gene:16173": [
+  "UP:P70380"
+ ],
+ "NCBI gene:16542": [
+  "UP:Q8VCD0"
+ ],
+ "NCBI gene:14254": [
+  "UP:P35969"
+ ],
+ "NCBI gene:216799": [
+  "UP:Q8R4B8"
+ ],
+ "NCBI gene:13058": [
+  "UP:Q61093"
+ ],
+ "NCBI gene:20655": [
+  "UP:P08228"
+ ],
+ "NCBI gene:12359": [
+  "UP:P24270"
+ ],
+ "NCBI gene:14775": [
+  "UP:P11352"
+ ],
+ "NCBI gene:24115": [
+  "UP:O88870"
+ ],
+ "NCBI gene:77040": [
+  "UP:Q8C0J2"
+ ],
+ "NCBI gene:56208": [
+  "UP:O88597"
+ ],
+ "NCBI gene:24088": [
+  "UP:Q9QUN7"
+ ],
+ "NCBI gene:18198": [
+  "UP:Q61006"
+ ],
+ "NCBI gene:11435": [
+  "UP:P04756"
+ ],
+ "NCBI gene:11449": [
+  "UP:F8VQK4"
+ ],
+ "NCBI gene:433766": [
+  "UP:F8VPZ1",
+  "UP:Q8CFN7"
+ ],
+ "NCBI gene:22241": [
+  "UP:O70405"
+ ],
+ "NCBI gene:27273": [
+  "UP:O70571"
+ ],
+ "NCBI gene:18604": [
+  "UP:Q9JK42"
+ ],
+ "NCBI gene:264895": [
+  "UP:Q8VCW8"
+ ],
+ "NCBI gene:12895": [
+  "UP:Q924X2"
+ ],
+ "NCBI gene:56458": [
+  "UP:Q9R1E0"
+ ],
+ "NCBI gene:12974": [
+  "UP:Q9CZU6"
+ ],
+ "NCBI gene:19015": [
+  "UP:P35396"
+ ],
+ "NCBI gene:26379": [
+  "UP:O08580"
+ ],
+ "NCBI gene:18181": [
+  "UP:Q9WU00"
+ ],
+ "NCBI gene:18642": [
+  "UP:P47857"
+ ],
+ "NCBI gene:22346": [
+  "UP:P40338"
+ ],
+ "NCBI gene:51022": [
+  "UP:Q9NS18"
+ ],
+ "NCBI gene:23479": [
+  "UP:Q9H1K1"
+ ],
+ "NCBI gene:856709": [
+  "UP:P03069"
+ ],
+ "NCBI gene:66383": [
+  "UP:Q9D7P6"
+ ],
+ "NCBI gene:56637": [
+  "UP:Q9WV60"
+ ],
+ "NCBI gene:606496": [
+  "UP:Q2NL51"
+ ],
+ "NCBI gene:2932": [
+  "UP:P49841"
+ ],
+ "NCBI gene:2305": [
+  "UP:Q08050"
+ ],
+ "NCBI gene:8312": [
+  "UP:O15169"
+ ],
+ "NCBI gene:55294": [
+  "UP:Q969H0"
+ ],
+ "NCBI gene:8078": [
+  "UP:P45974"
+ ],
+ "NCBI gene:56998": [
+  "UP:Q9NSA3"
+ ],
+ "NCBI gene:854417": [
+  "UP:Q08647"
+ ],
+ "NCBI gene:855889": [
+  "UP:Q12211"
+ ],
+ "NCBI gene:852539": [
+  "UP:P21372"
+ ],
+ "NCBI gene:16159": [
+  "UP:P43431"
+ ],
+ "NCBI gene:74610": [
+  "UP:Q9CXJ4"
+ ],
+ "NCBI gene:230899": [
+  "UP:P05125"
+ ],
+ "NCBI gene:18158": [
+  "UP:P40753"
+ ],
+ "NCBI gene:140781": [
+  "UP:Q91Z83"
+ ],
+ "NCBI gene:11194": [
+  "UP:Q9NUT2"
+ ],
+ "NCBI gene:362302": [
+  "UP:Q5RKI8"
+ ],
+ "NCBI gene:60676": [
+  "UP:Q9BXP8"
+ ],
+ "NCBI gene:5717250": [
+  "UP:Q5DM57"
+ ],
+ "NCBI gene:5724201": [
+  "UP:Q2XQY7"
+ ],
+ "NCBI gene:5722691": [
+  "UP:A8J6F1"
+ ],
+ "NCBI gene:5717848": [
+  "UP:Q946G4"
+ ],
+ "NCBI gene:5725696": [
+  "UP:A8JCJ2"
+ ],
+ "NCBI gene:114799": [
+  "UP:Q5FWF5"
+ ],
+ "NCBI gene:157570": [
+  "UP:Q56NI9"
+ ],
+ "NCBI gene:13006": [
+  "UP:Q9CW03"
+ ],
+ "NCBI gene:113130": [
+  "UP:Q96FF9"
+ ],
+ "NCBI gene:67849": [
+  "UP:Q9CPY3"
+ ],
+ "NCBI gene:60599": [
+  "UP:Q9QXE4"
+ ],
+ "NCBI gene:1978": [
+  "UP:Q13541"
+ ],
+ "NCBI gene:6751": [
+  "UP:P30872"
+ ],
+ "NCBI gene:5781": [
+  "UP:Q06124"
+ ],
+ "NCBI gene:5791": [
+  "UP:P23469"
+ ],
+ "NCBI gene:19122": [
+  "UP:P04925"
+ ],
+ "NCBI gene:29126": [
+  "UP:Q9NZQ7"
+ ],
+ "NCBI gene:3576": [
+  "UP:P10145"
+ ],
+ "NCBI gene:10803": [
+  "UP:P51686"
+ ],
+ "NCBI gene:2869": [
+  "UP:P34947"
+ ],
+ "NCBI gene:2914": [
+  "UP:Q14833"
+ ],
+ "NCBI gene:3958": [
+  "UP:P17931"
+ ],
+ "NCBI gene:20597": [
+  "UP:Q04519"
+ ],
+ "NCBI gene:843133": [
+  "UP:Q9C9W9"
+ ],
+ "NCBI gene:836364": [
+  "UP:Q8W1E3"
+ ],
+ "NCBI gene:838883": [
+  "UP:Q9SQI2"
+ ],
+ "NCBI gene:819296": [
+  "UP:P92973"
+ ],
+ "NCBI gene:839341": [
+  "UP:Q6R0H1"
+ ],
+ "NCBI gene:819292": [
+  "UP:Q8L500"
+ ],
+ "NCBI gene:831441": [
+  "UP:Q39057"
+ ],
+ "NCBI gene:842859": [
+  "UP:Q9SXZ2"
+ ],
+ "NCBI gene:818903": [
+  "UP:Q8W2F3"
+ ],
+ "NCBI gene:829361": [
+  "UP:Q93WC4"
+ ],
+ "NCBI gene:827384": [
+  "UP:Q05466"
+ ],
+ "NCBI gene:825075": [
+  "UP:Q84LH8"
+ ],
+ "NCBI gene:7804": [
+  "UP:Q14114"
+ ],
+ "NCBI gene:6426": [
+  "UP:Q07955"
+ ],
+ "NCBI gene:110809": [
+  "UP:Q6PDM2"
+ ],
+ "NCBI gene:16975": [
+  "UP:Q924X6"
+ ],
+ "NCBI gene:78473": [
+  "UP:Q3UUV5"
+ ],
+ "NCBI gene:18566": [
+  "UP:Q02242"
+ ],
+ "NCBI gene:23880": [
+  "UP:O35601"
+ ],
+ "NCBI gene:2533": [
+  "UP:O15117"
+ ],
+ "NCBI gene:8631": [
+  "UP:Q86WV1"
+ ],
+ "NCBI gene:18018": [
+  "UP:Q6P7T9",
+  "UP:B5B2N2",
+  "UP:B5B2N5",
+  "UP:B5B2N4",
+  "UP:Q9DBQ6",
+  "UP:B5B2N7"
+ ],
+ "NCBI gene:14939": [
+  "UP:P04187"
+ ],
+ "NCBI gene:67153": [
+  "UP:Q80ZV0"
+ ],
+ "NCBI gene:79621": [
+  "UP:Q5TBB1"
+ ],
+ "NCBI gene:15452": [
+  "UP:P00493"
+ ],
+ "NCBI gene:246730": [
+  "UP:P11928"
+ ],
+ "NCBI gene:214763": [
+  "UP:Q8C6L5"
+ ],
+ "NCBI gene:72512": [
+  "UP:Q3TBT3"
+ ],
+ "NCBI gene:15957": [
+  "UP:Q64282"
+ ],
+ "NCBI gene:19819": [
+  "UP:E9QLN8"
+ ],
+ "NCBI gene:24188": [
+  "UP:P51647"
+ ],
+ "NCBI gene:116676": [
+  "UP:Q63639"
+ ],
+ "NCBI gene:24186": [
+  "UP:P02770"
+ ],
+ "NCBI gene:363071": [
+  "UP:Q4QR83"
+ ],
+ "NCBI gene:4854": [
+  "UP:Q9UM47"
+ ],
+ "NCBI gene:3280": [
+  "UP:Q14469"
+ ],
+ "NCBI gene:23462": [
+  "UP:Q9Y5J3"
+ ],
+ "NCBI gene:26508": [
+  "UP:Q9NQ87"
+ ],
+ "NCBI gene:10231": [
+  "UP:Q14206"
+ ],
+ "NCBI gene:51378": [
+  "UP:Q9Y264"
+ ],
+ "NCBI gene:3240": [
+  "UP:P00738"
+ ],
+ "NCBI gene:10580": [
+  "UP:Q9BX66"
+ ],
+ "NCBI gene:8470": [
+  "UP:O94875"
+ ],
+ "NCBI gene:10174": [
+  "UP:O60504"
+ ],
+ "NCBI gene:367": [
+  "UP:P10275"
+ ],
+ "NCBI gene:2081": [
+  "UP:O75460"
+ ],
+ "NCBI gene:9695": [
+  "UP:Q92611"
+ ],
+ "NCBI gene:5611": [
+  "UP:Q13217"
+ ],
+ "NCBI gene:22433": [
+  "UP:O35426"
+ ],
+ "NCBI gene:78943": [
+  "UP:Q9EQY0"
+ ],
+ "NCBI gene:7852": [
+  "UP:P61073"
+ ],
+ "NCBI gene:7518": [
+  "UP:Q13426"
+ ],
+ "NCBI gene:15218": [
+  "UP:Q61575"
+ ],
+ "NCBI gene:21749": [
+  "UP:P70371"
+ ],
+ "NCBI gene:7013": [
+  "UP:P54274"
+ ],
+ "NCBI gene:950801": [
+  "UP:P44790"
+ ],
+ "NCBI gene:949684": [
+  "UP:P44791"
+ ],
+ "NCBI gene:22601": [
+  "UP:P46938"
+ ],
+ "NCBI gene:71950": [
+  "UP:Q80Z64"
+ ],
+ "NCBI gene:20674": [
+  "UP:P48432"
+ ],
+ "NCBI gene:26380": [
+  "UP:Q61539"
+ ],
+ "NCBI gene:21676": [
+  "UP:P30051"
+ ],
+ "NCBI gene:21678": [
+  "UP:P70210"
+ ],
+ "NCBI gene:21679": [
+  "UP:Q62296"
+ ],
+ "NCBI gene:14465": [
+  "UP:Q61169"
+ ],
+ "NCBI gene:16206": [
+  "UP:P70193"
+ ],
+ "NCBI gene:26018": [
+  "UP:Q96JA1"
+ ],
+ "NCBI gene:25054": [
+  "UP:Q63604"
+ ],
+ "NCBI gene:299830": [
+  "UP:G3V8Y2"
+ ],
+ "NCBI gene:9860": [
+  "UP:O94898"
+ ],
+ "NCBI gene:851545": [
+  "UP:P06243"
+ ],
+ "NCBI gene:852765": [
+  "UP:P53135"
+ ],
+ "NCBI gene:855950": [
+  "UP:P22216"
+ ],
+ "NCBI gene:856130": [
+  "UP:P30665"
+ ],
+ "NCBI gene:852673": [
+  "UP:P53091"
+ ],
+ "NCBI gene:90665": [
+  "UP:Q9BQ87"
+ ],
+ "NCBI gene:6907": [
+  "UP:O60907"
+ ],
+ "NCBI gene:21372": [
+  "UP:Q9QXE7"
+ ],
+ "NCBI gene:5290": [
+  "UP:P42336"
+ ],
+ "NCBI gene:18708": [
+  "UP:P26450"
+ ],
+ "NCBI gene:8481": [
+  "UP:O75665"
+ ],
+ "NCBI gene:54820": [
+  "UP:Q9NXR1"
+ ],
+ "NCBI gene:99100": [
+  "UP:A2AUM9"
+ ],
+ "NCBI gene:20873": [
+  "UP:Q64702"
+ ],
+ "NCBI gene:26370": [
+  "UP:Q9R1K9"
+ ],
+ "NCBI gene:234964": [
+  "UP:Q7M6Y5"
+ ],
+ "NCBI gene:381077": [
+  "UP:D3Z5T1"
+ ],
+ "NCBI gene:218630": [
+  "UP:P0C242"
+ ],
+ "NCBI gene:17863": [
+  "UP:P06876"
+ ],
+ "NCBI gene:647309": [
+  "UP:A6NCL1"
+ ],
+ "NCBI gene:1874": [
+  "UP:Q16254"
+ ],
+ "NCBI gene:1869": [
+  "UP:Q01094"
+ ],
+ "NCBI gene:345643": [
+  "UP:D6RGH6"
+ ],
+ "NCBI gene:2302": [
+  "UP:Q92949"
+ ],
+ "NCBI gene:13017": [
+  "UP:P56546"
+ ],
+ "NCBI gene:233908": [
+  "UP:P56959"
+ ],
+ "NCBI gene:52906": [
+  "UP:E9QP54",
+  "UP:E9Q552"
+ ],
+ "NCBI gene:70357": [
+  "UP:Q9JJ57"
+ ],
+ "NCBI gene:18040": [
+  "UP:P08553"
+ ],
+ "NCBI gene:18039": [
+  "UP:P08551"
+ ],
+ "NCBI gene:22145": [
+  "UP:P68368"
+ ],
+ "NCBI gene:13400": [
+  "UP:P54265"
+ ],
+ "NCBI gene:231724": [
+  "UP:Q6WBX7"
+ ],
+ "NCBI gene:237611": [
+  "UP:Q8BZ71"
+ ],
+ "NCBI gene:68024": [
+  "UP:Q6ZWY9"
+ ],
+ "NCBI gene:50708": [
+  "UP:P15864"
+ ],
+ "NCBI gene:212483": [
+  "UP:Q3U2K0"
+ ],
+ "NCBI gene:54128": [
+  "UP:Q9Z2M7"
+ ],
+ "NCBI gene:68021": [
+  "UP:Q8R164"
+ ],
+ "NCBI gene:70439": [
+  "UP:Q8BQ46"
+ ],
+ "NCBI gene:20822": [
+  "UP:O08848"
+ ],
+ "NCBI gene:16589": [
+  "UP:P97343"
+ ],
+ "NCBI gene:245857": [
+  "UP:Q8K330"
+ ],
+ "NCBI gene:22370": [
+  "UP:P29788"
+ ],
+ "NCBI gene:20638": [
+  "UP:P27048"
+ ],
+ "NCBI gene:13845": [
+  "UP:P54754"
+ ],
+ "NCBI gene:12647": [
+  "UP:Q8BQV2"
+ ],
+ "NCBI gene:2547": [
+  "UP:P12956"
+ ],
+ "NCBI gene:3251": [
+  "UP:P00492"
+ ],
+ "NCBI gene:9540": [
+  "UP:Q53FA7"
+ ],
+ "NCBI gene:7832": [
+  "UP:P78543"
+ ],
+ "NCBI gene:7520": [
+  "UP:P13010"
+ ],
+ "NCBI gene:8850": [
+  "UP:Q92831"
+ ],
+ "NCBI gene:12096": [
+  "UP:P86546"
+ ],
+ "NCBI gene:68549": [
+  "UP:Q7TSY8"
+ ],
+ "NCBI gene:244495": [
+  "UP:J3QMK1"
+ ],
+ "NCBI gene:140557": [
+  "UP:Q920F6"
+ ],
+ "NCBI gene:18985": [
+  "UP:Q64693"
+ ],
+ "NCBI gene:208154": [
+  "UP:Q7TSA3"
+ ],
+ "NCBI gene:12053": [
+  "UP:P41183"
+ ],
+ "NCBI gene:15978": [
+  "UP:P01580"
+ ],
+ "NCBI gene:18987": [
+  "UP:Q00196"
+ ],
+ "NCBI gene:2538763": [
+  "UP:Q9P802"
+ ],
+ "NCBI gene:11339": [
+  "UP:O43482"
+ ],
+ "NCBI gene:54069": [
+  "UP:Q9NYP9"
+ ],
+ "NCBI gene:8493": [
+  "UP:O15297"
+ ],
+ "NCBI gene:11011": [
+  "UP:Q86UE8"
+ ],
+ "NCBI gene:25842": [
+  "UP:Q9Y294"
+ ],
+ "NCBI gene:14071": [
+  "UP:P16294"
+ ],
+ "NCBI gene:5580": [
+  "UP:Q05655"
+ ],
+ "NCBI gene:19164": [
+  "UP:P49769"
+ ],
+ "NCBI gene:10869": [
+  "UP:O94966"
+ ],
+ "NCBI gene:8678": [
+  "UP:Q14457"
+ ],
+ "NCBI gene:30849": [
+  "UP:Q99570"
+ ],
+ "NCBI gene:5289": [
+  "UP:Q8NEB9"
+ ],
+ "NCBI gene:55626": [
+  "UP:Q9C0C7"
+ ],
+ "NCBI gene:8975": [
+  "UP:Q92995"
+ ],
+ "NCBI gene:84640": [
+  "UP:Q8NB14"
+ ],
+ "NCBI gene:3456": [
+  "UP:P01574"
+ ],
+ "NCBI gene:9636": [
+  "UP:P05161"
+ ],
+ "NCBI gene:3433": [
+  "UP:P09913"
+ ],
+ "NCBI gene:3434": [
+  "UP:P09914"
+ ],
+ "NCBI gene:956531": [
+  "UP:P03466"
+ ],
+ "NCBI gene:8878": [
+  "UP:Q13501"
+ ],
+ "NCBI gene:57506": [
+  "UP:Q7Z434"
+ ],
+ "NCBI gene:23586": [
+  "UP:O95786"
+ ],
+ "NCBI gene:16478": [
+  "UP:P15066"
+ ],
+ "NCBI gene:15270": [
+  "UP:P27661"
+ ],
+ "NCBI gene:70238": [
+  "UP:Q80XJ2"
+ ],
+ "NCBI gene:58230": [
+  "UP:Q8VC56"
+ ],
+ "NCBI gene:12151": [
+  "UP:P25916"
+ ],
+ "NCBI gene:3014": [
+  "UP:P16104"
+ ],
+ "NCBI gene:11332": [
+  "UP:O00154"
+ ],
+ "NCBI gene:5226": [
+  "UP:P52209"
+ ],
+ "NCBI gene:196": [
+  "UP:P35869"
+ ],
+ "NCBI gene:182": [
+  "UP:P78504"
+ ],
+ "NCBI gene:33835": [
+  "UP:Q02748"
+ ],
+ "NCBI gene:33710": [
+  "UP:O02195"
+ ],
+ "NCBI gene:45525": [
+  "UP:P48598"
+ ],
+ "NCBI gene:43839": [
+  "UP:O61380",
+  "UP:A8DZ29"
+ ],
+ "NCBI gene:35793": [
+  "UP:Q7K519"
+ ],
+ "NCBI gene:41071": [
+  "UP:Q9VHJ4"
+ ],
+ "NCBI gene:40201": [
+  "UP:M9PD17",
+  "UP:Q9VW83"
+ ],
+ "NCBI gene:117332": [
+  "UP:Q9VND8"
+ ],
+ "NCBI gene:46020": [
+  "UP:A1Z968",
+  "UP:Q0E996"
+ ],
+ "NCBI gene:2539045": [
+  "UP:O74842"
+ ],
+ "NCBI gene:2541531": [
+  "UP:O42861"
+ ],
+ "NCBI gene:16948": [
+  "UP:P28301"
+ ],
+ "NCBI gene:16535": [
+  "UP:P97414"
+ ],
+ "NCBI gene:3480": [
+  "UP:P08069"
+ ],
+ "NCBI gene:5894": [
+  "UP:P04049"
+ ],
+ "NCBI gene:5594": [
+  "UP:P28482"
+ ],
+ "NCBI gene:5595": [
+  "UP:P27361"
+ ],
+ "NCBI gene:5605": [
+  "UP:P36507"
+ ],
+ "NCBI gene:83558": [
+  "UP:Q14AT2"
+ ],
+ "NCBI gene:216274": [
+  "UP:Q6A078"
+ ],
+ "NCBI gene:77945": [
+  "UP:Q9EPQ2"
+ ],
+ "NCBI gene:6010": [
+  "UP:P08100"
+ ],
+ "NCBI gene:22259": [
+  "UP:Q9Z0Y9"
+ ],
+ "NCBI gene:54720": [
+  "UP:Q9JHG6"
+ ],
+ "NCBI gene:14219": [
+  "UP:P29268"
+ ],
+ "NCBI gene:17888": [
+  "UP:Q02566"
+ ],
+ "NCBI gene:11459": [
+  "UP:P68134"
+ ],
+ "NCBI gene:410": [
+  "UP:P15289"
+ ],
+ "NCBI gene:2581": [
+  "UP:P54803"
+ ],
+ "NCBI gene:67963": [
+  "UP:Q9Z0J0"
+ ],
+ "NCBI gene:10512": [
+  "UP:Q99985"
+ ],
+ "NCBI gene:23129": [
+  "UP:Q9Y4D7"
+ ],
+ "NCBI gene:8829": [
+  "UP:O14786"
+ ],
+ "NCBI gene:20348": [
+  "UP:Q62181"
+ ],
+ "NCBI gene:67784": [
+  "UP:Q3UH93"
+ ],
+ "NCBI gene:12836": [
+  "UP:Q63870"
+ ],
+ "NCBI gene:21813": [
+  "UP:Q62312"
+ ],
+ "NCBI gene:21825": [
+  "UP:Q3TR40",
+  "UP:Q80YQ1"
+ ],
+ "NCBI gene:21923": [
+  "UP:Q80YX1"
+ ],
+ "NCBI gene:4179": [
+  "UP:P15529"
+ ],
+ "NCBI gene:718": [
+  "UP:P01024"
+ ],
+ "NCBI gene:5888": [
+  "UP:Q06609"
+ ],
+ "NCBI gene:6657": [
+  "UP:P48431"
+ ],
+ "NCBI gene:79728": [
+  "UP:Q86YC2"
+ ],
+ "NCBI gene:84893": [
+  "UP:Q8NFZ0"
+ ],
+ "NCBI gene:641": [
+  "UP:P54132"
+ ],
+ "NCBI gene:898": [
+  "UP:P24864"
+ ],
+ "NCBI gene:9134": [
+  "UP:O96020"
+ ],
+ "NCBI gene:12447": [
+  "UP:Q61457"
+ ],
+ "NCBI gene:12448": [
+  "UP:Q9Z238"
+ ],
+ "NCBI gene:24383": [
+  "UP:P04797"
+ ],
+ "NCBI gene:11793": [
+  "UP:Q99J83"
+ ],
+ "NCBI gene:57379": [
+  "UP:Q9GZX7"
+ ],
+ "NCBI gene:11628": [
+  "UP:Q9WVE0"
+ ],
+ "NCBI gene:22349": [
+  "UP:Q62468"
+ ],
+ "NCBI gene:109901": [
+  "UP:Q91X79"
+ ],
+ "NCBI gene:13706": [
+  "UP:P05208"
+ ],
+ "NCBI gene:8452": [
+  "UP:Q13618"
+ ],
+ "NCBI gene:55832": [
+  "UP:Q86VP6"
+ ],
+ "NCBI gene:26554": [
+  "UP:Q9JLV5"
+ ],
+ "NCBI gene:36544": [
+  "UP:Q7KY08",
+  "UP:Q32KD4"
+ ],
+ "NCBI gene:27161": [
+  "UP:Q9UKV8"
+ ],
+ "NCBI gene:32752": [
+  "UP:O97111"
+ ],
+ "NCBI gene:37729": [
+  "UP:O02002"
+ ],
+ "NCBI gene:167227": [
+  "UP:Q8IU60"
+ ],
+ "NCBI gene:43808": [
+  "UP:Q8SY33"
+ ],
+ "NCBI gene:5740252": [
+  "UP:A8DY80",
+  "UP:A0A0B4LEZ3",
+  "UP:A8DY82",
+  "UP:E2QCN4",
+  "UP:A8DY81"
+ ],
+ "NCBI gene:23019": [
+  "UP:A5YKK6"
+ ],
+ "NCBI gene:27327": [
+  "UP:Q8NDV7"
+ ],
+ "NCBI gene:44786": [
+  "UP:Q9V3B8"
+ ],
+ "NCBI gene:1656": [
+  "UP:P26196"
+ ],
+ "NCBI gene:56478": [
+  "UP:Q9NRA8"
+ ],
+ "NCBI gene:12505": [
+  "UP:P15379"
+ ],
+ "NCBI gene:18787": [
+  "UP:G5E899"
+ ],
+ "NCBI gene:10533": [
+  "UP:O95352"
+ ],
+ "NCBI gene:56426": [
+  "UP:Q8VE70"
+ ],
+ "NCBI gene:90550": [
+  "UP:Q8NE86"
+ ],
+ "NCBI gene:55013": [
+  "UP:Q9NWR8"
+ ],
+ "NCBI gene:215999": [
+  "UP:Q3UMR5"
+ ],
+ "NCBI gene:3091": [
+  "UP:Q16665"
+ ],
+ "NCBI gene:2034": [
+  "UP:Q99814"
+ ],
+ "NCBI gene:4015": [
+  "UP:P28300"
+ ],
+ "NCBI gene:5163": [
+  "UP:Q15118"
+ ],
+ "NCBI gene:2821": [
+  "UP:P06744"
+ ],
+ "NCBI gene:768": [
+  "UP:Q16790"
+ ],
+ "NCBI gene:3099": [
+  "UP:P52789"
+ ],
+ "NCBI gene:1489088": [
+  "UP:P06463"
+ ],
+ "NCBI gene:9306": [
+  "UP:O14544"
+ ],
+ "NCBI gene:1489078": [
+  "UP:P03126"
+ ],
+ "NCBI gene:1489079": [
+  "UP:P03129"
+ ],
+ "NCBI gene:1956": [
+  "UP:P00533"
+ ],
+ "NCBI gene:374": [
+  "UP:P15514"
+ ],
+ "NCBI gene:7039": [
+  "UP:P01135"
+ ],
+ "NCBI gene:22341": [
+  "UP:P97953"
+ ],
+ "NCBI gene:14205": [
+  "UP:P97946"
+ ],
+ "NCBI gene:14257": [
+  "UP:P35917"
+ ],
+ "NCBI gene:18591": [
+  "UP:P31240"
+ ],
+ "NCBI gene:11727": [
+  "UP:P21570"
+ ],
+ "NCBI gene:11731": [
+  "UP:Q64438"
+ ],
+ "NCBI gene:20346": [
+  "UP:O08665"
+ ],
+ "NCBI gene:18613": [
+  "UP:Q08481"
+ ],
+ "NCBI gene:12525": [
+  "UP:P01731"
+ ],
+ "NCBI gene:12526": [
+  "UP:P10300"
+ ],
+ "NCBI gene:100507436": [
+  "UP:Q29983"
+ ],
+ "NCBI gene:31459": [
+  "UP:Q7KVW1",
+  "UP:Q9W4C4"
+ ],
+ "NCBI gene:8165": [
+  "UP:Q92667"
+ ],
+ "NCBI gene:42297": [
+  "UP:P25724"
+ ],
+ "NCBI gene:53567": [
+  "UP:Q9VAW5"
+ ],
+ "NCBI gene:40189": [
+  "UP:Q95RF6"
+ ],
+ "NCBI gene:34792": [
+  "UP:Q27607"
+ ],
+ "NCBI gene:42433": [
+  "UP:Q9VDL2",
+  "UP:Q86BR8"
+ ],
+ "NCBI gene:35279": [
+  "UP:Q9VIQ8"
+ ],
+ "NCBI gene:41968": [
+  "UP:P54622"
+ ],
+ "NCBI gene:41028": [
+  "UP:Q9VHN6"
+ ],
+ "NCBI gene:5015": [
+  "UP:P32243"
+ ],
+ "NCBI gene:4009": [
+  "UP:Q8TE12"
+ ],
+ "NCBI gene:1638": [
+  "UP:P40126"
+ ],
+ "NCBI gene:1815": [
+  "UP:P21917"
+ ],
+ "NCBI gene:841": [
+  "UP:Q14790"
+ ],
+ "NCBI gene:836": [
+  "UP:P42574"
+ ],
+ "NCBI gene:26059": [
+  "UP:O15083"
+ ],
+ "NCBI gene:4753": [
+  "UP:Q99435"
+ ],
+ "NCBI gene:3169": [
+  "UP:P55317"
+ ],
+ "NCBI gene:3170": [
+  "UP:Q9Y261"
+ ],
+ "NCBI gene:2908": [
+  "UP:P04150"
+ ],
+ "NCBI gene:3172": [
+  "UP:P41235"
+ ],
+ "NCBI gene:2355": [
+  "UP:P15408"
+ ],
+ "NCBI gene:569403": [
+  "UP:B5LZ08"
+ ],
+ "NCBI gene:30269": [
+  "UP:Q92008"
+ ],
+ "NCBI gene:30181": [
+  "UP:F1Q8S0"
+ ],
+ "NCBI gene:30697": [
+  "UP:F1QNE4"
+ ],
+ "NCBI gene:325288": [
+  "UP:Q8QGI4"
+ ],
+ "NCBI gene:319757": [
+  "UP:P56726"
+ ],
+ "NCBI gene:110355": [
+  "UP:Q99MK8"
+ ],
+ "NCBI gene:30225": [
+  "UP:Q5RH73"
+ ],
+ "NCBI gene:25550": [
+  "UP:P51907"
+ ],
+ "NCBI gene:6608": [
+  "UP:Q99835"
+ ],
+ "NCBI gene:6505": [
+  "UP:P43005"
+ ],
+ "NCBI gene:107747": [
+  "UP:Q8R0Y6"
+ ],
+ "NCBI gene:17076": [
+  "UP:Q60767"
+ ],
+ "NCBI gene:21898": [
+  "UP:Q9QUK6"
+ ],
+ "NCBI gene:114879": [
+  "UP:Q9H0X9"
+ ],
+ "NCBI gene:114882": [
+  "UP:Q9BZF1"
+ ],
+ "NCBI gene:55177": [
+  "UP:Q96TC7"
+ ],
+ "NCBI gene:9218": [
+  "UP:Q9P0L0"
+ ],
+ "NCBI gene:9217": [
+  "UP:O95292"
+ ],
+ "NCBI gene:68346": [
+  "UP:Q8K2C6"
+ ],
+ "NCBI gene:23408": [
+  "UP:Q9NXA8"
+ ],
+ "NCBI gene:2539": [
+  "UP:P11413"
+ ],
+ "NCBI gene:3418": [
+  "UP:P48735"
+ ],
+ "NCBI gene:5460": [
+  "UP:Q01860"
+ ],
+ "NCBI gene:6615": [
+  "UP:O95863"
+ ],
+ "NCBI gene:7291": [
+  "UP:Q15672"
+ ],
+ "NCBI gene:3236": [
+  "UP:P28358"
+ ],
+ "NCBI gene:389": [
+  "UP:P08134"
+ ],
+ "NCBI gene:5728": [
+  "UP:P60484"
+ ],
+ "NCBI gene:23405": [
+  "UP:Q9UPY3"
+ ],
+ "NCBI gene:201163": [
+  "UP:Q8NFG4"
+ ],
+ "NCBI gene:19376": [
+  "UP:Q64008"
+ ],
+ "NCBI gene:338382": [
+  "UP:Q96AH8"
+ ],
+ "NCBI gene:7879": [
+  "UP:P51149"
+ ],
+ "NCBI gene:83547": [
+  "UP:Q96NA2"
+ ],
+ "NCBI gene:16510": [
+  "UP:Q60603"
+ ],
+ "NCBI gene:3756": [
+  "UP:O95259"
+ ],
+ "NCBI gene:27133": [
+  "UP:Q8NCM2"
+ ],
+ "NCBI gene:13043": [
+  "UP:Q60598"
+ ],
+ "NCBI gene:20910": [
+  "UP:O08599"
+ ],
+ "NCBI gene:22187": [
+  "UP:P0CG49"
+ ],
+ "NCBI gene:78294": [
+  "UP:P62983"
+ ],
+ "NCBI gene:22186": [
+  "UP:P62984"
+ ],
+ "NCBI gene:22190": [
+  "UP:P0CG50"
+ ],
+ "NCBI gene:73205": [
+  "UP:Q3U3D8"
+ ],
+ "NCBI gene:67790": [
+  "UP:Q8BHC1"
+ ],
+ "NCBI gene:17274": [
+  "UP:P55258"
+ ],
+ "NCBI gene:19349": [
+  "UP:P51150"
+ ],
+ "NCBI gene:237782": [
+  "UP:Q3UMB5"
+ ],
+ "NCBI gene:56480": [
+  "UP:Q9WUN2"
+ ],
+ "NCBI gene:203228": [
+  "UP:Q96LT7"
+ ],
+ "NCBI gene:6311": [
+  "UP:Q99700"
+ ],
+ "NCBI gene:402895": [
+  "UP:Q6TLH8"
+ ],
+ "NCBI gene:821563": [
+  "UP:Q9LJY0"
+ ],
+ "NCBI gene:841483": [
+  "UP:Q9LPT1"
+ ],
+ "NCBI gene:841747": [
+  "UP:Q9LNN7"
+ ],
+ "NCBI gene:830299": [
+  "UP:Q9FYE1"
+ ],
+ "NCBI gene:850585": [
+  "UP:Q00684"
+ ],
+ "NCBI gene:850768": [
+  "UP:P38634"
+ ],
+ "NCBI gene:852308": [
+  "UP:P04385"
+ ],
+ "NCBI gene:852762": [
+  "UP:P26309"
+ ],
+ "NCBI gene:853466": [
+  "UP:P08536"
+ ],
+ "NCBI gene:856236": [
+  "UP:P24869"
+ ],
+ "NCBI gene:855570": [
+  "UP:P53901"
+ ],
+ "NCBI gene:852326": [
+  "UP:P14180"
+ ],
+ "NCBI gene:12918": [
+  "UP:Q8CIT0"
+ ],
+ "NCBI gene:14815": [
+  "UP:E9PYV1",
+  "UP:E9PUR6"
+ ],
+ "NCBI gene:214189": [
+  "UP:Q91WD9"
+ ],
+ "NCBI gene:836808": [
+  "UP:Q9XFH4"
+ ],
+ "NCBI gene:824112": [
+  "UP:Q9SG02"
+ ],
+ "NCBI gene:837341": [
+  "UP:Q9SGE0"
+ ],
+ "NCBI gene:817856": [
+  "UP:O48771"
+ ],
+ "NCBI gene:817246": [
+  "UP:Q9ZVD5"
+ ],
+ "NCBI gene:2540353": [
+  "UP:O14342"
+ ],
+ "NCBI gene:2540115": [
+  "UP:Q96TL7"
+ ],
+ "NCBI gene:2539108": [
+  "UP:P36597"
+ ],
+ "NCBI gene:2540601": [
+  "UP:O13339"
+ ],
+ "NCBI gene:2542244": [
+  "UP:O13852"
+ ],
+ "NCBI gene:2542313": [
+  "UP:P79005"
+ ],
+ "NCBI gene:2542061": [
+  "UP:O13915"
+ ],
+ "NCBI gene:5099": [
+  "UP:O60245"
+ ],
+ "NCBI gene:75599": [
+  "UP:Q8CFX3"
+ ],
+ "NCBI gene:5097": [
+  "UP:Q08174"
+ ],
+ "NCBI gene:4627": [
+  "UP:P35579"
+ ],
+ "NCBI gene:854976": [
+  "UP:P06778"
+ ],
+ "NCBI gene:855264": [
+  "UP:P32829"
+ ],
+ "NCBI gene:854392": [
+  "UP:P38630"
+ ],
+ "NCBI gene:851415": [
+  "UP:P04050"
+ ],
+ "NCBI gene:853500": [
+  "UP:P47110"
+ ],
+ "NCBI gene:856831": [
+  "UP:P25454"
+ ],
+ "NCBI gene:850342": [
+  "UP:P04173"
+ ],
+ "NCBI gene:856692": [
+  "UP:P03962"
+ ],
+ "NCBI gene:854295": [
+  "UP:P21264"
+ ],
+ "NCBI gene:855274": [
+  "UP:Q04740"
+ ],
+ "NCBI gene:851625": [
+  "UP:Q12355"
+ ],
+ "NCBI gene:856681": [
+  "UP:P39986"
+ ],
+ "NCBI gene:850510": [
+  "UP:P43564"
+ ],
+ "NCBI gene:852876": [
+  "UP:P05030"
+ ],
+ "NCBI gene:854322": [
+  "UP:P08518"
+ ],
+ "NCBI gene:852810": [
+  "UP:P27999"
+ ],
+ "NCBI gene:20186": [
+  "UP:Q60641"
+ ],
+ "NCBI gene:59004": [
+  "UP:Q9JM05"
+ ],
+ "NCBI gene:19697": [
+  "UP:Q04207"
+ ],
+ "NCBI gene:20181": [
+  "UP:P28700"
+ ],
+ "NCBI gene:23957": [
+  "UP:Q62227"
+ ],
+ "NCBI gene:22164": [
+  "UP:P43488"
+ ],
+ "NCBI gene:12288": [
+  "UP:Q01815"
+ ],
+ "NCBI gene:16151": [
+  "UP:O88522"
+ ],
+ "NCBI gene:56893": [
+  "UP:Q9NRR5"
+ ],
+ "NCBI gene:3559": [
+  "UP:P01589"
+ ],
+ "NCBI gene:7917": [
+  "UP:P46379"
+ ],
+ "NCBI gene:29979": [
+  "UP:Q9UMX0"
+ ],
+ "NCBI gene:94232": [
+  "UP:Q99NB8"
+ ],
+ "NCBI gene:6729": [
+  "UP:P61011"
+ ],
+ "NCBI gene:79092": [
+  "UP:Q9BXL6"
+ ],
+ "NCBI gene:10892": [
+  "UP:Q9UDY8"
+ ],
+ "NCBI gene:8915": [
+  "UP:O95999"
+ ],
+ "NCBI gene:84433": [
+  "UP:Q9BXL7"
+ ],
+ "NCBI gene:1540": [
+  "UP:Q9NQC7"
+ ],
+ "NCBI gene:10318": [
+  "UP:Q15025"
+ ],
+ "NCBI gene:7128": [
+  "UP:P21580"
+ ],
+ "NCBI gene:139341": [
+  "UP:Q8IVP5"
+ ],
+ "NCBI gene:821": [
+  "UP:P27824"
+ ],
+ "NCBI gene:64783": [
+  "UP:Q96T37"
+ ],
+ "NCBI gene:861": [
+  "UP:Q01196"
+ ],
+ "NCBI gene:862": [
+  "UP:Q06455"
+ ],
+ "NCBI gene:67956": [
+  "UP:Q2YDW7"
+ ],
+ "NCBI gene:11657": [
+  "UP:P07724"
+ ],
+ "NCBI gene:11576": [
+  "UP:P02772"
+ ],
+ "NCBI gene:15378": [
+  "UP:P49698"
+ ],
+ "NCBI gene:14178": [
+  "UP:P36363"
+ ],
+ "NCBI gene:14734": [
+  "UP:Q8CFZ4"
+ ],
+ "NCBI gene:10075": [
+  "UP:Q7Z6Z7"
+ ],
+ "NCBI gene:56852": [
+  "UP:Q9NS91"
+ ],
+ "NCBI gene:5111": [
+  "UP:P12004"
+ ],
+ "NCBI gene:165918": [
+  "UP:Q8IYW5"
+ ],
+ "NCBI gene:648": [
+  "UP:P35226"
+ ],
+ "NCBI gene:12825": [
+  "UP:P08121"
+ ],
+ "NCBI gene:94223": [
+  "UP:Q9EQM6"
+ ],
+ "NCBI gene:12591": [
+  "UP:P43241"
+ ],
+ "NCBI gene:15110": [
+  "UP:Q64279"
+ ],
+ "NCBI gene:14176": [
+  "UP:P15656"
+ ],
+ "NCBI gene:18008": [
+  "UP:Q6P5H2"
+ ],
+ "NCBI gene:4735": [
+  "UP:Q15019"
+ ],
+ "NCBI gene:989": [
+  "UP:Q16181"
+ ],
+ "NCBI gene:10801": [
+  "UP:Q9UHD8"
+ ],
+ "NCBI gene:18000": [
+  "UP:P42208"
+ ],
+ "NCBI gene:74006": [
+  "UP:Q8K1M6"
+ ],
+ "NCBI gene:173233": [
+  "UP:Q9U334"
+ ],
+ "NCBI gene:179976": [
+  "UP:Q9U277",
+  "UP:Q25AR8",
+  "UP:Q8I4C9"
+ ],
+ "NCBI gene:177336": [
+  "UP:G5EDY8",
+  "UP:Q8WQC9"
+ ],
+ "NCBI gene:56739": [
+  "UP:Q8C5S7"
+ ],
+ "NCBI gene:50878": [
+  "UP:O70576"
+ ],
+ "NCBI gene:925": [
+  "UP:P01732"
+ ],
+ "NCBI gene:387357": [
+  "UP:Q8N1K5"
+ ],
+ "NCBI gene:3932": [
+  "UP:P06239"
+ ],
+ "NCBI gene:2885": [
+  "UP:P62993"
+ ],
+ "NCBI gene:5777": [
+  "UP:P29350"
+ ],
+ "NCBI gene:16818": [
+  "UP:P06240"
+ ],
+ "NCBI gene:12189": [
+  "UP:P48754"
+ ],
+ "NCBI gene:237336": [
+  "UP:P62340"
+ ],
+ "NCBI gene:225182": [
+  "UP:Q80YR6"
+ ],
+ "NCBI gene:11545": [
+  "UP:Q921K2"
+ ],
+ "NCBI gene:85015": [
+  "UP:Q70EL2"
+ ],
+ "NCBI gene:13870": [
+  "UP:P07903"
+ ],
+ "NCBI gene:52864": [
+  "UP:Q6P1D7"
+ ],
+ "NCBI gene:2067": [
+  "UP:P07992"
+ ],
+ "NCBI gene:73707": [
+  "UP:Q6TL19"
+ ],
+ "NCBI gene:14913": [
+  "UP:P43081"
+ ],
+ "NCBI gene:12790": [
+  "UP:Q9JJZ8"
+ ],
+ "NCBI gene:14281": [
+  "UP:P01101"
+ ],
+ "NCBI gene:281370": [
+  "UP:P0CG53"
+ ],
+ "NCBI gene:615199": [
+  "UP:P63048"
+ ],
+ "NCBI gene:444874": [
+  "UP:P0CH28"
+ ],
+ "NCBI gene:286839": [
+  "UP:P62992"
+ ],
+ "NCBI gene:8517": [
+  "UP:Q9Y6K9"
+ ],
+ "NCBI gene:9230": [
+  "UP:Q15907"
+ ],
+ "NCBI gene:5879": [
+  "UP:P63000"
+ ],
+ "NCBI gene:55144": [
+  "UP:Q7L1W4"
+ ],
+ "NCBI gene:80131": [
+  "UP:Q6NSJ5"
+ ],
+ "NCBI gene:56262": [
+  "UP:Q8IWT6"
+ ],
+ "NCBI gene:84230": [
+  "UP:Q8TDW0"
+ ],
+ "NCBI gene:2540492": [
+  "UP:O74804"
+ ],
+ "NCBI gene:15975": [
+  "UP:P33896"
+ ],
+ "NCBI gene:65018": [
+  "UP:Q9BXM7"
+ ],
+ "NCBI gene:4218": [
+  "UP:P61006"
+ ],
+ "NCBI gene:51762": [
+  "UP:Q92930"
+ ],
+ "NCBI gene:5872": [
+  "UP:P51153"
+ ],
+ "NCBI gene:68943": [
+  "UP:Q99MQ3"
+ ],
+ "NCBI gene:3361384": [
+  "UP:Q9UTN3"
+ ],
+ "NCBI gene:2539481": [
+  "UP:O94603"
+ ],
+ "NCBI gene:851932": [
+  "UP:Q06683"
+ ],
+ "NCBI gene:2540735": [
+  "UP:O94687"
+ ],
+ "NCBI gene:13434": [
+  "UP:O55055"
+ ],
+ "NCBI gene:170574": [
+  "UP:Q8VI67"
+ ],
+ "NCBI gene:12606": [
+  "UP:P53566"
+ ],
+ "NCBI gene:11789": [
+  "UP:Q8BNP7",
+  "UP:B2RUG9"
+ ],
+ "NCBI gene:14160": [
+  "UP:Q9Z1P4"
+ ],
+ "NCBI gene:44392": [
+  "UP:Q9VPM0"
+ ],
+ "NCBI gene:2768677": [
+  "UP:A0A0B4K7P1",
+  "UP:Q9N6D8",
+  "UP:Q8IMZ4"
+ ],
+ "NCBI gene:35288": [
+  "UP:O61267"
+ ],
+ "NCBI gene:326205": [
+  "UP:Q8IRB5"
+ ],
+ "NCBI gene:41666": [
+  "UP:Q08473"
+ ],
+ "NCBI gene:34524": [
+  "UP:O76922"
+ ],
+ "NCBI gene:56636": [
+  "UP:Q9JJN1"
+ ],
+ "NCBI gene:53895": [
+  "UP:O88696"
+ ],
+ "NCBI gene:226539": [
+  "UP:Q8BIP0"
+ ],
+ "NCBI gene:72981": [
+  "UP:Q9CUX1"
+ ],
+ "NCBI gene:59092": [
+  "UP:P57724"
+ ],
+ "NCBI gene:21807": [
+  "UP:P62500"
+ ],
+ "NCBI gene:5612": [
+  "UP:O43422"
+ ],
+ "NCBI gene:57060": [
+  "UP:P57723"
+ ],
+ "NCBI gene:8848": [
+  "UP:Q15714"
+ ],
+ "NCBI gene:4783": [
+  "UP:Q16649"
+ ],
+ "NCBI gene:852200": [
+  "UP:P38182"
+ ],
+ "NCBI gene:852695": [
+  "UP:P53104"
+ ],
+ "NCBI gene:855949": [
+  "UP:P07267"
+ ],
+ "NCBI gene:853653": [
+  "UP:P07149"
+ ],
+ "NCBI gene:854419": [
+  "UP:Q08650"
+ ],
+ "NCBI gene:855753": [
+  "UP:P53629"
+ ],
+ "NCBI gene:855742": [
+  "UP:P40345"
+ ],
+ "NCBI gene:850415": [
+  "UP:P25628"
+ ],
+ "NCBI gene:853717": [
+  "UP:P34163"
+ ],
+ "NCBI gene:850648": [
+  "UP:Q07804"
+ ],
+ "NCBI gene:850707": [
+  "UP:Q07950"
+ ],
+ "NCBI gene:855361": [
+  "UP:P40308"
+ ],
+ "NCBI gene:853964": [
+  "UP:P36165"
+ ],
+ "NCBI gene:854248": [
+  "UP:Q12043"
+ ],
+ "NCBI gene:854682": [
+  "UP:P40471"
+ ],
+ "NCBI gene:852503": [
+  "UP:P38139"
+ ],
+ "NCBI gene:854718": [
+  "UP:P40499"
+ ],
+ "NCBI gene:850351": [
+  "UP:P25587"
+ ],
+ "NCBI gene:10818": [
+  "UP:Q8WU20"
+ ],
+ "NCBI gene:7048": [
+  "UP:P37173"
+ ],
+ "NCBI gene:4087": [
+  "UP:Q15796"
+ ],
+ "NCBI gene:327826": [
+  "UP:Q8C180"
+ ],
+ "NCBI gene:16847": [
+  "UP:P48356"
+ ],
+ "NCBI gene:13197": [
+  "UP:P48316"
+ ],
+ "NCBI gene:17873": [
+  "UP:P22339"
+ ],
+ "NCBI gene:23882": [
+  "UP:Q9R0S0"
+ ],
+ "NCBI gene:4616": [
+  "UP:O75293"
+ ],
+ "NCBI gene:269346": [
+  "UP:O88627"
+ ],
+ "NCBI gene:26459": [
+  "UP:Q4LDG0"
+ ],
+ "NCBI gene:14080": [
+  "UP:P12710"
+ ],
+ "NCBI gene:13167": [
+  "UP:P31786"
+ ],
+ "NCBI gene:104112": [
+  "UP:Q91V92"
+ ],
+ "NCBI gene:13350": [
+  "UP:Q9Z2A7"
+ ],
+ "NCBI gene:66853": [
+  "UP:Q8BJ56"
+ ],
+ "NCBI gene:16890": [
+  "UP:P54310"
+ ],
+ "NCBI gene:930": [
+  "UP:P15391"
+ ],
+ "NCBI gene:47121": [
+  "UP:Q7JVY2"
+ ],
+ "NCBI gene:34924": [
+  "UP:P54733"
+ ],
+ "NCBI gene:42453": [
+  "UP:P23573"
+ ],
+ "NCBI gene:36001": [
+  "UP:Q7JNL9"
+ ],
+ "NCBI gene:834623": [
+  "UP:A0SVK0"
+ ],
+ "NCBI gene:816248": [
+  "UP:Q39242"
+ ],
+ "NCBI gene:829698": [
+  "UP:Q39243"
+ ],
+ "NCBI gene:830761": [
+  "UP:F4KB50",
+  "UP:A0A1P8BDG3",
+  "UP:Q9FNM8"
+ ],
+ "NCBI gene:818438": [
+  "UP:Q9ZVH8"
+ ],
+ "NCBI gene:4772": [
+  "UP:O95644"
+ ],
+ "NCBI gene:20613": [
+  "UP:Q02085"
+ ],
+ "NCBI gene:17000": [
+  "UP:P50284"
+ ],
+ "NCBI gene:50930": [
+  "UP:Q9QYH9"
+ ],
+ "NCBI gene:21908": [
+  "UP:Q9QX99"
+ ],
+ "NCBI gene:16992": [
+  "UP:P09225"
+ ],
+ "NCBI gene:19885": [
+  "UP:P51450"
+ ],
+ "NCBI gene:16994": [
+  "UP:P41155"
+ ],
+ "NCBI gene:7839648": [
+  "UP:I7ME13"
+ ],
+ "NCBI gene:7826679": [
+  "UP:I7MKB8"
+ ],
+ "NCBI gene:7840065": [
+  "UP:Q23ND1"
+ ],
+ "NCBI gene:7842494": [
+  "UP:Q23TC8"
+ ],
+ "NCBI gene:7844980": [
+  "UP:Q23DJ8"
+ ],
+ "NCBI gene:7835183": [
+  "UP:Q22W82"
+ ],
+ "NCBI gene:7825902": [
+  "UP:Q22A77"
+ ],
+ "NCBI gene:937920": [
+  "UP:P37524"
+ ],
+ "NCBI gene:937907": [
+  "UP:P26497"
+ ],
+ "NCBI gene:7113": [
+  "UP:O15393"
+ ],
+ "NCBI gene:354": [
+  "UP:P07288"
+ ],
+ "NCBI gene:80315": [
+  "UP:Q17RY0"
+ ],
+ "NCBI gene:4961484": [
+  "UP:F5HB62"
+ ],
+ "NCBI gene:6093": [
+  "UP:Q13464"
+ ],
+ "NCBI gene:9475": [
+  "UP:O75116"
+ ],
+ "NCBI gene:1497151": [
+  "UP:O41940"
+ ],
+ "NCBI gene:5747": [
+  "UP:Q05397"
+ ],
+ "NCBI gene:2185": [
+  "UP:Q14289"
+ ],
+ "NCBI gene:5829": [
+  "UP:P49023"
+ ],
+ "NCBI gene:1398": [
+  "UP:P46108"
+ ],
+ "NCBI gene:850440": [
+  "UP:P25644"
+ ],
+ "NCBI gene:834867": [
+  "UP:Q9LDL7"
+ ],
+ "NCBI gene:820605": [
+  "UP:P41376"
+ ],
+ "NCBI gene:817566": [
+  "UP:O64733"
+ ],
+ "NCBI gene:823740": [
+  "UP:Q9LZT4"
+ ],
+ "NCBI gene:22196": [
+  "UP:P63280"
+ ],
+ "NCBI gene:7329": [
+  "UP:P63279"
+ ],
+ "NCBI gene:5329": [
+  "UP:Q03405"
+ ],
+ "NCBI gene:7448": [
+  "UP:P04004"
+ ],
+ "NCBI gene:5328": [
+  "UP:P00749"
+ ],
+ "NCBI gene:53870": [
+  "UP:Q9JMB8"
+ ],
+ "NCBI gene:19280": [
+  "UP:B0V2N1"
+ ],
+ "NCBI gene:12661": [
+  "UP:P70232"
+ ],
+ "NCBI gene:208": [
+  "UP:P31751"
+ ],
+ "NCBI gene:27130": [
+  "UP:Q9Y283"
+ ],
+ "NCBI gene:4602": [
+  "UP:P10242"
+ ],
+ "NCBI gene:14828": [
+  "UP:P20029"
+ ],
+ "NCBI gene:1191": [
+  "UP:P10909"
+ ],
+ "NCBI gene:995": [
+  "UP:P30307"
+ ],
+ "NCBI gene:7465": [
+  "UP:P30291"
+ ],
+ "NCBI gene:64422": [
+  "UP:Q9NT62"
+ ],
+ "NCBI gene:50873": [
+  "UP:Q9WVS6"
+ ],
+ "NCBI gene:20747": [
+  "UP:Q6ZWS8"
+ ],
+ "NCBI gene:14634": [
+  "UP:Q61602"
+ ],
+ "NCBI gene:20382": [
+  "UP:Q62093"
+ ],
+ "NCBI gene:42737": [
+  "UP:Q02936"
+ ],
+ "NCBI gene:41704": [
+  "UP:Q9VFP2"
+ ],
+ "NCBI gene:209011": [
+  "UP:Q8BKJ9"
+ ],
+ "NCBI gene:110454": [
+  "UP:P05533"
+ ],
+ "NCBI gene:16590": [
+  "UP:P05532"
+ ],
+ "NCBI gene:51547": [
+  "UP:Q9NRC8"
+ ],
+ "NCBI gene:854590": [
+  "UP:P03882"
+ ],
+ "NCBI gene:7158": [
+  "UP:Q12888"
+ ],
+ "NCBI gene:8350": [
+  "UP:P68431"
+ ],
+ "NCBI gene:333932": [
+  "UP:Q71DI3"
+ ],
+ "NCBI gene:3020": [
+  "UP:P84243"
+ ],
+ "NCBI gene:360198": [
+  "UP:P68433"
+ ],
+ "NCBI gene:319150": [
+  "UP:P84228"
+ ],
+ "NCBI gene:15078": [
+  "UP:P84244"
+ ],
+ "NCBI gene:10396": [
+  "UP:Q9Y2Q0"
+ ],
+ "NCBI gene:55754": [
+  "UP:Q9NV96"
+ ],
+ "NCBI gene:10938": [
+  "UP:Q9H4M9"
+ ],
+ "NCBI gene:51761": [
+  "UP:Q9NTI2"
+ ],
+ "NCBI gene:50769": [
+  "UP:P98200"
+ ],
+ "NCBI gene:5725": [
+  "UP:P26599"
+ ],
+ "NCBI gene:9782": [
+  "UP:P43243"
+ ],
+ "NCBI gene:125950": [
+  "UP:Q8IY67"
+ ],
+ "NCBI gene:58155": [
+  "UP:Q9UKA9"
+ ],
+ "NCBI gene:7982": [
+  "UP:Q9NRC1"
+ ],
+ "NCBI gene:2181": [
+  "UP:O95573"
+ ],
+ "NCBI gene:65977": [
+  "UP:Q9HB20"
+ ],
+ "NCBI gene:6938": [
+  "UP:Q99081"
+ ],
+ "NCBI gene:4013": [
+  "UP:O00534"
+ ],
+ "NCBI gene:9991": [
+  "UP:O95758"
+ ],
+ "NCBI gene:25871": [
+  "UP:Q6NW34"
+ ],
+ "NCBI gene:23613": [
+  "UP:Q9ULU4"
+ ],
+ "NCBI gene:55591": [
+  "UP:Q9HBM0"
+ ],
+ "NCBI gene:54965": [
+  "UP:Q8TBF5"
+ ],
+ "NCBI gene:1756": [
+  "UP:P11532"
+ ],
+ "NCBI gene:10152": [
+  "UP:Q9NYB9"
+ ],
+ "NCBI gene:21943": [
+  "UP:O35235"
+ ],
+ "NCBI gene:22417": [
+  "UP:P22724"
+ ],
+ "NCBI gene:12006": [
+  "UP:O88566"
+ ],
+ "NCBI gene:18746": [
+  "UP:P52480"
+ ],
+ "NCBI gene:17191": [
+  "UP:Q9Z2E1"
+ ],
+ "NCBI gene:380924": [
+  "UP:D3YYD0"
+ ],
+ "NCBI gene:851223": [
+  "UP:P18409"
+ ],
+ "NCBI gene:854153": [
+  "UP:Q92328"
+ ],
+ "NCBI gene:850654": [
+  "UP:P41800"
+ ],
+ "NCBI gene:852654": [
+  "UP:P53083"
+ ],
+ "NCBI gene:855602": [
+  "UP:P07213"
+ ],
+ "NCBI gene:855243": [
+  "UP:P23644"
+ ],
+ "NCBI gene:855592": [
+  "UP:P49334"
+ ],
+ "NCBI gene:855751": [
+  "UP:P32897"
+ ],
+ "NCBI gene:855182": [
+  "UP:P28627"
+ ],
+ "NCBI gene:855051": [
+  "UP:P46972"
+ ],
+ "NCBI gene:854131": [
+  "UP:Q08176"
+ ],
+ "NCBI gene:850789": [
+  "UP:Q3E798"
+ ],
+ "NCBI gene:10018": [
+  "UP:O43521"
+ ],
+ "NCBI gene:122786": [
+  "UP:Q96NE9"
+ ],
+ "NCBI gene:1045": [
+  "UP:Q99626"
+ ],
+ "NCBI gene:23984": [
+  "UP:Q8CA95"
+ ],
+ "NCBI gene:327766": [
+  "UP:Q3UP23"
+ ],
+ "NCBI gene:12683": [
+  "UP:O70302"
+ ],
+ "NCBI gene:7350": [
+  "UP:P25874"
+ ],
+ "NCBI gene:1149": [
+  "UP:O60543"
+ ],
+ "NCBI gene:1734": [
+  "UP:Q92813"
+ ],
+ "NCBI gene:63976": [
+  "UP:Q9HAZ2"
+ ],
+ "NCBI gene:9364": [
+  "UP:P51157"
+ ],
+ "NCBI gene:115273": [
+  "UP:Q8N4Z0"
+ ],
+ "NCBI gene:4323": [
+  "UP:P50281"
+ ],
+ "NCBI gene:9644": [
+  "UP:Q5TCZ1"
+ ],
+ "NCBI gene:5862": [
+  "UP:P61019"
+ ],
+ "NCBI gene:59021": [
+  "UP:P53994"
+ ],
+ "NCBI gene:23339": [
+  "UP:Q96JC1"
+ ],
+ "NCBI gene:27072": [
+  "UP:P49754"
+ ],
+ "NCBI gene:5045": [
+  "UP:P09958"
+ ],
+ "NCBI gene:14314": [
+  "UP:Q62356"
+ ],
+ "NCBI gene:14268": [
+  "UP:P11276"
+ ],
+ "NCBI gene:79210": [
+  "UP:Q62632"
+ ],
+ "NCBI gene:24615": [
+  "UP:P05942"
+ ],
+ "NCBI gene:81633": [
+  "UP:P62738"
+ ],
+ "NCBI gene:64839": [
+  "UP:Q9UF56"
+ ],
+ "NCBI gene:51684": [
+  "UP:Q9UMX1"
+ ],
+ "NCBI gene:50758": [
+  "UP:Q9QZN1"
+ ],
+ "NCBI gene:12043": [
+  "UP:P10417"
+ ],
+ "NCBI gene:2735": [
+  "UP:P08151"
+ ],
+ "NCBI gene:24069": [
+  "UP:Q9Z0P7"
+ ],
+ "NCBI gene:56897": [
+  "UP:Q96S55"
+ ],
+ "NCBI gene:5890": [
+  "UP:O15315"
+ ],
+ "NCBI gene:5889": [
+  "UP:O43502"
+ ],
+ "NCBI gene:5892": [
+  "UP:O75771"
+ ],
+ "NCBI gene:675": [
+  "UP:P51587"
+ ],
+ "NCBI gene:853922": [
+  "UP:P25293"
+ ],
+ "NCBI gene:444528": [
+  "UP:Q6GM86"
+ ],
+ "NCBI gene:426939": [
+  "UP:Q860H5"
+ ],
+ "NCBI gene:396233": [
+  "UP:P84247"
+ ],
+ "NCBI gene:427887": [
+  "UP:P84247"
+ ],
+ "NCBI gene:418257": [
+  "UP:E1BVI0"
+ ],
+ "NCBI gene:416928": [
+  "UP:R9PXM5"
+ ],
+ "NCBI gene:395848": [
+  "UP:Q91953"
+ ],
+ "NCBI gene:115004": [
+  "UP:Q8N884"
+ ],
+ "NCBI gene:340061": [
+  "UP:Q86WV6"
+ ],
+ "NCBI gene:24271474": [
+  "UP:P10238"
+ ],
+ "NCBI gene:29110": [
+  "UP:Q9UHD2"
+ ],
+ "NCBI gene:3661": [
+  "UP:Q14653"
+ ],
+ "NCBI gene:148022": [
+  "UP:Q8IUC6"
+ ],
+ "NCBI gene:1487343": [
+  "UP:D4QFJ3"
+ ],
+ "NCBI gene:2952533": [
+  "UP:G3G8W1"
+ ],
+ "NCBI gene:180992": [
+  "UP:Q21166"
+ ],
+ "NCBI gene:180714": [
+  "UP:Q86ME4",
+  "UP:Q86ME6",
+  "UP:Q86ME5"
+ ],
+ "NCBI gene:176718": [
+  "UP:P49632"
+ ],
+ "NCBI gene:175840": [
+  "UP:P0CG71"
+ ],
+ "NCBI gene:181503": [
+  "UP:G5ECF7",
+  "UP:E5QCG7",
+  "UP:B7WN96",
+  "UP:E5QCG8"
+ ],
+ "NCBI gene:174705": [
+  "UP:G5EFY7"
+ ],
+ "NCBI gene:181705": [
+  "UP:Q17905"
+ ],
+ "NCBI gene:177343": [
+  "UP:P34707"
+ ],
+ "NCBI gene:23157": [
+  "UP:Q14141"
+ ],
+ "NCBI gene:55669": [
+  "UP:Q8IWA4"
+ ],
+ "NCBI gene:876473": [
+  "UP:Q7BCK4"
+ ],
+ "NCBI gene:854411": [
+  "UP:P07807"
+ ],
+ "NCBI gene:854038": [
+  "UP:Q12285"
+ ],
+ "NCBI gene:854335": [
+  "UP:Q12125"
+ ],
+ "NCBI gene:854950": [
+  "UP:P00175"
+ ],
+ "NCBI gene:850562": [
+  "UP:P43593"
+ ],
+ "NCBI gene:10342": [
+  "UP:Q92734"
+ ],
+ "NCBI gene:16438": [
+  "UP:P11881"
+ ],
+ "NCBI gene:16439": [
+  "UP:Q9Z329"
+ ],
+ "NCBI gene:16440": [
+  "UP:P70227"
+ ],
+ "NCBI gene:12142": [
+  "UP:Q60636"
+ ],
+ "NCBI gene:17248": [
+  "UP:O35618"
+ ],
+ "NCBI gene:110147": [
+  "UP:Q9Z148"
+ ],
+ "NCBI gene:27374": [
+  "UP:Q8CIG8"
+ ],
+ "NCBI gene:851751": [
+  "UP:Q12329"
+ ],
+ "NCBI gene:853096": [
+  "UP:P19812"
+ ],
+ "NCBI gene:851721": [
+  "UP:P22470"
+ ],
+ "NCBI gene:853043": [
+  "UP:P53286"
+ ],
+ "NCBI gene:851774": [
+  "UP:P49686"
+ ],
+ "NCBI gene:854192": [
+  "UP:P15705"
+ ],
+ "NCBI gene:855012": [
+  "UP:P32939"
+ ],
+ "NCBI gene:854072": [
+  "UP:P35193"
+ ],
+ "NCBI gene:853758": [
+  "UP:P14904"
+ ],
+ "NCBI gene:852721": [
+  "UP:P22855"
+ ],
+ "NCBI gene:2521": [
+  "UP:P35637"
+ ],
+ "NCBI gene:4839": [
+  "UP:P46087"
+ ],
+ "NCBI gene:6329": [
+  "UP:P35499"
+ ],
+ "NCBI gene:20273": [
+  "UP:Q9WTU3"
+ ],
+ "NCBI gene:3627": [
+  "UP:P02778"
+ ],
+ "NCBI gene:5610": [
+  "UP:P19525"
+ ],
+ "NCBI gene:4791": [
+  "UP:Q00653"
+ ],
+ "NCBI gene:7124": [
+  "UP:P01375"
+ ],
+ "NCBI gene:2633": [
+  "UP:P32455"
+ ],
+ "NCBI gene:3458": [
+  "UP:P01579"
+ ],
+ "NCBI gene:30009": [
+  "UP:Q9UL17"
+ ],
+ "NCBI gene:2308": [
+  "UP:Q12778"
+ ],
+ "NCBI gene:2309": [
+  "UP:O43524"
+ ],
+ "NCBI gene:10000": [
+  "UP:Q9Y243"
+ ],
+ "NCBI gene:3586": [
+  "UP:P22301"
+ ],
+ "NCBI gene:50943": [
+  "UP:Q9BZS1"
+ ],
+ "NCBI gene:877881": [
+  "UP:Q9HUV7"
+ ],
+ "NCBI gene:38231": [
+  "UP:P13395"
+ ],
+ "NCBI gene:38418": [
+  "UP:M9PBL6",
+  "UP:Q9VZQ3",
+  "UP:A8JNJ6",
+  "UP:Q7KV69",
+  "UP:Q7KV70"
+ ],
+ "NCBI gene:41783": [
+  "UP:Q9VFG8"
+ ],
+ "NCBI gene:33218": [
+  "UP:Q07436"
+ ],
+ "NCBI gene:37247": [
+  "UP:Q8T0S6"
+ ],
+ "NCBI gene:42896": [
+  "UP:P10040"
+ ],
+ "NCBI gene:32351": [
+  "UP:Q9VY77"
+ ],
+ "NCBI gene:37851": [
+  "UP:Q45VV3"
+ ],
+ "NCBI gene:6709": [
+  "UP:Q13813"
+ ],
+ "NCBI gene:6711": [
+  "UP:Q01082"
+ ],
+ "NCBI gene:23863": [
+  "UP:Q76LW6"
+ ],
+ "NCBI gene:28135": [
+  "UP:Q3UPP8"
+ ],
+ "NCBI gene:73916": [
+  "UP:Q8BXG3"
+ ],
+ "NCBI gene:3252692": [
+  "UP:Q5FMK0"
+ ],
+ "NCBI gene:3253051": [
+  "UP:Q5FLN0"
+ ],
+ "NCBI gene:3252774": [
+  "UP:P35829"
+ ],
+ "NCBI gene:19373": [
+  "UP:P15919"
+ ],
+ "NCBI gene:12739": [
+  "UP:Q9Z0G9"
+ ],
+ "NCBI gene:170779": [
+  "UP:Q91ZW8"
+ ],
+ "NCBI gene:170786": [
+  "UP:Q91ZX1"
+ ],
+ "NCBI gene:30835": [
+  "UP:Q9NNX6"
+ ],
+ "NCBI gene:217695": [
+  "UP:Q810J8"
+ ],
+ "NCBI gene:52639": [
+  "UP:Q8R3E3"
+ ],
+ "NCBI gene:74781": [
+  "UP:Q80W47"
+ ],
+ "NCBI gene:76815": [
+  "UP:A2A6M5"
+ ],
+ "NCBI gene:56048": [
+  "UP:Q9JL15"
+ ],
+ "NCBI gene:4232": [
+  "UP:Q5EB52"
+ ],
+ "NCBI gene:23089": [
+  "UP:Q86TG7"
+ ],
+ "NCBI gene:2778": [
+  "UP:O95467",
+  "UP:P84996",
+  "UP:P63092",
+  "UP:Q5JWF2"
+ ],
+ "NCBI gene:639": [
+  "UP:O75626"
+ ],
+ "NCBI gene:63978": [
+  "UP:Q9GZV8"
+ ],
+ "NCBI gene:9821": [
+  "UP:Q8TDY2"
+ ],
+ "NCBI gene:9776": [
+  "UP:O75143"
+ ],
+ "NCBI gene:2806": [
+  "UP:P00505"
+ ],
+ "NCBI gene:4191": [
+  "UP:P40926"
+ ],
+ "NCBI gene:14719": [
+  "UP:P05202"
+ ],
+ "NCBI gene:23410": [
+  "UP:Q9NTG7"
+ ],
+ "NCBI gene:23409": [
+  "UP:Q9Y6E7"
+ ],
+ "NCBI gene:11303": [
+  "UP:P41233"
+ ],
+ "NCBI gene:56463": [
+  "UP:Q78PY7"
+ ],
+ "NCBI gene:20227": [
+  "UP:Q9Z315"
+ ],
+ "NCBI gene:219150": [
+  "UP:Q8BJA3"
+ ],
+ "NCBI gene:228869": [
+  "UP:Q91W39"
+ ],
+ "NCBI gene:20583": [
+  "UP:P97469"
+ ],
+ "NCBI gene:171543": [
+  "UP:Q91ZE9"
+ ],
+ "NCBI gene:170770": [
+  "UP:Q99ML1"
+ ],
+ "NCBI gene:12125": [
+  "UP:O54918"
+ ],
+ "NCBI gene:26943": [
+  "UP:Q9QZI9"
+ ],
+ "NCBI gene:10955": [
+  "UP:Q13530"
+ ],
+ "NCBI gene:27036": [
+  "UP:Q9Y286"
+ ],
+ "NCBI gene:8778": [
+  "UP:O15389"
+ ],
+ "NCBI gene:100049587": [
+  "UP:Q08ET2"
+ ],
+ "NCBI gene:55573": [
+  "UP:Q9UKY7"
+ ],
+ "NCBI gene:8094872": [
+  "UP:C6G9P0"
+ ],
+ "NCBI gene:56910": [
+  "UP:Q9NQZ5"
+ ],
+ "NCBI gene:23603": [
+  "UP:Q9ULV4"
+ ],
+ "NCBI gene:4869": [
+  "UP:P06748"
+ ],
+ "NCBI gene:4691": [
+  "UP:P19338"
+ ],
+ "NCBI gene:68501": [
+  "UP:Q91VT1"
+ ],
+ "NCBI gene:12478": [
+  "UP:P25918"
+ ],
+ "NCBI gene:12144": [
+  "UP:O88700"
+ ],
+ "NCBI gene:25023": [
+  "UP:P68403"
+ ],
+ "NCBI gene:83730": [
+  "UP:Q9WUF4"
+ ],
+ "NCBI gene:851431": [
+  "UP:P25694"
+ ],
+ "NCBI gene:854068": [
+  "UP:P00330"
+ ],
+ "NCBI gene:854781": [
+  "UP:P40318"
+ ],
+ "NCBI gene:855895": [
+  "UP:Q08959"
+ ],
+ "NCBI gene:856856": [
+  "UP:P40075"
+ ],
+ "NCBI gene:850767": [
+  "UP:P25385"
+ ],
+ "NCBI gene:37852": [
+  "UP:Q960R0",
+  "UP:Q9W1B5",
+  "UP:A0A0B4LHH1",
+  "UP:A0A0B4LGJ9"
+ ],
+ "NCBI gene:226": [
+  "UP:P04075"
+ ],
+ "NCBI gene:229": [
+  "UP:P05062"
+ ],
+ "NCBI gene:6610": [
+  "UP:O60906"
+ ],
+ "NCBI gene:1994": [
+  "UP:Q15717"
+ ],
+ "NCBI gene:11987": [
+  "UP:Q09143"
+ ],
+ "NCBI gene:15568": [
+  "UP:P70372"
+ ],
+ "NCBI gene:11674": [
+  "UP:P05064"
+ ],
+ "NCBI gene:230163": [
+  "UP:Q91Y97"
+ ],
+ "NCBI gene:12671": [
+  "UP:Q9ERZ3"
+ ],
+ "NCBI gene:79792": [
+  "UP:P57764"
+ ],
+ "NCBI gene:317638": [
+  "UP:Q90YJ7"
+ ],
+ "NCBI gene:30262": [
+  "UP:O73727"
+ ],
+ "NCBI gene:945778": [
+  "UP:P38489"
+ ],
+ "NCBI gene:57934": [
+  "UP:Q7ZVI7"
+ ],
+ "NCBI gene:793907": [
+  "UP:A4K8J2",
+  "UP:A4IGH0"
+ ],
+ "NCBI gene:171481": [
+  "UP:Q9I8L5"
+ ],
+ "NCBI gene:79186": [
+  "UP:Q9DDE4"
+ ],
+ "NCBI gene:794176": [
+  "UP:Q9PTH3"
+ ],
+ "NCBI gene:798920": [
+  "UP:M9MM96"
+ ],
+ "NCBI gene:403079": [
+  "UP:Q66I28"
+ ],
+ "NCBI gene:795084": [
+  "UP:A5PLA3"
+ ],
+ "NCBI gene:100301946": [
+  "UP:F6N9E8",
+  "UP:C4MCP1"
+ ],
+ "NCBI gene:405860": [
+  "UP:Q6NW92"
+ ],
+ "NCBI gene:368320": [
+  "UP:Q7SXL0"
+ ],
+ "NCBI gene:30657": [
+  "UP:O42115"
+ ],
+ "NCBI gene:30710": [
+  "UP:Q9PUD0"
+ ],
+ "NCBI gene:830502": [
+  "UP:Q39067"
+ ],
+ "NCBI gene:820325": [
+  "UP:Q39069"
+ ],
+ "NCBI gene:817217": [
+  "UP:O48790"
+ ],
+ "NCBI gene:829904": [
+  "UP:P30183"
+ ],
+ "NCBI gene:824585": [
+  "UP:P25859"
+ ],
+ "NCBI gene:818444": [
+  "UP:Q2V419"
+ ],
+ "NCBI gene:839453": [
+  "UP:Q8L4H0"
+ ],
+ "NCBI gene:838268": [
+  "UP:Q9FQ08"
+ ],
+ "NCBI gene:824036": [
+  "UP:P24100"
+ ],
+ "NCBI gene:832208": [
+  "UP:P94102"
+ ],
+ "NCBI gene:839145": [
+  "UP:Q6NQK2"
+ ],
+ "NCBI gene:63899": [
+  "UP:Q9H649"
+ ],
+ "NCBI gene:8846": [
+  "UP:Q13686"
+ ],
+ "NCBI gene:11820": [
+  "UP:P12023"
+ ],
+ "NCBI gene:298648": [
+  "UP:I6L9G6"
+ ],
+ "NCBI gene:360834": [
+  "UP:Q4KLL7"
+ ],
+ "NCBI gene:9525": [
+  "UP:O75351"
+ ],
+ "NCBI gene:59323": [
+  "UP:Q62956"
+ ],
+ "NCBI gene:47874": [
+  "UP:Q9W4X9"
+ ],
+ "NCBI gene:37774": [
+  "UP:Q9W1I8"
+ ],
+ "NCBI gene:9342": [
+  "UP:O95721"
+ ],
+ "NCBI gene:20682": [
+  "UP:Q04887"
+ ],
+ "NCBI gene:2931": [
+  "UP:P49840"
+ ],
+ "NCBI gene:6662": [
+  "UP:P48436"
+ ],
+ "NCBI gene:6591": [
+  "UP:O43623"
+ ],
+ "NCBI gene:5453": [
+  "UP:Q03052"
+ ],
+ "NCBI gene:538": [
+  "UP:Q04656"
+ ],
+ "NCBI gene:1844": [
+  "UP:Q05923"
+ ],
+ "NCBI gene:7272": [
+  "UP:P33981"
+ ],
+ "NCBI gene:17096": [
+  "UP:P25911"
+ ],
+ "NCBI gene:129563": [
+  "UP:Q8IYB7"
+ ],
+ "NCBI gene:22894": [
+  "UP:Q9Y2L1"
+ ],
+ "NCBI gene:4942": [
+  "UP:P04181"
+ ],
+ "NCBI gene:6136": [
+  "UP:P30050"
+ ],
+ "NCBI gene:836819": [
+  "UP:Q9C5H5"
+ ],
+ "NCBI gene:831979": [
+  "UP:Q1PDV6"
+ ],
+ "NCBI gene:834842": [
+  "UP:Q9FIJ0"
+ ],
+ "NCBI gene:821717": [
+  "UP:A8R7E6"
+ ],
+ "NCBI gene:90268": [
+  "UP:Q96BN8"
+ ],
+ "NCBI gene:31789": [
+  "UP:P10383"
+ ],
+ "NCBI gene:33950": [
+  "UP:E1JHA3",
+  "UP:M9PC77",
+  "UP:M9PB55",
+  "UP:Q9VM88",
+  "UP:Q8IPJ3",
+  "UP:M9PCS0",
+  "UP:M9PCD7"
+ ],
+ "NCBI gene:55072": [
+  "UP:Q96EP0"
+ ],
+ "NCBI gene:10616": [
+  "UP:Q9BYM8"
+ ],
+ "NCBI gene:34380": [
+  "UP:Q8IPC5",
+  "UP:Q8IPC3"
+ ],
+ "NCBI gene:36032": [
+  "UP:P40791"
+ ],
+ "NCBI gene:18655": [
+  "UP:P09411"
+ ],
+ "NCBI gene:16456": [
+  "UP:O88792"
+ ],
+ "NCBI gene:50848": [
+  "UP:Q9Y624"
+ ],
+ "NCBI gene:232414": [
+  "UP:Q8BRU4"
+ ],
+ "NCBI gene:853398": [
+  "UP:P47048"
+ ],
+ "NCBI gene:854771": [
+  "UP:P40532"
+ ],
+ "NCBI gene:852069": [
+  "UP:Q03281"
+ ],
+ "NCBI gene:854974": [
+  "UP:Q03707"
+ ],
+ "NCBI gene:850712": [
+  "UP:P39929"
+ ],
+ "NCBI gene:856303": [
+  "UP:P52917"
+ ],
+ "NCBI gene:855159": [
+  "UP:P39685"
+ ],
+ "NCBI gene:853957": [
+  "UP:P36161"
+ ],
+ "NCBI gene:855066": [
+  "UP:Q02630"
+ ],
+ "NCBI gene:855091": [
+  "UP:Q04751"
+ ],
+ "NCBI gene:851680": [
+  "UP:P32917"
+ ],
+ "NCBI gene:853369": [
+  "UP:P47035"
+ ],
+ "NCBI gene:851688": [
+  "UP:O13329"
+ ],
+ "NCBI gene:852294": [
+  "UP:P02309"
+ ],
+ "NCBI gene:855701": [
+  "UP:P02309"
+ ],
+ "NCBI gene:79829": [
+  "UP:Q86UY6"
+ ],
+ "NCBI gene:852846": [
+  "UP:P53184"
+ ],
+ "NCBI gene:855053": [
+  "UP:P33748"
+ ],
+ "NCBI gene:853803": [
+  "UP:P33749"
+ ],
+ "NCBI gene:851520": [
+  "UP:P06700"
+ ],
+ "NCBI gene:10714": [
+  "UP:Q15054"
+ ],
+ "NCBI gene:57804": [
+  "UP:Q9HCU8"
+ ],
+ "NCBI gene:21349": [
+  "UP:P22091"
+ ],
+ "NCBI gene:16399": [
+  "UP:Q9QUM0"
+ ],
+ "NCBI gene:14461": [
+  "UP:O09100"
+ ],
+ "NCBI gene:20201": [
+  "UP:P27005"
+ ],
+ "NCBI gene:67933": [
+  "UP:G5E837"
+ ],
+ "NCBI gene:228033": [
+  "UP:P56384"
+ ],
+ "NCBI gene:12236": [
+  "UP:Q9Z1S0"
+ ],
+ "NCBI gene:13177": [
+  "UP:P42125"
+ ],
+ "NCBI gene:213550": [
+  "UP:Q8C0S1"
+ ],
+ "NCBI gene:22381": [
+  "UP:Q9DD24"
+ ],
+ "NCBI gene:74213": [
+  "UP:Q6NZN0"
+ ],
+ "NCBI gene:233537": [
+  "UP:Q3TT99"
+ ],
+ "NCBI gene:18189": [
+  "UP:P0DI97",
+  "UP:Q9CS84"
+ ],
+ "NCBI gene:11771": [
+  "UP:P17426"
+ ],
+ "NCBI gene:239706": [
+  "UP:Q8R1C6"
+ ],
+ "NCBI gene:227738": [
+  "UP:Q80ZI6"
+ ],
+ "NCBI gene:15109": [
+  "UP:P35492"
+ ],
+ "NCBI gene:562066": [
+  "UP:A2CF42"
+ ],
+ "NCBI gene:796066": [
+  "UP:B3DIQ7"
+ ],
+ "NCBI gene:100004331": [
+  "UP:A4FUP1"
+ ],
+ "NCBI gene:58126": [
+  "UP:Q9DGB8"
+ ],
+ "NCBI gene:30519": [
+  "UP:F1QP25",
+  "UP:F1QP24"
+ ],
+ "NCBI gene:559174": [
+  "UP:A5XCD6"
+ ],
+ "NCBI gene:160": [
+  "UP:O95782"
+ ],
+ "NCBI gene:79091": [
+  "UP:Q9BUU2"
+ ],
+ "NCBI gene:90678": [
+  "UP:Q6UWE0"
+ ],
+ "NCBI gene:3034": [
+  "UP:P42357"
+ ],
+ "NCBI gene:228607": [
+  "UP:Q8VCF0"
+ ],
+ "NCBI gene:192119": [
+  "UP:F8VQ54"
+ ],
+ "NCBI gene:239528": [
+  "UP:Q8CJG0"
+ ],
+ "NCBI gene:84557": [
+  "UP:Q9H492"
+ ],
+ "NCBI gene:665": [
+  "UP:O60238"
+ ],
+ "NCBI gene:9528": [
+  "UP:Q9BXS4"
+ ],
+ "NCBI gene:81631": [
+  "UP:Q9GZQ8"
+ ],
+ "NCBI gene:2214": [
+  "UP:P08637"
+ ],
+ "NCBI gene:2215": [
+  "UP:O75015"
+ ],
+ "NCBI gene:440738": [
+  "UP:Q9BXW4"
+ ],
+ "NCBI gene:55054": [
+  "UP:Q676U5"
+ ],
+ "NCBI gene:64127": [
+  "UP:Q9HC29"
+ ],
+ "NCBI gene:7097": [
+  "UP:O60603"
+ ],
+ "NCBI gene:80342": [
+  "UP:Q9Y228"
+ ],
+ "NCBI gene:162989": [
+  "UP:Q8WXF8"
+ ],
+ "NCBI gene:10392": [
+  "UP:Q9Y239"
+ ],
+ "NCBI gene:72018": [
+  "UP:Q9DB70"
+ ],
+ "NCBI gene:855291": [
+  "UP:Q04792"
+ ],
+ "NCBI gene:852291": [
+  "UP:P38067"
+ ],
+ "NCBI gene:214579": [
+  "UP:Q8BWF0"
+ ],
+ "NCBI gene:19211": [
+  "UP:O08586"
+ ],
+ "NCBI gene:353": [
+  "UP:P07741"
+ ],
+ "NCBI gene:856576": [
+  "UP:P38862"
+ ],
+ "NCBI gene:854778": [
+  "UP:P07278"
+ ],
+ "NCBI gene:852088": [
+  "UP:P06782"
+ ],
+ "NCBI gene:856759": [
+  "UP:P40025"
+ ],
+ "NCBI gene:852648": [
+  "UP:P53078"
+ ],
+ "NCBI gene:850906": [
+  "UP:Q05788"
+ ],
+ "NCBI gene:852009": [
+  "UP:Q04179"
+ ],
+ "NCBI gene:855321": [
+  "UP:Q03262"
+ ],
+ "NCBI gene:856188": [
+  "UP:P23254"
+ ],
+ "NCBI gene:852414": [
+  "UP:P33315"
+ ],
+ "NCBI gene:851068": [
+  "UP:P15019"
+ ],
+ "NCBI gene:852934": [
+  "UP:P53228"
+ ],
+ "NCBI gene:853155": [
+  "UP:P16861"
+ ],
+ "NCBI gene:16331": [
+  "UP:Q9ES52"
+ ],
+ "NCBI gene:20111": [
+  "UP:P18653"
+ ],
+ "NCBI gene:12444": [
+  "UP:P30280"
+ ],
+ "NCBI gene:12452": [
+  "UP:O08918"
+ ],
+ "NCBI gene:12576": [
+  "UP:P46414"
+ ],
+ "NCBI gene:67526": [
+  "UP:Q9CQY1"
+ ],
+ "NCBI gene:56484": [
+  "UP:Q9WVH4"
+ ],
+ "NCBI gene:850846": [
+  "UP:P52910"
+ ],
+ "NCBI gene:851245": [
+  "UP:Q01574"
+ ],
+ "NCBI gene:852266": [
+  "UP:P32316"
+ ],
+ "NCBI gene:852800": [
+  "UP:P53157"
+ ],
+ "NCBI gene:852295": [
+  "UP:P61830"
+ ],
+ "NCBI gene:855700": [
+  "UP:P61830"
+ ],
+ "NCBI gene:856612": [
+  "UP:P11792"
+ ],
+ "NCBI gene:40348": [
+  "UP:Q9VP61"
+ ],
+ "NCBI gene:3622": [
+  "UP:Q9H160"
+ ],
+ "NCBI gene:5305": [
+  "UP:P48426"
+ ],
+ "NCBI gene:79837": [
+  "UP:Q8TBX8"
+ ],
+ "NCBI gene:15194": [
+  "UP:G3X9H5"
+ ],
+ "NCBI gene:9140": [
+  "UP:O94817"
+ ],
+ "NCBI gene:8897": [
+  "UP:Q13615"
+ ],
+ "NCBI gene:26100": [
+  "UP:Q9Y4P8"
+ ],
+ "NCBI gene:53349": [
+  "UP:Q9HBF4"
+ ],
+ "NCBI gene:57103": [
+  "UP:Q9NQ88"
+ ],
+ "NCBI gene:55332": [
+  "UP:Q8N682"
+ ],
+ "NCBI gene:114508": [
+  "UP:Q9Z1N1"
+ ],
+ "NCBI gene:83734": [
+  "UP:Q9H0Y0"
+ ],
+ "NCBI gene:4780": [
+  "UP:Q16236"
+ ],
+ "NCBI gene:7305": [
+  "UP:O43914"
+ ],
+ "NCBI gene:1032": [
+  "UP:P55273"
+ ],
+ "NCBI gene:1027": [
+  "UP:P46527"
+ ],
+ "NCBI gene:835985": [
+  "UP:Q9SP02"
+ ],
+ "NCBI gene:855498": [
+  "UP:P53867"
+ ],
+ "NCBI gene:39454": [
+  "UP:Q9VU14",
+  "UP:Q8MQJ7"
+ ],
+ "NCBI gene:43573": [
+  "UP:P04359"
+ ],
+ "NCBI gene:47396": [
+  "UP:Q9VK45"
+ ],
+ "NCBI gene:9706": [
+  "UP:Q8IYT8"
+ ],
+ "NCBI gene:6196": [
+  "UP:Q15349"
+ ],
+ "NCBI gene:6197": [
+  "UP:P51812"
+ ],
+ "NCBI gene:6195": [
+  "UP:Q15418"
+ ],
+ "NCBI gene:29978": [
+  "UP:Q9UHD9"
+ ],
+ "NCBI gene:23604": [
+  "UP:Q9UIK4"
+ ],
+ "NCBI gene:801": [
+  "UP:P0DP25",
+  "UP:P0DP23",
+  "UP:P0DP24"
+ ],
+ "NCBI gene:805": [
+  "UP:P0DP25",
+  "UP:P0DP23",
+  "UP:P0DP24"
+ ],
+ "NCBI gene:808": [
+  "UP:P0DP25",
+  "UP:P0DP23",
+  "UP:P0DP24"
+ ],
+ "NCBI gene:58476": [
+  "UP:Q8IXH6"
+ ],
+ "NCBI gene:100702192": [
+  "UP:I3KPD4"
+ ],
+ "NCBI gene:68728": [
+  "UP:Q8CFU8"
+ ],
+ "NCBI gene:38543": [
+  "UP:Q8IRB4",
+  "UP:A8JNK7",
+  "UP:M9NFM7",
+  "UP:Q9VZC7"
+ ],
+ "NCBI gene:12177": [
+  "UP:Q9Z2F7"
+ ],
+ "NCBI gene:56486": [
+  "UP:Q9DCD6"
+ ],
+ "NCBI gene:9531": [
+  "UP:O95817"
+ ],
+ "NCBI gene:3308": [
+  "UP:P34932"
+ ],
+ "NCBI gene:6647": [
+  "UP:P00441"
+ ],
+ "NCBI gene:51008": [
+  "UP:Q8N9N2"
+ ],
+ "NCBI gene:20657": [
+  "UP:O09164"
+ ],
+ "NCBI gene:9512": [
+  "UP:O75439"
+ ],
+ "NCBI gene:5362": [
+  "UP:O75051"
+ ],
+ "NCBI gene:14083": [
+  "UP:P34152"
+ ],
+ "NCBI gene:74244": [
+  "UP:Q9D906"
+ ],
+ "NCBI gene:852518": [
+  "UP:P38316"
+ ],
+ "NCBI gene:855954": [
+  "UP:Q12380"
+ ],
+ "NCBI gene:100504663": [
+  "UP:Q8CDJ3"
+ ],
+ "NCBI gene:66734": [
+  "UP:Q91VR7"
+ ],
+ "NCBI gene:67443": [
+  "UP:Q9CQV6"
+ ],
+ "NCBI gene:12421": [
+  "UP:Q9ESK9"
+ ],
+ "NCBI gene:4085": [
+  "UP:Q13257"
+ ],
+ "NCBI gene:10459": [
+  "UP:Q9UI95"
+ ],
+ "NCBI gene:9183": [
+  "UP:O43264"
+ ],
+ "NCBI gene:8200351": [
+  "UP:C4R5T1"
+ ],
+ "NCBI gene:854660": [
+  "UP:P40458"
+ ],
+ "NCBI gene:853254": [
+  "UP:P46983"
+ ],
+ "NCBI gene:856162": [
+  "UP:Q12527"
+ ],
+ "NCBI gene:10241": [
+  "UP:Q13137"
+ ],
+ "NCBI gene:956309": [
+  "UP:Q8JUX6"
+ ],
+ "NCBI gene:18412": [
+  "UP:Q64337"
+ ],
+ "NCBI gene:176138": [
+  "UP:P34529"
+ ],
+ "NCBI gene:180949": [
+  "UP:Q21480"
+ ],
+ "NCBI gene:189705": [
+  "UP:Q86MP3",
+  "UP:Q9XX21",
+  "UP:E3CTH5",
+  "UP:Q5DTE8"
+ ],
+ "NCBI gene:176921": [
+  "UP:Q9N369",
+  "UP:U4PRD2"
+ ],
+ "NCBI gene:172167": [
+  "UP:Q95Q95"
+ ],
+ "NCBI gene:178104": [
+  "UP:P22981"
+ ],
+ "NCBI gene:3565794": [
+  "UP:Q18892"
+ ],
+ "NCBI gene:181719": [
+  "UP:Q17740"
+ ],
+ "NCBI gene:178139": [
+  "UP:F1LIM5",
+  "UP:Q22436"
+ ],
+ "NCBI gene:21380": [
+  "UP:P70323"
+ ],
+ "NCBI gene:67731": [
+  "UP:Q9CPU7"
+ ],
+ "NCBI gene:16367": [
+  "UP:P35569"
+ ],
+ "NCBI gene:856450": [
+  "UP:P0CX80",
+  "UP:P0CX81"
+ ],
+ "NCBI gene:854071": [
+  "UP:Q12292"
+ ],
+ "NCBI gene:855897": [
+  "UP:P29295"
+ ],
+ "NCBI gene:175490": [
+  "UP:Q22712"
+ ],
+ "NCBI gene:172280": [
+  "UP:Q9TXI7"
+ ],
+ "NCBI gene:174050": [
+  "UP:Q09490"
+ ],
+ "NCBI gene:179246": [
+  "UP:O16466",
+  "UP:H2KYN5"
+ ],
+ "NCBI gene:856649": [
+  "UP:P09232"
+ ],
+ "NCBI gene:851010": [
+  "UP:P06106"
+ ],
+ "NCBI gene:855194": [
+  "UP:Q03818"
+ ],
+ "NCBI gene:850684": [
+  "UP:Q07879"
+ ],
+ "NCBI gene:852092": [
+  "UP:P11491"
+ ],
+ "NCBI gene:19025": [
+  "UP:P16675"
+ ],
+ "NCBI gene:19752": [
+  "UP:Q8C6G3"
+ ],
+ "NCBI gene:114114": [
+  "UP:O35303"
+ ],
+ "NCBI gene:288584": [
+  "UP:P84817"
+ ],
+ "NCBI gene:192647": [
+  "UP:Q8R4Z9"
+ ],
+ "NCBI gene:16784": [
+  "UP:P17047"
+ ],
+ "NCBI gene:3920": [
+  "UP:P13473"
+ ],
+ "NCBI gene:850917": [
+  "UP:P47818"
+ ],
+ "NCBI gene:855003": [
+  "UP:P25087"
+ ],
+ "NCBI gene:2010": [
+  "UP:P50402"
+ ],
+ "NCBI gene:572": [
+  "UP:Q92934"
+ ],
+ "NCBI gene:12015": [
+  "UP:Q61337"
+ ],
+ "NCBI gene:179943": [
+  "UP:O61667"
+ ],
+ "NCBI gene:26409": [
+  "UP:Q62073"
+ ],
+ "NCBI gene:3320": [
+  "UP:P07900"
+ ],
+ "NCBI gene:3312": [
+  "UP:P11142"
+ ],
+ "NCBI gene:573": [
+  "UP:Q99933"
+ ],
+ "NCBI gene:55062": [
+  "UP:Q5MNZ9"
+ ],
+ "NCBI gene:23192": [
+  "UP:Q9Y4P1"
+ ],
+ "NCBI gene:55578": [
+  "UP:Q8NEM7"
+ ],
+ "NCBI gene:79065": [
+  "UP:Q7Z3C6"
+ ],
+ "NCBI gene:285973": [
+  "UP:Q674R7"
+ ],
+ "NCBI gene:12354": [
+  "UP:Q9ERQ8"
+ ],
+ "NCBI gene:12349": [
+  "UP:P00920"
+ ],
+ "NCBI gene:11345": [
+  "UP:P60520"
+ ],
+ "NCBI gene:11337": [
+  "UP:O95166"
+ ],
+ "NCBI gene:115201": [
+  "UP:Q8WYN0"
+ ],
+ "NCBI gene:637": [
+  "UP:P55957"
+ ],
+ "NCBI gene:17210": [
+  "UP:P97287"
+ ],
+ "NCBI gene:15228": [
+  "UP:Q60987"
+ ],
+ "NCBI gene:854954": [
+  "UP:P04387"
+ ],
+ "NCBI gene:46156": [
+  "UP:M9PHT1",
+  "UP:M9PES2",
+  "UP:M9NE54",
+  "UP:Q9VSK5",
+  "UP:Q86BH2",
+  "UP:Q7KUA8",
+  "UP:M9NDL9",
+  "UP:Q8IQA6"
+ ],
+ "NCBI gene:33627": [
+  "UP:P33450"
+ ],
+ "NCBI gene:42367": [
+  "UP:P06002"
+ ],
+ "NCBI gene:252554": [
+  "UP:Q9VCR6"
+ ],
+ "NCBI gene:43651": [
+  "UP:Q9VA38"
+ ],
+ "NCBI gene:33245": [
+  "UP:Q24292"
+ ],
+ "NCBI gene:40554": [
+  "UP:P22812"
+ ],
+ "NCBI gene:32001": [
+  "UP:X2JEE0",
+  "UP:Q9W2S2",
+  "UP:X2JJA8"
+ ],
+ "NCBI gene:2543254": [
+  "UP:Q9UTR8"
+ ],
+ "NCBI gene:2540433": [
+  "UP:P40379"
+ ],
+ "NCBI gene:2540450": [
+  "UP:O43008"
+ ],
+ "NCBI gene:2539342": [
+  "UP:O94243"
+ ],
+ "NCBI gene:2540712": [
+  "UP:Q9Y7J9"
+ ],
+ "NCBI gene:2542069": [
+  "UP:O42667"
+ ],
+ "NCBI gene:2540458": [
+  "UP:P36626"
+ ],
+ "NCBI gene:2540637": [
+  "UP:Q2L4W6"
+ ],
+ "NCBI gene:2539540": [
+  "UP:O74958"
+ ],
+ "NCBI gene:2543630": [
+  "UP:Q10146"
+ ],
+ "NCBI gene:2541741": [
+  "UP:Q10719"
+ ],
+ "NCBI gene:2542080": [
+  "UP:P08965"
+ ],
+ "NCBI gene:54881": [
+  "UP:Q9NXF1"
+ ],
+ "NCBI gene:23195": [
+  "UP:Q9NU22"
+ ],
+ "NCBI gene:27043": [
+  "UP:Q8IZL8"
+ ],
+ "NCBI gene:57418": [
+  "UP:Q9BV38"
+ ],
+ "NCBI gene:26168": [
+  "UP:Q9H4L4"
+ ],
+ "NCBI gene:110213": [
+  "UP:Q9D2C7"
+ ],
+ "NCBI gene:22030": [
+  "UP:P39429"
+ ],
+ "NCBI gene:38936": [
+  "UP:Q9VSH3"
+ ],
+ "NCBI gene:36993": [
+  "UP:A1ZAW0",
+  "UP:A0A0B4LFK8"
+ ],
+ "NCBI gene:6885": [
+  "UP:O43318"
+ ],
+ "NCBI gene:10454": [
+  "UP:Q15750"
+ ],
+ "NCBI gene:23118": [
+  "UP:Q9NYJ8"
+ ],
+ "NCBI gene:257397": [
+  "UP:Q8N5C8"
+ ],
+ "NCBI gene:27183": [
+  "UP:Q9UN37"
+ ],
+ "NCBI gene:58528": [
+  "UP:Q9NQL2"
+ ],
+ "NCBI gene:64121": [
+  "UP:Q9HB90"
+ ],
+ "NCBI gene:227743": [
+  "UP:Q8BKH7"
+ ],
+ "NCBI gene:10988": [
+  "UP:P50579"
+ ],
+ "NCBI gene:5911": [
+  "UP:P10114"
+ ],
+ "NCBI gene:10670": [
+  "UP:Q7L523"
+ ],
+ "NCBI gene:340371": [
+  "UP:Q9NSY0"
+ ],
+ "NCBI gene:84938": [
+  "UP:Q96DT6"
+ ],
+ "NCBI gene:4943": [
+  "UP:Q3MII6"
+ ],
+ "NCBI gene:51100": [
+  "UP:Q9Y371"
+ ],
+ "NCBI gene:28956": [
+  "UP:Q9Y2Q5"
+ ],
+ "NCBI gene:9711": [
+  "UP:Q92622"
+ ],
+ "NCBI gene:60592": [
+  "UP:Q9UIL1"
+ ],
+ "NCBI gene:6829": [
+  "UP:O00267"
+ ],
+ "NCBI gene:51322": [
+  "UP:Q9BTA9"
+ ],
+ "NCBI gene:9638": [
+  "UP:Q99689"
+ ],
+ "NCBI gene:89849": [
+  "UP:Q8NAA4"
+ ],
+ "NCBI gene:856315": [
+  "UP:Q06628"
+ ],
+ "NCBI gene:853313": [
+  "UP:P08018"
+ ],
+ "NCBI gene:851362": [
+  "UP:P19881"
+ ],
+ "NCBI gene:11798": [
+  "UP:Q60989"
+ ],
+ "NCBI gene:17246": [
+  "UP:P23804"
+ ],
+ "NCBI gene:68767": [
+  "UP:Q8VDD8"
+ ],
+ "NCBI gene:100287171": [
+  "UP:A8K0Z3"
+ ],
+ "NCBI gene:467": [
+  "UP:P18847"
+ ],
+ "NCBI gene:11921": [
+  "UP:P48985"
+ ],
+ "NCBI gene:17831": [
+  "UP:Q80Z19"
+ ],
+ "NCBI gene:13057": [
+  "UP:Q61462"
+ ],
+ "NCBI gene:181728": [
+  "UP:P24612"
+ ],
+ "NCBI gene:3565200": [
+  "UP:P54244"
+ ],
+ "NCBI gene:174120": [
+  "UP:P34693"
+ ],
+ "NCBI gene:171952": [
+  "UP:Q9XZI6"
+ ],
+ "NCBI gene:180713": [
+  "UP:P35603"
+ ],
+ "NCBI gene:181644": [
+  "UP:P39055"
+ ],
+ "NCBI gene:178284": [
+  "UP:G5ECL2"
+ ],
+ "NCBI gene:184091": [
+  "UP:Q19123"
+ ],
+ "NCBI gene:172755": [
+  "UP:P91857"
+ ],
+ "NCBI gene:171601": [
+  "UP:O01803"
+ ],
+ "NCBI gene:4363014": [
+  "UP:Q1ZXR4"
+ ],
+ "NCBI gene:176179": [
+  "UP:P34540"
+ ],
+ "NCBI gene:174144": [
+  "UP:P23678"
+ ],
+ "NCBI gene:177989": [
+  "UP:Q23536"
+ ],
+ "NCBI gene:326115": [
+  "UP:B7Z0R7",
+  "UP:Q9VAF9",
+  "UP:Q86BR6",
+  "UP:Q95TJ1"
+ ],
+ "NCBI gene:66824": [
+  "UP:Q9EPB4"
+ ],
+ "NCBI gene:8323": [
+  "UP:O60353"
+ ],
+ "NCBI gene:8290": [
+  "UP:Q16695"
+ ],
+ "NCBI gene:15463": [
+  "UP:Q8K2K6"
+ ],
+ "NCBI gene:19328": [
+  "UP:P35283"
+ ],
+ "NCBI gene:234967": [
+  "UP:Q8CH36"
+ ],
+ "NCBI gene:219135": [
+  "UP:Q8VE11"
+ ],
+ "NCBI gene:97287": [
+  "UP:Q8VEL2"
+ ],
+ "NCBI gene:17772": [
+  "UP:Q9Z2C5"
+ ],
+ "NCBI gene:77116": [
+  "UP:Q9Z2D1"
+ ],
+ "NCBI gene:245860": [
+  "UP:Q68FE2"
+ ],
+ "NCBI gene:64419": [
+  "UP:Q8NCE2"
+ ],
+ "NCBI gene:16854": [
+  "UP:Q8C253"
+ ],
+ "NCBI gene:66615": [
+  "UP:Q8BGE6"
+ ],
+ "NCBI gene:16483": [
+  "UP:P61110"
+ ],
+ "NCBI gene:31554": [
+  "UP:P40423"
+ ],
+ "NCBI gene:39383": [
+  "UP:Q9VTU1"
+ ],
+ "NCBI gene:35851": [
+  "UP:P18502"
+ ],
+ "NCBI gene:36002": [
+  "UP:A1Z7Y7",
+  "UP:Q95SK9"
+ ],
+ "NCBI gene:37141": [
+  "UP:Q7JY94",
+  "UP:A1ZBA9"
+ ],
+ "NCBI gene:36571": [
+  "UP:A0A0B4LF29",
+  "UP:A1Z9M3",
+  "UP:A8DYD1",
+  "UP:Q7KHK4",
+  "UP:A0A126GUP1",
+  "UP:B7YZE6",
+  "UP:A1Z9M4",
+  "UP:A8DYD3",
+  "UP:A8DYD2",
+  "UP:A0A0B4LFC7"
+ ],
+ "NCBI gene:1613": [
+  "UP:O43293"
+ ],
+ "NCBI gene:78610": [
+  "UP:Q8K245"
+ ],
+ "NCBI gene:32461": [
+  "UP:M9NGF7",
+  "UP:Q9XYX1",
+  "UP:Q8IR37",
+  "UP:M9PJN5",
+  "UP:Q8IR38",
+  "UP:M9NEH6",
+  "UP:Q86NK9"
+ ],
+ "NCBI gene:12292": [
+  "UP:F8VQE0",
+  "UP:E9Q7B5",
+  "UP:E9QPX8",
+  "UP:Q3UPG8"
+ ],
+ "NCBI gene:18125": [
+  "UP:Q9Z0J4"
+ ],
+ "NCBI gene:30955": [
+  "UP:Q9JHG7"
+ ],
+ "NCBI gene:12176": [
+  "UP:O55003"
+ ],
+ "NCBI gene:13039": [
+  "UP:P06797"
+ ],
+ "NCBI gene:23710": [
+  "UP:Q9H0R8"
+ ],
+ "NCBI gene:66212": [
+  "UP:Q9CQS8"
+ ],
+ "NCBI gene:226641": [
+  "UP:F6VAN0"
+ ],
+ "NCBI gene:852724": [
+  "UP:P53112"
+ ],
+ "NCBI gene:851843": [
+  "UP:P15202"
+ ],
+ "NCBI gene:854377": [
+  "UP:P06633"
+ ],
+ "NCBI gene:851929": [
+  "UP:P28795"
+ ],
+ "NCBI gene:852688": [
+  "UP:P04037"
+ ],
+ "NCBI gene:851494": [
+  "UP:Q07418"
+ ],
+ "NCBI gene:854018": [
+  "UP:Q12462"
+ ],
+ "NCBI gene:851620": [
+  "UP:P00942"
+ ],
+ "NCBI gene:855016": [
+  "UP:P40959"
+ ],
+ "NCBI gene:854670": [
+  "UP:P16547"
+ ],
+ "NCBI gene:851109": [
+  "UP:P18496"
+ ],
+ "NCBI gene:851491": [
+  "UP:P14066"
+ ],
+ "NCBI gene:850900": [
+  "UP:P32335"
+ ],
+ "NCBI gene:855299": [
+  "UP:P08468"
+ ],
+ "NCBI gene:856897": [
+  "UP:P10355"
+ ],
+ "NCBI gene:856647": [
+  "UP:P39923"
+ ],
+ "NCBI gene:855538": [
+  "UP:P22211"
+ ],
+ "NCBI gene:853275": [
+  "UP:P06244"
+ ],
+ "NCBI gene:855898": [
+  "UP:P06245"
+ ],
+ "NCBI gene:855625": [
+  "UP:P01120"
+ ],
+ "NCBI gene:850824": [
+  "UP:P20485"
+ ],
+ "NCBI gene:851406": [
+  "UP:Q12142"
+ ],
+ "NCBI gene:638": [
+  "UP:Q13323"
+ ],
+ "NCBI gene:493856": [
+  "UP:Q8N5K1"
+ ],
+ "NCBI gene:66437": [
+  "UP:Q9CQ92"
+ ],
+ "NCBI gene:51024": [
+  "UP:Q9Y3D6"
+ ],
+ "NCBI gene:664": [
+  "UP:Q12983"
+ ],
+ "NCBI gene:175070": [
+  "UP:Q9U2A8"
+ ],
+ "NCBI gene:175877": [
+  "UP:Q18115"
+ ],
+ "NCBI gene:3565555": [
+  "UP:G5EE66"
+ ],
+ "NCBI gene:177617": [
+  "UP:Q17796"
+ ],
+ "NCBI gene:178988": [
+  "UP:O16368"
+ ],
+ "NCBI gene:175955": [
+  "UP:P45896"
+ ],
+ "NCBI gene:172249": [
+  "UP:G5EDT1"
+ ],
+ "NCBI gene:175410": [
+  "UP:Q968Y9"
+ ],
+ "NCBI gene:172981": [
+  "UP:O16850"
+ ],
+ "NCBI gene:179068": [
+  "UP:G5EEL5"
+ ],
+ "NCBI gene:176229": [
+  "UP:Q02330"
+ ],
+ "NCBI gene:177345": [
+  "UP:Q22592"
+ ],
+ "NCBI gene:172847": [
+  "UP:H1UBJ2",
+  "UP:Q9XWQ4",
+  "UP:H1UBJ1"
+ ],
+ "NCBI gene:178005": [
+  "UP:G5EBK4"
+ ],
+ "NCBI gene:181663": [
+  "UP:Q27365"
+ ],
+ "NCBI gene:176256": [
+  "UP:P30630"
+ ],
+ "NCBI gene:181662": [
+  "UP:Q27395"
+ ],
+ "NCBI gene:175541": [
+  "UP:G5EE07",
+  "UP:V6CLI2",
+  "UP:A0FLQ8"
+ ],
+ "NCBI gene:173952": [
+  "UP:H2KYU6",
+  "UP:Q95QZ7"
+ ],
+ "NCBI gene:179058": [
+  "UP:G5EFY4"
+ ],
+ "NCBI gene:179922": [
+  "UP:Q23272",
+  "UP:Q52GY6",
+  "UP:Q8I4B7",
+  "UP:E5QCH2"
+ ],
+ "NCBI gene:179022": [
+  "UP:Q94246"
+ ],
+ "NCBI gene:171116": [
+  "UP:Q2TA68"
+ ],
+ "NCBI gene:1351": [
+  "UP:P10176"
+ ],
+ "NCBI gene:365601": [
+  "UP:Q5XIS0"
+ ],
+ "NCBI gene:25328": [
+  "UP:P14562"
+ ],
+ "NCBI gene:64862": [
+  "UP:Q62625"
+ ],
+ "NCBI gene:362245": [
+  "UP:Q6XVN8"
+ ],
+ "NCBI gene:29448": [
+  "UP:P09527"
+ ],
+ "NCBI gene:501854": [
+  "UP:D4A7A8"
+ ],
+ "NCBI gene:38218": [
+  "UP:Q9W0A0"
+ ],
+ "NCBI gene:35411": [
+  "UP:Q9V9S0"
+ ],
+ "NCBI gene:75788": [
+  "UP:Q9CUN6"
+ ],
+ "NCBI gene:3964": [
+  "UP:O00214"
+ ],
+ "NCBI gene:40336": [
+  "UP:Q7KTX7"
+ ],
+ "NCBI gene:13240": [
+  "UP:P50704"
+ ],
+ "NCBI gene:55978": [
+  "UP:Q61025"
+ ],
+ "NCBI gene:14633": [
+  "UP:Q0VGT2"
+ ],
+ "NCBI gene:8031": [
+  "UP:Q13772"
+ ],
+ "NCBI gene:5978": [
+  "UP:Q13127"
+ ],
+ "NCBI gene:19712": [
+  "UP:Q8VIG1"
+ ],
+ "NCBI gene:172596": [
+  "UP:O17582"
+ ],
+ "NCBI gene:43991": [
+  "UP:Q9Y0B6",
+  "UP:Q7KMQ6",
+  "UP:Q9V3L4"
+ ],
+ "NCBI gene:6198": [
+  "UP:P23443"
+ ],
+ "NCBI gene:7248": [
+  "UP:Q92574"
+ ],
+ "NCBI gene:7249": [
+  "UP:P49815"
+ ],
+ "NCBI gene:6009": [
+  "UP:Q15382"
+ ],
+ "NCBI gene:29924": [
+  "UP:Q9Y6I3"
+ ],
+ "NCBI gene:1213": [
+  "UP:Q00610"
+ ],
+ "NCBI gene:5333": [
+  "UP:P51178"
+ ],
+ "NCBI gene:345611": [
+  "UP:A1A4Y4"
+ ],
+ "NCBI gene:9927": [
+  "UP:O95140"
+ ],
+ "NCBI gene:15944": [
+  "UP:Q60766"
+ ],
+ "NCBI gene:55207": [
+  "UP:Q9NVJ2"
+ ],
+ "NCBI gene:3796": [
+  "UP:O00139"
+ ],
+ "NCBI gene:84643": [
+  "UP:Q8N4N8"
+ ],
+ "NCBI gene:11004": [
+  "UP:Q99661"
+ ],
+ "NCBI gene:4646": [
+  "UP:Q9UM54"
+ ],
+ "NCBI gene:10043": [
+  "UP:O60784"
+ ],
+ "NCBI gene:26523": [
+  "UP:Q9UL18"
+ ],
+ "NCBI gene:11218": [
+  "UP:Q9UHI6"
+ ],
+ "NCBI gene:50628": [
+  "UP:P57678"
+ ],
+ "NCBI gene:76137": [
+  "UP:Q9CXD6"
+ ],
+ "NCBI gene:216001": [
+  "UP:Q8VCX5"
+ ],
+ "NCBI gene:63933": [
+  "UP:Q96AQ8"
+ ],
+ "NCBI gene:10367": [
+  "UP:Q9BPX6"
+ ],
+ "NCBI gene:3954": [
+  "UP:O95202"
+ ],
+ "NCBI gene:29869": [
+  "UP:Q9QY01"
+ ],
+ "NCBI gene:71742": [
+  "UP:Q3U3Q1"
+ ],
+ "NCBI gene:180311": [
+  "UP:Q23023"
+ ],
+ "NCBI gene:38913": [
+  "UP:M9PHS3",
+  "UP:Q9VSF0",
+  "UP:M9PER1",
+  "UP:M9PEY7"
+ ],
+ "NCBI gene:38344": [
+  "UP:Q9VZX7"
+ ],
+ "NCBI gene:37733": [
+  "UP:Q9W1M7"
+ ],
+ "NCBI gene:35998": [
+  "UP:Q8T0L3",
+  "UP:A0A0B4KF46"
+ ],
+ "NCBI gene:39628": [
+  "UP:Q9VUJ1"
+ ],
+ "NCBI gene:40044": [
+  "UP:Q9VVS6"
+ ],
+ "NCBI gene:33283": [
+  "UP:Q9VPW2",
+  "UP:M9PBM3"
+ ],
+ "NCBI gene:41868": [
+  "UP:Q9VF80"
+ ],
+ "NCBI gene:38456": [
+  "UP:P0CG69"
+ ],
+ "NCBI gene:326237": [
+  "UP:Q9W418"
+ ],
+ "NCBI gene:22084": [
+  "UP:Q3TQ10",
+  "UP:Q3UG88",
+  "UP:Q3UHB2",
+  "UP:Q7TT21",
+  "UP:Q3UGI8"
+ ],
+ "NCBI gene:24855": [
+  "UP:P49816"
+ ],
+ "NCBI gene:60445": [
+  "UP:Q9Z136"
+ ],
+ "NCBI gene:57048": [
+  "UP:Q9NRY6"
+ ],
+ "NCBI gene:70310": [
+  "UP:Q9JIZ9"
+ ],
+ "NCBI gene:366196": [
+  "UP:Q5U2V5"
+ ],
+ "NCBI gene:60561": [
+  "UP:Q6NUQ1"
+ ],
+ "NCBI gene:5783": [
+  "UP:Q12923"
+ ],
+ "NCBI gene:24392": [
+  "UP:P08050"
+ ],
+ "NCBI gene:313474": [
+  "UP:Q5JC29"
+ ],
+ "NCBI gene:73683": [
+  "UP:Q6KAU8"
+ ],
+ "NCBI gene:14609": [
+  "UP:P23242"
+ ],
+ "NCBI gene:305831": [
+  "UP:D4A4K3"
+ ],
+ "NCBI gene:363254": [
+  "UP:Q5FWU3"
+ ],
+ "NCBI gene:499973": [
+  "UP:D4ABD5"
+ ],
+ "NCBI gene:67841": [
+  "UP:Q9CPX6"
+ ],
+ "NCBI gene:1457": [
+  "UP:P68400"
+ ],
+ "NCBI gene:5300": [
+  "UP:Q13526"
+ ],
+ "NCBI gene:1460": [
+  "UP:P67870"
+ ],
+ "NCBI gene:12367": [
+  "UP:P70677"
+ ],
+ "NCBI gene:12369": [
+  "UP:P97864"
+ ],
+ "NCBI gene:10715": [
+  "UP:P27544"
+ ],
+ "NCBI gene:19401": [
+  "UP:P11416"
+ ],
+ "NCBI gene:5914": [
+  "UP:P10276"
+ ],
+ "NCBI gene:20617": [
+  "UP:O55042"
+ ],
+ "NCBI gene:114558": [
+  "UP:Q91XJ1"
+ ],
+ "NCBI gene:294515": [
+  "UP:D3ZBQ1"
+ ],
+ "NCBI gene:5727": [
+  "UP:Q13635"
+ ],
+ "NCBI gene:8643": [
+  "UP:Q9Y6C5"
+ ],
+ "NCBI gene:43767": [
+  "UP:P19538"
+ ],
+ "NCBI gene:35653": [
+  "UP:O16844"
+ ],
+ "NCBI gene:9627": [
+  "UP:Q9Y6H5"
+ ],
+ "NCBI gene:67847": [
+  "UP:Q99ME3"
+ ],
+ "NCBI gene:4077": [
+  "UP:Q14596"
+ ],
+ "NCBI gene:4659": [
+  "UP:O14974"
+ ],
+ "NCBI gene:19877": [
+  "UP:P70335"
+ ],
+ "NCBI gene:176633": [
+  "UP:Q9U221"
+ ],
+ "NCBI gene:171938": [
+  "UP:Q9TXR4"
+ ],
+ "NCBI gene:171914": [
+  "UP:Q9N3T8"
+ ],
+ "NCBI gene:176783": [
+  "UP:Q9XU10"
+ ],
+ "NCBI gene:174291": [
+  "UP:Q10002"
+ ],
+ "NCBI gene:173069": [
+  "UP:G5EBR7",
+  "UP:Q564V5"
+ ],
+ "NCBI gene:176765": [
+  "UP:O62245"
+ ],
+ "NCBI gene:834630": [
+  "UP:Q94CD5"
+ ],
+ "NCBI gene:179352": [
+  "UP:Q22258"
+ ],
+ "NCBI gene:3565793": [
+  "UP:Q9N3Q4"
+ ],
+ "NCBI gene:4436": [
+  "UP:P43246"
+ ],
+ "NCBI gene:6188": [
+  "UP:P23396"
+ ],
+ "NCBI gene:850686": [
+  "UP:P54861"
+ ],
+ "NCBI gene:854444": [
+  "UP:P32563"
+ ],
+ "NCBI gene:851493": [
+  "UP:P21954"
+ ],
+ "NCBI gene:854386": [
+  "UP:P32266"
+ ],
+ "NCBI gene:854303": [
+  "UP:P28241"
+ ],
+ "NCBI gene:853230": [
+  "UP:P39533"
+ ],
+ "NCBI gene:851845": [
+  "UP:P33416"
+ ],
+ "NCBI gene:13712": [
+  "UP:P41969"
+ ],
+ "NCBI gene:22695": [
+  "UP:P22893"
+ ],
+ "NCBI gene:67603": [
+  "UP:Q9DBB1"
+ ],
+ "NCBI gene:19052": [
+  "UP:P63330"
+ ],
+ "NCBI gene:51792": [
+  "UP:Q76MZ3"
+ ],
+ "NCBI gene:26413": [
+  "UP:P63085"
+ ],
+ "NCBI gene:99296": [
+  "UP:P58406"
+ ],
+ "NCBI gene:15186": [
+  "UP:P23738"
+ ],
+ "NCBI gene:29876": [
+  "UP:Q9QYB1"
+ ],
+ "NCBI gene:57531": [
+  "UP:Q8IYU2"
+ ],
+ "NCBI gene:209462": [
+  "UP:Q3U0D9"
+ ],
+ "NCBI gene:83619": [
+  "UP:O54968"
+ ],
+ "NCBI gene:55737": [
+  "UP:Q96QK1"
+ ],
+ "NCBI gene:51699": [
+  "UP:Q9UBQ0"
+ ],
+ "NCBI gene:387680": [
+  "UP:Q641Q2"
+ ],
+ "NCBI gene:23307": [
+  "UP:Q5T1M5"
+ ],
+ "NCBI gene:6622": [
+  "UP:P37840"
+ ],
+ "NCBI gene:641340": [
+  "UP:Q8VCQ3"
+ ],
+ "NCBI gene:29982": [
+  "UP:Q96F24"
+ ],
+ "NCBI gene:225326": [
+  "UP:Q6PF93"
+ ],
+ "NCBI gene:17969": [
+  "UP:Q09014"
+ ],
+ "NCBI gene:13405": [
+  "UP:P11531"
+ ],
+ "NCBI gene:5599": [
+  "UP:P45983"
+ ],
+ "NCBI gene:5601": [
+  "UP:P45984"
+ ],
+ "NCBI gene:5602": [
+  "UP:P53779"
+ ],
+ "NCBI gene:8301": [
+  "UP:Q13492"
+ ],
+ "NCBI gene:30295": [
+  "UP:P35359"
+ ],
+ "NCBI gene:569098": [
+  "UP:Q2VRP7"
+ ],
+ "NCBI gene:9341": [
+  "UP:Q15836"
+ ],
+ "NCBI gene:8673": [
+  "UP:Q9BV40"
+ ],
+ "NCBI gene:6844": [
+  "UP:P63027"
+ ],
+ "NCBI gene:36670": [
+  "UP:Q9V780"
+ ],
+ "NCBI gene:383619": [
+  "UP:Q91VJ1"
+ ],
+ "NCBI gene:192656": [
+  "UP:P58801"
+ ],
+ "NCBI gene:53905": [
+  "UP:Q9NRD9"
+ ],
+ "NCBI gene:7386": [
+  "UP:P47985"
+ ],
+ "NCBI gene:132612": [
+  "UP:Q96M93"
+ ],
+ "NCBI gene:3558": [
+  "UP:P60568"
+ ],
+ "NCBI gene:83737": [
+  "UP:Q96J02"
+ ],
+ "NCBI gene:1827": [
+  "UP:P53805"
+ ],
+ "NCBI gene:16396": [
+  "UP:Q8C863"
+ ],
+ "NCBI gene:120892": [
+  "UP:Q5S007"
+ ],
+ "NCBI gene:14580": [
+  "UP:P03995"
+ ],
+ "NCBI gene:25793": [
+  "UP:Q9Y3I1"
+ ],
+ "NCBI gene:38443": [
+  "UP:Q8SX86"
+ ],
+ "NCBI gene:34413": [
+  "UP:P11420"
+ ],
+ "NCBI gene:31607": [
+  "UP:Q0KHV6"
+ ],
+ "NCBI gene:176089": [
+  "UP:P34669"
+ ],
+ "NCBI gene:16783": [
+  "UP:P11438"
+ ],
+ "NCBI gene:108664": [
+  "UP:Q8BVE3"
+ ],
+ "NCBI gene:11605": [
+  "UP:Q8BGZ6",
+  "UP:Q3UM38"
+ ],
+ "NCBI gene:56464": [
+  "UP:Q9R013"
+ ],
+ "NCBI gene:11835": [
+  "UP:P19091"
+ ],
+ "NCBI gene:13033": [
+  "UP:P18242"
+ ],
+ "NCBI gene:54205": [
+  "UP:P99999"
+ ],
+ "NCBI gene:2717": [
+  "UP:P06280"
+ ],
+ "NCBI gene:34": [
+  "UP:P11310"
+ ],
+ "NCBI gene:1337": [
+  "UP:P12074"
+ ],
+ "NCBI gene:1497180": [
+  "UP:P89884"
+ ],
+ "NCBI gene:885903": [
+  "UP:P9WFK7"
+ ],
+ "NCBI gene:26419": [
+  "UP:Q91Y86"
+ ],
+ "NCBI gene:7900047": [
+  "UP:A0A125YKY6"
+ ],
+ "NCBI gene:7900125": [
+  "UP:S8GE21"
+ ],
+ "NCBI gene:985114": [
+  "UP:Q8Y7I7"
+ ],
+ "NCBI gene:986837": [
+  "UP:Q8Y8H5"
+ ],
+ "NCBI gene:987035": [
+  "UP:P33379"
+ ],
+ "NCBI gene:9961": [
+  "UP:Q14764"
+ ],
+ "NCBI gene:820": [
+  "UP:P49913"
+ ],
+ "NCBI gene:1594": [
+  "UP:O15528"
+ ],
+ "NCBI gene:7421": [
+  "UP:P11473"
+ ],
+ "NCBI gene:1051": [
+  "UP:P17676"
+ ],
+ "NCBI gene:19765": [
+  "UP:Q62172"
+ ],
+ "NCBI gene:1253809": [
+  "UP:Q8ZNG2"
+ ],
+ "NCBI gene:5912": [
+  "UP:P61225"
+ ],
+ "NCBI gene:5653628": [
+  "UP:Q4Q7K5"
+ ],
+ "NCBI gene:3565776": [
+  "UP:P41958"
+ ],
+ "NCBI gene:828287": [
+  "UP:Q8LEM4"
+ ],
+ "NCBI gene:838652": [
+  "UP:Q96528"
+ ],
+ "NCBI gene:944566": [
+  "UP:Q2F514"
+ ],
+ "NCBI gene:951475": [
+  "UP:P27958"
+ ],
+ "NCBI gene:4536": [
+  "UP:P03891"
+ ],
+ "NCBI gene:4513": [
+  "UP:P00403"
+ ],
+ "NCBI gene:13649": [
+  "UP:Q01279"
+ ],
+ "NCBI gene:100774580": [
+  "UP:G3HEF7"
+ ],
+ "NCBI gene:7896467": [
+  "UP:A0A125YMF8"
+ ],
+ "NCBI gene:7901253": [
+  "UP:S8EU18"
+ ],
+ "NCBI gene:1254421": [
+  "UP:P35672"
+ ],
+ "NCBI gene:1248100": [
+  "UP:Q8Z6L1"
+ ],
+ "NCBI gene:1249311": [
+  "UP:P74849"
+ ],
+ "NCBI gene:1249313": [
+  "UP:Q56135"
+ ],
+ "NCBI gene:1254393": [
+  "UP:P0CL44"
+ ],
+ "NCBI gene:156110": [
+  "UP:P04601"
+ ],
+ "NCBI gene:886209": [
+  "UP:P9WNK7"
+ ],
+ "NCBI gene:56085": [
+  "UP:Q8R317"
+ ],
+ "NCBI gene:17110": [
+  "UP:P17897"
+ ],
+ "NCBI gene:81555": [
+  "UP:Q969M3"
+ ],
+ "NCBI gene:18145": [
+  "UP:O35604"
+ ],
+ "NCBI gene:175072": [
+  "UP:Q9U298"
+ ],
+ "NCBI gene:177335": [
+  "UP:P17221"
+ ],
+ "NCBI gene:180357": [
+  "UP:Q17381"
+ ],
+ "NCBI gene:266836": [
+  "UP:Q94148"
+ ],
+ "NCBI gene:177770": [
+  "UP:Q68TI8",
+  "UP:G5EF88",
+  "UP:S6FD39",
+  "UP:G5EEV7",
+  "UP:S6F588"
+ ],
+ "NCBI gene:177594": [
+  "UP:G5ED76"
+ ],
+ "NCBI gene:38654": [
+  "UP:Q94533"
+ ],
+ "NCBI gene:36073": [
+  "UP:P31396"
+ ],
+ "NCBI gene:35509": [
+  "UP:P29673"
+ ],
+ "NCBI gene:43812": [
+  "UP:O18381"
+ ],
+ "NCBI gene:42862": [
+  "UP:Q9VCC9"
+ ],
+ "NCBI gene:36240": [
+  "UP:P02836"
+ ],
+ "NCBI gene:13198": [
+  "UP:P35639"
+ ],
+ "NCBI gene:828571": [
+  "UP:Q9SB64"
+ ],
+ "NCBI gene:831594": [
+  "UP:Q9FFI2"
+ ],
+ "NCBI gene:799873": [
+  "UP:G1K2F4"
+ ],
+ "NCBI gene:322425": [
+  "UP:Q7ZUD8"
+ ],
+ "NCBI gene:406466": [
+  "UP:Q6NX90"
+ ],
+ "NCBI gene:393846": [
+  "UP:Q6P4P7"
+ ],
+ "NCBI gene:326974": [
+  "UP:Q6NZZ7",
+  "UP:Q6PSS4"
+ ],
+ "NCBI gene:30590": [
+  "UP:P79734"
+ ],
+ "NCBI gene:40138": [
+  "UP:Q7KUT2"
+ ],
+ "NCBI gene:45928": [
+  "UP:P27619"
+ ],
+ "NCBI gene:33418": [
+  "UP:Q9V3I2"
+ ],
+ "NCBI gene:42841": [
+  "UP:O76742"
+ ],
+ "NCBI gene:42501": [
+  "UP:O18335"
+ ],
+ "NCBI gene:33211": [
+  "UP:P91926"
+ ],
+ "NCBI gene:33458": [
+  "UP:Q960X8"
+ ],
+ "NCBI gene:32947": [
+  "UP:Q9Y1I2"
+ ],
+ "NCBI gene:37455": [
+  "UP:P04412"
+ ],
+ "NCBI gene:39389": [
+  "UP:Q9VTU7"
+ ],
+ "NCBI gene:40224": [
+  "UP:P40421"
+ ],
+ "NCBI gene:3354888": [
+  "UP:P40417"
+ ],
+ "NCBI gene:35253": [
+  "UP:Q01083"
+ ],
+ "NCBI gene:38168": [
+  "UP:P20350"
+ ],
+ "NCBI gene:33281": [
+  "UP:P42519"
+ ],
+ "NCBI gene:326198": [
+  "UP:Q9VVJ6"
+ ],
+ "NCBI gene:44856": [
+  "UP:Q9W0F8"
+ ],
+ "NCBI gene:3916": [
+  "UP:P11279"
+ ],
+ "NCBI gene:850505": [
+  "UP:P01123"
+ ],
+ "NCBI gene:851203": [
+  "UP:P31109"
+ ],
+ "NCBI gene:855479": [
+  "UP:P53855"
+ ],
+ "NCBI gene:850577": [
+  "UP:P43601"
+ ],
+ "NCBI gene:855760": [
+  "UP:P11655"
+ ],
+ "NCBI gene:854256": [
+  "UP:P36017"
+ ],
+ "NCBI gene:856478": [
+  "UP:P32361"
+ ],
+ "NCBI gene:850513": [
+  "UP:P41546"
+ ],
+ "NCBI gene:851574": [
+  "UP:P32568"
+ ],
+ "NCBI gene:40174": [
+  "UP:Q9VW54"
+ ],
+ "NCBI gene:39855": [
+  "UP:P40304"
+ ],
+ "NCBI gene:3355072": [
+  "UP:A8Y582",
+  "UP:Q7PLP5",
+  "UP:Q7PLP4"
+ ],
+ "NCBI gene:38945": [
+  "UP:A8JNN5",
+  "UP:Q9VSI2"
+ ],
+ "NCBI gene:33338": [
+  "UP:Q9VQ26"
+ ],
+ "NCBI gene:34626": [
+  "UP:Q9VKB9"
+ ],
+ "NCBI gene:36127": [
+  "UP:P25228"
+ ],
+ "NCBI gene:31684": [
+  "UP:Q9W3Q0"
+ ],
+ "NCBI gene:41823": [
+  "UP:Q9VFC8"
+ ],
+ "NCBI gene:36060": [
+  "UP:P52034"
+ ],
+ "NCBI gene:37435": [
+  "UP:Q86BS7",
+  "UP:Q7KVP4",
+  "UP:E1JGQ5",
+  "UP:Q9W2H8"
+ ],
+ "NCBI gene:326264": [
+  "UP:A1Z992"
+ ],
+ "NCBI gene:851445": [
+  "UP:Q07528"
+ ],
+ "NCBI gene:33386": [
+  "UP:Q9XTL9"
+ ],
+ "NCBI gene:174295": [
+  "UP:Q09349"
+ ],
+ "NCBI gene:173214": [
+  "UP:Q9XWP6"
+ ],
+ "NCBI gene:34699": [
+  "UP:Q9VK44"
+ ],
+ "NCBI gene:40217": [
+  "UP:Q9VW97"
+ ],
+ "NCBI gene:10277": [
+  "UP:O95155"
+ ],
+ "NCBI gene:23028": [
+  "UP:O60341"
+ ],
+ "NCBI gene:4303": [
+  "UP:P98177"
+ ],
+ "NCBI gene:5717": [
+  "UP:O00231"
+ ],
+ "NCBI gene:24842": [
+  "UP:P10361"
+ ],
+ "NCBI gene:32158": [
+  "UP:P91645"
+ ],
+ "NCBI gene:36015": [
+  "UP:Q7JYX5"
+ ],
+ "NCBI gene:37033": [
+  "UP:O96838"
+ ],
+ "NCBI gene:36526": [
+  "UP:A0A0B4K7P4",
+  "UP:A0A0B4K866",
+  "UP:Q7K0H4"
+ ],
+ "NCBI gene:43442": [
+  "UP:Q8IML3",
+  "UP:Q8IML5",
+  "UP:Q6NLA3",
+  "UP:Q8IML4",
+  "UP:Q9XZ10"
+ ],
+ "NCBI gene:38196": [
+  "UP:Q86BQ0",
+  "UP:M9PDW0",
+  "UP:Q9W0C2",
+  "UP:Q9W0C1",
+  "UP:M9PE71"
+ ],
+ "NCBI gene:12286": [
+  "UP:P97445"
+ ],
+ "NCBI gene:56808": [
+  "UP:Q6PHS9"
+ ],
+ "NCBI gene:26420": [
+  "UP:Q9WTU6"
+ ],
+ "NCBI gene:16150": [
+  "UP:O88351"
+ ],
+ "NCBI gene:4842": [
+  "UP:P29475"
+ ],
+ "NCBI gene:4843": [
+  "UP:P35228"
+ ],
+ "NCBI gene:4846": [
+  "UP:P29474"
+ ],
+ "NCBI gene:43392": [
+  "UP:Q9V3N4"
+ ],
+ "NCBI gene:30214": [
+  "UP:O42269"
+ ],
+ "NCBI gene:8655": [
+  "UP:P63167"
+ ],
+ "NCBI gene:1254408": [
+  "UP:Q56019"
+ ],
+ "NCBI gene:1254407": [
+  "UP:P0CL47"
+ ],
+ "NCBI gene:1254406": [
+  "UP:Q56026"
+ ],
+ "NCBI gene:15898": [
+  "UP:Q60625"
+ ],
+ "NCBI gene:4851": [
+  "UP:P46531"
+ ],
+ "NCBI gene:4853": [
+  "UP:Q04721"
+ ],
+ "NCBI gene:4855": [
+  "UP:Q99466"
+ ],
+ "NCBI gene:7087": [
+  "UP:Q9UMF0"
+ ],
+ "NCBI gene:249": [
+  "UP:P05186"
+ ],
+ "NCBI gene:19165": [
+  "UP:Q61144"
+ ],
+ "NCBI gene:9146": [
+  "UP:O14964"
+ ],
+ "NCBI gene:7251": [
+  "UP:Q99816"
+ ],
+ "NCBI gene:25978": [
+  "UP:Q9UQN3"
+ ],
+ "NCBI gene:51652": [
+  "UP:Q9Y3E7"
+ ],
+ "NCBI gene:31666": [
+  "UP:Q9W3R7"
+ ],
+ "NCBI gene:42132": [
+  "UP:Q9VEG5"
+ ],
+ "NCBI gene:31271": [
+  "UP:P10090"
+ ],
+ "NCBI gene:40015": [
+  "UP:Q24475"
+ ],
+ "NCBI gene:40014": [
+  "UP:Q24570"
+ ],
+ "NCBI gene:40016": [
+  "UP:Q9VVP8"
+ ],
+ "NCBI gene:41140": [
+  "UP:P08646"
+ ],
+ "NCBI gene:38494": [
+  "UP:P04388"
+ ],
+ "NCBI gene:31221": [
+  "UP:P11346"
+ ],
+ "NCBI gene:39753": [
+  "UP:Q24306"
+ ],
+ "NCBI gene:41260": [
+  "UP:A0A0B4KH36",
+  "UP:A0A0B4KGR9",
+  "UP:Q9VH01",
+  "UP:A0A0B4KFQ0",
+  "UP:A0A0B4KG50"
+ ],
+ "NCBI gene:53585": [
+  "UP:Q9V9C8"
+ ],
+ "NCBI gene:36251": [
+  "UP:Q8T8Y5"
+ ],
+ "NCBI gene:9020": [
+  "UP:Q99558"
+ ],
+ "NCBI gene:31000": [
+  "UP:P16914"
+ ],
+ "NCBI gene:35246": [
+  "UP:P14199"
+ ],
+ "NCBI gene:269523": [
+  "UP:Q01853"
+ ],
+ "NCBI gene:7415": [
+  "UP:P55072"
+ ],
+ "NCBI gene:9276": [
+  "UP:P35606"
+ ],
+ "NCBI gene:1314": [
+  "UP:P53621"
+ ],
+ "NCBI gene:10484": [
+  "UP:Q15436"
+ ],
+ "NCBI gene:1315": [
+  "UP:P53618"
+ ],
+ "NCBI gene:19645": [
+  "UP:P13405"
+ ],
+ "NCBI gene:18033": [
+  "UP:P25799"
+ ],
+ "NCBI gene:56816": [
+  "UP:Q9JK66"
+ ],
+ "NCBI gene:40998": [
+  "UP:Q9VHR6"
+ ],
+ "NCBI gene:79443": [
+  "UP:Q9BQS8"
+ ],
+ "NCBI gene:15289": [
+  "UP:P63158"
+ ],
+ "NCBI gene:6648": [
+  "UP:P04179"
+ ],
+ "NCBI gene:23411": [
+  "UP:Q96EB6"
+ ],
+ "NCBI gene:177924": [
+  "UP:Q21921"
+ ],
+ "NCBI gene:4001": [
+  "UP:P20700"
+ ],
+ "NCBI gene:3930": [
+  "UP:Q14739"
+ ],
+ "NCBI gene:850908": [
+  "UP:Q05789"
+ ],
+ "NCBI gene:852425": [
+  "UP:P38270"
+ ],
+ "NCBI gene:855983": [
+  "UP:Q02948"
+ ],
+ "NCBI gene:851074": [
+  "UP:Q05919"
+ ],
+ "NCBI gene:112574": [
+  "UP:Q96RF0"
+ ],
+ "NCBI gene:39136": [
+  "UP:Q9NCC3"
+ ],
+ "NCBI gene:2280": [
+  "UP:P62942"
+ ],
+ "NCBI gene:170625": [
+  "UP:Q8C788"
+ ],
+ "NCBI gene:180996": [
+  "UP:Q22342"
+ ],
+ "NCBI gene:171787": [
+  "UP:Q95XR4"
+ ],
+ "NCBI gene:176150": [
+  "UP:P34379"
+ ],
+ "NCBI gene:176009": [
+  "UP:Q20123"
+ ],
+ "NCBI gene:176712": [
+  "UP:Q9XWU8"
+ ],
+ "NCBI gene:178561": [
+  "UP:H2L0M4",
+  "UP:Q9TXN6"
+ ],
+ "NCBI gene:176327": [
+  "UP:P34443"
+ ],
+ "NCBI gene:55004": [
+  "UP:Q6IAA8"
+ ],
+ "NCBI gene:25751": [
+  "UP:P39052"
+ ],
+ "NCBI gene:13430": [
+  "UP:P39054"
+ ],
+ "NCBI gene:100502841": [
+  "UP:Q80TA9"
+ ],
+ "NCBI gene:57724": [
+  "UP:Q9HCE0"
+ ],
+ "NCBI gene:32007": [
+  "UP:Q26365"
+ ],
+ "NCBI gene:855972": [
+  "UP:P26321"
+ ],
+ "NCBI gene:853993": [
+  "UP:P04456"
+ ],
+ "NCBI gene:850620": [
+  "UP:P0CG63"
+ ],
+ "NCBI gene:854658": [
+  "UP:P0CH08",
+  "UP:P0CH09"
+ ],
+ "NCBI gene:853969": [
+  "UP:P0CH08",
+  "UP:P0CH09"
+ ],
+ "NCBI gene:850864": [
+  "UP:P05759"
+ ],
+ "NCBI gene:856895": [
+  "UP:Q01477"
+ ],
+ "NCBI gene:855289": [
+  "UP:Q04781"
+ ],
+ "NCBI gene:57650": [
+  "UP:Q8TCG1"
+ ],
+ "NCBI gene:5518": [
+  "UP:P30153"
+ ],
+ "NCBI gene:6232": [
+  "UP:P42677"
+ ],
+ "NCBI gene:14466": [
+  "UP:P17439"
+ ],
+ "NCBI gene:1173": [
+  "UP:Q96CW1"
+ ],
+ "NCBI gene:4645": [
+  "UP:Q9ULV0"
+ ],
+ "Rfam:RF00731": [
+  "HGNC:31542"
+ ],
+ "Rfam:RF00254": [
+  "HGNC:29664"
+ ],
+ "Rfam:RF00642": [
+  "HGNC:31605"
+ ],
+ "Rfam:RF00644": [
+  "HGNC:31613"
+ ],
+ "UBERON:0000002": [
+  "MESH:D002584"
+ ],
+ "UBERON:0000004": [
+  "MESH:D009666"
+ ],
+ "UBERON:0000006": [
+  "MESH:D007515"
+ ],
+ "UBERON:0000007": [
+  "MESH:D010902"
+ ],
+ "UBERON:0000010": [
+  "MESH:D017933"
+ ],
+ "UBERON:0000011": [
+  "MESH:D010275"
+ ],
+ "UBERON:0000013": [
+  "MESH:D013564"
+ ],
+ "UBERON:0000014": [
+  "MESH:D012867"
+ ],
+ "UBERON:0000020": [
+  "MESH:D012679"
+ ],
+ "UBERON:0000022": [
+  "MESH:D005241"
+ ],
+ "UBERON:0000023": [
+  "MESH:D014921"
+ ],
+ "UBERON:0000026": [
+  "MESH:D005121"
+ ],
+ "UBERON:0000029": [
+  "MESH:D008198"
+ ],
+ "UBERON:0000033": [
+  "MESH:D006257"
+ ],
+ "UBERON:0000038": [
+  "MESH:D015571"
+ ],
+ "UBERON:0000042": [
+  "MESH:D012704"
+ ],
+ "UBERON:0000043": [
+  "MESH:D013710"
+ ],
+ "UBERON:0000045": [
+  "MESH:D005724"
+ ],
+ "UBERON:0000053": [
+  "MESH:D008266"
+ ],
+ "UBERON:0000054": [
+  "MESH:D008267"
+ ],
+ "UBERON:0000056": [
+  "MESH:D014513"
+ ],
+ "UBERON:0000057": [
+  "MESH:D014521"
+ ],
+ "UBERON:0000061": [
+  "MESH:D000825"
+ ],
+ "UBERON:0000074": [
+  "MESH:D007678"
+ ],
+ "UBERON:0000079": [
+  "MESH:D005837"
+ ],
+ "UBERON:0000080": [
+  "MESH:D001755"
+ ],
+ "UBERON:0000082": [
+  "MESH:D007668"
+ ],
+ "UBERON:0000086": [
+  "MESH:D015044"
+ ],
+ "UBERON:0000158": [
+  "MESH:D008566"
+ ],
+ "UBERON:0000162": [
+  "MESH:D002988"
+ ],
+ "UBERON:0000165": [
+  "MESH:D009055"
+ ],
+ "UBERON:0000173": [
+  "MESH:D000653"
+ ],
+ "UBERON:0000178": [
+  "MESH:D001769"
+ ],
+ "UBERON:0000209": [
+  "MESH:D005624"
+ ],
+ "UBERON:0000210": [
+  "MESH:D010294"
+ ],
+ "UBERON:0000211": [
+  "MESH:D008022"
+ ],
+ "UBERON:0000310": [
+  "MESH:D001940"
+ ],
+ "UBERON:0000315": [
+  "MESH:D013346"
+ ],
+ "UBERON:0000316": [
+  "MESH:D002582"
+ ],
+ "UBERON:0000323": [
+  "MESH:D005333"
+ ],
+ "UBERON:0000326": [
+  "MESH:D010189"
+ ],
+ "UBERON:0000344": [
+  "MESH:D009092"
+ ],
+ "UBERON:0000347": [
+  "MESH:D009186"
+ ],
+ "UBERON:0000348": [
+  "MESH:D009882"
+ ],
+ "UBERON:0000362": [
+  "MESH:D007679"
+ ],
+ "UBERON:0000363": [
+  "MESH:D012157"
+ ],
+ "UBERON:0000365": [
+  "MESH:D019459"
+ ],
+ "UBERON:0000375": [
+  "MESH:D008340"
+ ],
+ "UBERON:0000376": [
+  "MESH:D013848"
+ ],
+ "UBERON:0000377": [
+  "MESH:D008442"
+ ],
+ "UBERON:0000382": [
+  "MESH:D001050"
+ ],
+ "UBERON:0000395": [
+  "MESH:D013136"
+ ],
+ "UBERON:0000403": [
+  "MESH:D012535"
+ ],
+ "UBERON:0000416": [
+  "MESH:D013355"
+ ],
+ "UBERON:0000423": [
+  "MESH:D004439"
+ ],
+ "UBERON:0000456": [
+  "MESH:D012634"
+ ],
+ "UBERON:0000460": [
+  "MESH:D001472"
+ ],
+ "UBERON:0000473": [
+  "MESH:D013737"
+ ],
+ "UBERON:0000474": [
+  "MESH:D005836"
+ ],
+ "UBERON:0000475": [
+  "MESH:D001829"
+ ],
+ "UBERON:0000479": [
+  "MESH:D014024"
+ ],
+ "UBERON:0000482": [
+  "MESH:D001485"
+ ],
+ "UBERON:0000483": [
+  "MESH:D004848"
+ ],
+ "UBERON:0000912": [
+  "MESH:D009093"
+ ],
+ "UBERON:0000922": [
+  "MESH:D004622"
+ ],
+ "UBERON:0000933": [
+  "MESH:D010609"
+ ],
+ "UBERON:0000941": [
+  "MESH:D009900"
+ ],
+ "UBERON:0000946": [
+  "MESH:D006351"
+ ],
+ "UBERON:0000947": [
+  "MESH:D001011"
+ ],
+ "UBERON:0000948": [
+  "MESH:D006321"
+ ],
+ "UBERON:0000949": [
+  "MESH:D004703"
+ ],
+ "UBERON:0000955": [
+  "MESH:D001921"
+ ],
+ "UBERON:0000959": [
+  "MESH:D009897"
+ ],
+ "UBERON:0000964": [
+  "MESH:D003315"
+ ],
+ "UBERON:0000966": [
+  "MESH:D012160"
+ ],
+ "UBERON:0000970": [
+  "MESH:D005123"
+ ],
+ "UBERON:0000974": [
+  "MESH:D009333"
+ ],
+ "UBERON:0000975": [
+  "MESH:D013249"
+ ],
+ "UBERON:0000977": [
+  "MESH:D010994"
+ ],
+ "UBERON:0000978": [
+  "MESH:D035002"
+ ],
+ "UBERON:0000982": [
+  "MESH:D007596"
+ ],
+ "UBERON:0000985": [
+  "MESH:D001367"
+ ],
+ "UBERON:0000988": [
+  "MESH:D011149"
+ ],
+ "UBERON:0000989": [
+  "MESH:D010413"
+ ],
+ "UBERON:0000991": [
+  "MESH:D006066"
+ ],
+ "UBERON:0000992": [
+  "MESH:D010053"
+ ],
+ "UBERON:0000993": [
+  "MESH:D010057"
+ ],
+ "UBERON:0000995": [
+  "MESH:D014599"
+ ],
+ "UBERON:0000996": [
+  "MESH:D014621"
+ ],
+ "UBERON:0000997": [
+  "MESH:D014844"
+ ],
+ "UBERON:0000998": [
+  "MESH:D012669"
+ ],
+ "UBERON:0000999": [
+  "MESH:D004543"
+ ],
+ "UBERON:0001000": [
+  "MESH:D014649"
+ ],
+ "UBERON:0001003": [
+  "MESH:D004817"
+ ],
+ "UBERON:0001004": [
+  "MESH:D012137"
+ ],
+ "UBERON:0001007": [
+  "MESH:D004064"
+ ],
+ "UBERON:0001008": [
+  "MESH:D014551"
+ ],
+ "UBERON:0001011": [
+  "MESH:D006458"
+ ],
+ "UBERON:0001013": [
+  "MESH:D000273"
+ ],
+ "UBERON:0001016": [
+  "MESH:D009420"
+ ],
+ "UBERON:0001017": [
+  "MESH:D002490"
+ ],
+ "UBERON:0001021": [
+  "MESH:D010525"
+ ],
+ "UBERON:0001031": [
+  "MESH:D009441"
+ ],
+ "UBERON:0001037": [
+  "MESH:D006197"
+ ],
+ "UBERON:0001044": [
+  "MESH:D012469"
+ ],
+ "UBERON:0001054": [
+  "MESH:D008317"
+ ],
+ "UBERON:0001057": [
+  "MESH:D003335"
+ ],
+ "UBERON:0001058": [
+  "MESH:D024521"
+ ],
+ "UBERON:0001064": [
+  "MESH:D010183"
+ ],
+ "UBERON:0001067": [
+  "MESH:D021801"
+ ],
+ "UBERON:0001070": [
+  "MESH:D002342"
+ ],
+ "UBERON:0001072": [
+  "MESH:D014682"
+ ],
+ "UBERON:0001088": [
+  "MESH:D014556"
+ ],
+ "UBERON:0001089": [
+  "MESH:D013542"
+ ],
+ "UBERON:0001090": [
+  "MESH:D013582"
+ ],
+ "UBERON:0001093": [
+  "MESH:D001368"
+ ],
+ "UBERON:0001103": [
+  "MESH:D003964"
+ ],
+ "UBERON:0001105": [
+  "MESH:D002968"
+ ],
+ "UBERON:0001111": [
+  "MESH:D007366"
+ ],
+ "UBERON:0001130": [
+  "MESH:D013131"
+ ],
+ "UBERON:0001132": [
+  "MESH:D010280"
+ ],
+ "UBERON:0001135": [
+  "MESH:D009130"
+ ],
+ "UBERON:0001140": [
+  "MESH:D012082"
+ ],
+ "UBERON:0001143": [
+  "MESH:D006503"
+ ],
+ "UBERON:0001148": [
+  "MESH:D008475"
+ ],
+ "UBERON:0001174": [
+  "MESH:D003135"
+ ],
+ "UBERON:0001175": [
+  "MESH:D006500"
+ ],
+ "UBERON:0001182": [
+  "MESH:D017538"
+ ],
+ "UBERON:0001183": [
+  "MESH:D017537"
+ ],
+ "UBERON:0001184": [
+  "MESH:D012077"
+ ],
+ "UBERON:0001193": [
+  "MESH:D006499"
+ ],
+ "UBERON:0001194": [
+  "MESH:D013157"
+ ],
+ "UBERON:0001224": [
+  "MESH:D007682"
+ ],
+ "UBERON:0001225": [
+  "MESH:D007672"
+ ],
+ "UBERON:0001228": [
+  "MESH:D007679"
+ ],
+ "UBERON:0001231": [
+  "MESH:D007684"
+ ],
+ "UBERON:0001232": [
+  "MESH:D007685"
+ ],
+ "UBERON:0001235": [
+  "MESH:D000302"
+ ],
+ "UBERON:0001236": [
+  "MESH:D019439"
+ ],
+ "UBERON:0001237": [
+  "MESH:D010220"
+ ],
+ "UBERON:0001264": [
+  "MESH:D010179"
+ ],
+ "UBERON:0001267": [
+  "MESH:D005267"
+ ],
+ "UBERON:0001283": [
+  "MESH:D001648"
+ ],
+ "UBERON:0001285": [
+  "MESH:D009399"
+ ],
+ "UBERON:0001288": [
+  "MESH:D008138"
+ ],
+ "UBERON:0001295": [
+  "MESH:D004717"
+ ],
+ "UBERON:0001296": [
+  "MESH:D009215"
+ ],
+ "UBERON:0001300": [
+  "MESH:D012611"
+ ],
+ "UBERON:0001305": [
+  "MESH:D006080"
+ ],
+ "UBERON:0001310": [
+  "MESH:D014469"
+ ],
+ "UBERON:0001322": [
+  "MESH:D012584"
+ ],
+ "UBERON:0001323": [
+  "MESH:D013979"
+ ],
+ "UBERON:0001324": [
+  "MESH:D010543"
+ ],
+ "UBERON:0001343": [
+  "MESH:D012671"
+ ],
+ "UBERON:0001346": [
+  "MESH:D006924"
+ ],
+ "UBERON:0001348": [
+  "MESH:D002001"
+ ],
+ "UBERON:0001350": [
+  "MESH:D003050"
+ ],
+ "UBERON:0001352": [
+  "MESH:D004424"
+ ],
+ "UBERON:0001361": [
+  "MESH:D005268"
+ ],
+ "UBERON:0001365": [
+  "MESH:D012446"
+ ],
+ "UBERON:0001394": [
+  "MESH:D001366"
+ ],
+ "UBERON:0001398": [
+  "MESH:D001916"
+ ],
+ "UBERON:0001404": [
+  "MESH:D017534"
+ ],
+ "UBERON:0001406": [
+  "MESH:D017535"
+ ],
+ "UBERON:0001437": [
+  "MESH:D004838"
+ ],
+ "UBERON:0001456": [
+  "MESH:D005145"
+ ],
+ "UBERON:0001460": [
+  "MESH:D001132"
+ ],
+ "UBERON:0001461": [
+  "MESH:D004550"
+ ],
+ "UBERON:0001463": [
+  "MESH:D013933"
+ ],
+ "UBERON:0001464": [
+  "MESH:D006615"
+ ],
+ "UBERON:0001465": [
+  "MESH:D007717"
+ ],
+ "UBERON:0001467": [
+  "MESH:D012782"
+ ],
+ "UBERON:0001469": [
+  "MESH:D013247"
+ ],
+ "UBERON:0001470": [
+  "MESH:D012785"
+ ],
+ "UBERON:0001479": [
+  "MESH:D012716"
+ ],
+ "UBERON:0001484": [
+  "MESH:D017746"
+ ],
+ "UBERON:0001485": [
+  "MESH:D007719"
+ ],
+ "UBERON:0001486": [
+  "MESH:D006621"
+ ],
+ "UBERON:0001487": [
+  "MESH:D033023"
+ ],
+ "UBERON:0001488": [
+  "MESH:D000843"
+ ],
+ "UBERON:0001490": [
+  "MESH:D004551"
+ ],
+ "UBERON:0001492": [
+  "MESH:D011826"
+ ],
+ "UBERON:0001494": [
+  "MESH:D014459"
+ ],
+ "UBERON:0001495": [
+  "MESH:D010369"
+ ],
+ "UBERON:0001515": [
+  "MESH:D001013"
+ ],
+ "UBERON:0001516": [
+  "MESH:D001012"
+ ],
+ "UBERON:0001529": [
+  "MESH:D016122"
+ ],
+ "UBERON:0001530": [
+  "MESH:D017536"
+ ],
+ "UBERON:0001532": [
+  "MESH:D002343"
+ ],
+ "UBERON:0001533": [
+  "MESH:D013348"
+ ],
+ "UBERON:0001535": [
+  "MESH:D014711"
+ ],
+ "UBERON:0001544": [
+  "MESH:D011152"
+ ],
+ "UBERON:0001567": [
+  "MESH:D002610"
+ ],
+ "UBERON:0001568": [
+  "MESH:D007821"
+ ],
+ "UBERON:0001577": [
+  "MESH:D005152"
+ ],
+ "UBERON:0001579": [
+  "MESH:D009832"
+ ],
+ "UBERON:0001585": [
+  "MESH:D014683"
+ ],
+ "UBERON:0001587": [
+  "MESH:D013350"
+ ],
+ "UBERON:0001594": [
+  "MESH:D001401"
+ ],
+ "UBERON:0001597": [
+  "MESH:D008406"
+ ],
+ "UBERON:0001598": [
+  "MESH:D013703"
+ ],
+ "UBERON:0001599": [
+  "MESH:D013198"
+ ],
+ "UBERON:0001600": [
+  "MESH:D013719"
+ ],
+ "UBERON:0001616": [
+  "MESH:D008438"
+ ],
+ "UBERON:0001619": [
+  "MESH:D009880"
+ ],
+ "UBERON:0001620": [
+  "MESH:D012161"
+ ],
+ "UBERON:0001624": [
+  "MESH:D020771"
+ ],
+ "UBERON:0001627": [
+  "MESH:D020768"
+ ],
+ "UBERON:0001632": [
+  "MESH:D013699"
+ ],
+ "UBERON:0001633": [
+  "MESH:D001488"
+ ],
+ "UBERON:0001636": [
+  "MESH:D020769"
+ ],
+ "UBERON:0001637": [
+  "MESH:D001158"
+ ],
+ "UBERON:0001638": [
+  "MESH:D014680"
+ ],
+ "UBERON:0001640": [
+  "MESH:D002445"
+ ],
+ "UBERON:0001643": [
+  "MESH:D009802"
+ ],
+ "UBERON:0001644": [
+  "MESH:D014321"
+ ],
+ "UBERON:0001645": [
+  "MESH:D014276"
+ ],
+ "UBERON:0001646": [
+  "MESH:D000010"
+ ],
+ "UBERON:0001647": [
+  "MESH:D005154"
+ ],
+ "UBERON:0001648": [
+  "MESH:D000159"
+ ],
+ "UBERON:0001649": [
+  "MESH:D005930"
+ ],
+ "UBERON:0001650": [
+  "MESH:D007002"
+ ],
+ "UBERON:0001663": [
+  "MESH:D002550"
+ ],
+ "UBERON:0001673": [
+  "MESH:D012169"
+ ],
+ "UBERON:0001675": [
+  "MESH:D012668"
+ ],
+ "UBERON:0001676": [
+  "MESH:D009777"
+ ],
+ "UBERON:0001677": [
+  "MESH:D013100"
+ ],
+ "UBERON:0001678": [
+  "MESH:D013701"
+ ],
+ "UBERON:0001679": [
+  "MESH:D005004"
+ ],
+ "UBERON:0001681": [
+  "MESH:D009295"
+ ],
+ "UBERON:0001684": [
+  "MESH:D008334"
+ ],
+ "UBERON:0001685": [
+  "MESH:D006928"
+ ],
+ "UBERON:0001687": [
+  "MESH:D013199"
+ ],
+ "UBERON:0001688": [
+  "MESH:D007188"
+ ],
+ "UBERON:0001689": [
+  "MESH:D008307"
+ ],
+ "UBERON:0001690": [
+  "MESH:D004423"
+ ],
+ "UBERON:0001691": [
+  "MESH:D004431"
+ ],
+ "UBERON:0001694": [
+  "MESH:D010579"
+ ],
+ "UBERON:0001697": [
+  "MESH:D009915"
+ ],
+ "UBERON:0001700": [
+  "MESH:D005830"
+ ],
+ "UBERON:0001702": [
+  "MESH:D005140"
+ ],
+ "UBERON:0001705": [
+  "MESH:D009262"
+ ],
+ "UBERON:0001707": [
+  "MESH:D009296"
+ ],
+ "UBERON:0001708": [
+  "MESH:D007568"
+ ],
+ "UBERON:0001710": [
+  "MESH:D008334"
+ ],
+ "UBERON:0001711": [
+  "MESH:D005143"
+ ],
+ "UBERON:0001716": [
+  "MESH:D010159"
+ ],
+ "UBERON:0001717": [
+  "MESH:D014279"
+ ],
+ "UBERON:0001720": [
+  "MESH:D017626"
+ ],
+ "UBERON:0001723": [
+  "MESH:D014059"
+ ],
+ "UBERON:0001724": [
+  "MESH:D013101"
+ ],
+ "UBERON:0001733": [
+  "MESH:D010160"
+ ],
+ "UBERON:0001734": [
+  "MESH:D014609"
+ ],
+ "UBERON:0001736": [
+  "MESH:D013363"
+ ],
+ "UBERON:0001737": [
+  "MESH:D007830"
+ ],
+ "UBERON:0001744": [
+  "MESH:D008221"
+ ],
+ "UBERON:0001750": [
+  "MESH:D007765"
+ ],
+ "UBERON:0001756": [
+  "MESH:D004432"
+ ],
+ "UBERON:0001759": [
+  "MESH:D014630"
+ ],
+ "UBERON:0001760": [
+  "MESH:D005626"
+ ],
+ "UBERON:0001762": [
+  "MESH:D014420"
+ ],
+ "UBERON:0001764": [
+  "MESH:D008443"
+ ],
+ "UBERON:0001766": [
+  "MESH:D000867"
+ ],
+ "UBERON:0001768": [
+  "MESH:D014602"
+ ],
+ "UBERON:0001769": [
+  "MESH:D007498"
+ ],
+ "UBERON:0001771": [
+  "MESH:D011680"
+ ],
+ "UBERON:0001772": [
+  "MESH:D019573"
+ ],
+ "UBERON:0001773": [
+  "MESH:D012590"
+ ],
+ "UBERON:0001775": [
+  "MESH:D002924"
+ ],
+ "UBERON:0001776": [
+  "MESH:D002829"
+ ],
+ "UBERON:0001777": [
+  "MESH:D003319"
+ ],
+ "UBERON:0001780": [
+  "MESH:D013127"
+ ],
+ "UBERON:0001783": [
+  "MESH:D009898"
+ ],
+ "UBERON:0001785": [
+  "MESH:D003391"
+ ],
+ "UBERON:0001786": [
+  "MESH:D005584"
+ ],
+ "UBERON:0001796": [
+  "MESH:D001082"
+ ],
+ "UBERON:0001800": [
+  "MESH:D017950"
+ ],
+ "UBERON:0001801": [
+  "MESH:D000869"
+ ],
+ "UBERON:0001805": [
+  "MESH:D005725"
+ ],
+ "UBERON:0001814": [
+  "MESH:D001917"
+ ],
+ "UBERON:0001815": [
+  "MESH:D008160"
+ ],
+ "UBERON:0001818": [
+  "MESH:D008537"
+ ],
+ "UBERON:0001820": [
+  "MESH:D013545"
+ ],
+ "UBERON:0001821": [
+  "MESH:D012627"
+ ],
+ "UBERON:0001824": [
+  "MESH:D007820"
+ ],
+ "UBERON:0001825": [
+  "MESH:D010256"
+ ],
+ "UBERON:0001827": [
+  "MESH:D013666"
+ ],
+ "UBERON:0001830": [
+  "MESH:D012470"
+ ],
+ "UBERON:0001831": [
+  "MESH:D010306"
+ ],
+ "UBERON:0001832": [
+  "MESH:D013361"
+ ],
+ "UBERON:0001833": [
+  "MESH:D008046"
+ ],
+ "UBERON:0001836": [
+  "MESH:D012463"
+ ],
+ "UBERON:0001837": [
+  "MESH:D018987"
+ ],
+ "UBERON:0001840": [
+  "MESH:D012665"
+ ],
+ "UBERON:0001844": [
+  "MESH:D003051"
+ ],
+ "UBERON:0001846": [
+  "MESH:D007758"
+ ],
+ "UBERON:0001855": [
+  "MESH:D003053"
+ ],
+ "UBERON:0001860": [
+  "MESH:D004711"
+ ],
+ "UBERON:0001864": [
+  "MESH:D012533"
+ ],
+ "UBERON:0001866": [
+  "MESH:D012629"
+ ],
+ "UBERON:0001884": [
+  "MESH:D010791"
+ ],
+ "UBERON:0001886": [
+  "MESH:D002831"
+ ],
+ "UBERON:0001887": [
+  "MESH:D020772"
+ ],
+ "UBERON:0001890": [
+  "MESH:D016548"
+ ],
+ "UBERON:0001891": [
+  "MESH:D008636"
+ ],
+ "UBERON:0001893": [
+  "MESH:D013687"
+ ],
+ "UBERON:0001895": [
+  "MESH:D020540"
+ ],
+ "UBERON:0001896": [
+  "MESH:D008526"
+ ],
+ "UBERON:0001905": [
+  "MESH:D010870"
+ ],
+ "UBERON:0001908": [
+  "MESH:D014795"
+ ],
+ "UBERON:0001910": [
+  "MESH:D008474"
+ ],
+ "UBERON:0001911": [
+  "MESH:D008321"
+ ],
+ "UBERON:0001914": [
+  "MESH:D003126"
+ ],
+ "UBERON:0001968": [
+  "MESH:D012661"
+ ],
+ "UBERON:0001969": [
+  "MESH:D010949"
+ ],
+ "UBERON:0001970": [
+  "MESH:D001646"
+ ],
+ "UBERON:0001971": [
+  "MESH:D005750"
+ ],
+ "UBERON:0001980": [
+  "MESH:D001160"
+ ],
+ "UBERON:0001981": [
+  "MESH:D001808"
+ ],
+ "UBERON:0001985": [
+  "MESH:D004728"
+ ],
+ "UBERON:0001986": [
+  "MESH:D004727"
+ ],
+ "UBERON:0001988": [
+  "MESH:D005243"
+ ],
+ "UBERON:0001989": [
+  "MESH:D017783"
+ ],
+ "UBERON:0001998": [
+  "MESH:D013248"
+ ],
+ "UBERON:0002005": [
+  "MESH:D017615"
+ ],
+ "UBERON:0002010": [
+  "MESH:D002447"
+ ],
+ "UBERON:0002012": [
+  "MESH:D011651"
+ ],
+ "UBERON:0002016": [
+  "MESH:D011667"
+ ],
+ "UBERON:0002017": [
+  "MESH:D011169"
+ ],
+ "UBERON:0002018": [
+  "MESH:D013583"
+ ],
+ "UBERON:0002019": [
+  "MESH:D000055"
+ ],
+ "UBERON:0002028": [
+  "MESH:D012249"
+ ],
+ "UBERON:0002030": [
+  "MESH:D009558"
+ ],
+ "UBERON:0002037": [
+  "MESH:D002531"
+ ],
+ "UBERON:0002040": [
+  "MESH:D001981"
+ ],
+ "UBERON:0002042": [
+  "MESH:D004729"
+ ],
+ "UBERON:0002046": [
+  "MESH:D013961"
+ ],
+ "UBERON:0002048": [
+  "MESH:D008168"
+ ],
+ "UBERON:0002050": [
+  "MESH:D004628"
+ ],
+ "UBERON:0002053": [
+  "MESH:D015384"
+ ],
+ "UBERON:0002054": [
+  "MESH:D015383"
+ ],
+ "UBERON:0002055": [
+  "MESH:D015385"
+ ],
+ "UBERON:0002060": [
+  "MESH:D005263"
+ ],
+ "UBERON:0002061": [
+  "MESH:D014338"
+ ],
+ "UBERON:0002066": [
+  "MESH:D014471"
+ ],
+ "UBERON:0002067": [
+  "MESH:D020405"
+ ],
+ "UBERON:0002073": [
+  "MESH:D018859"
+ ],
+ "UBERON:0002075": [
+  "MESH:D014781"
+ ],
+ "UBERON:0002081": [
+  "MESH:D006325"
+ ],
+ "UBERON:0002082": [
+  "MESH:D006352"
+ ],
+ "UBERON:0002097": [
+  "MESH:D012867"
+ ],
+ "UBERON:0002099": [
+  "MESH:D006346"
+ ],
+ "UBERON:0002102": [
+  "MESH:D005552"
+ ],
+ "UBERON:0002103": [
+  "MESH:D006614"
+ ],
+ "UBERON:0002107": [
+  "MESH:D008099"
+ ],
+ "UBERON:0002110": [
+  "MESH:D005704"
+ ],
+ "UBERON:0002113": [
+  "MESH:D007668"
+ ],
+ "UBERON:0002129": [
+  "MESH:D002525"
+ ],
+ "UBERON:0002130": [
+  "MESH:D002529"
+ ],
+ "UBERON:0002134": [
+  "MESH:D014261"
+ ],
+ "UBERON:0002135": [
+  "MESH:D008943"
+ ],
+ "UBERON:0002137": [
+  "MESH:D001021"
+ ],
+ "UBERON:0002146": [
+  "MESH:D011664"
+ ],
+ "UBERON:0002148": [
+  "MESH:D008125"
+ ],
+ "UBERON:0002162": [
+  "MESH:D031608"
+ ],
+ "UBERON:0002165": [
+  "MESH:D004699"
+ ],
+ "UBERON:0002185": [
+  "MESH:D001980"
+ ],
+ "UBERON:0002204": [
+  "MESH:D009141"
+ ],
+ "UBERON:0002205": [
+  "MESH:D008371"
+ ],
+ "UBERON:0002223": [
+  "MESH:D004712"
+ ],
+ "UBERON:0002226": [
+  "MESH:D001489"
+ ],
+ "UBERON:0002228": [
+  "MESH:D012272"
+ ],
+ "UBERON:0002240": [
+  "MESH:D013116"
+ ],
+ "UBERON:0002250": [
+  "MESH:D011150"
+ ],
+ "UBERON:0002275": [
+  "MESH:D012154"
+ ],
+ "UBERON:0002279": [
+  "MESH:D014723"
+ ],
+ "UBERON:0002282": [
+  "MESH:D013316"
+ ],
+ "UBERON:0002285": [
+  "MESH:D020547"
+ ],
+ "UBERON:0002286": [
+  "MESH:D020542"
+ ],
+ "UBERON:0002294": [
+  "MESH:D001659"
+ ],
+ "UBERON:0002297": [
+  "MESH:D002571"
+ ],
+ "UBERON:0002298": [
+  "MESH:D001933"
+ ],
+ "UBERON:0002299": [
+  "MESH:D011650"
+ ],
+ "UBERON:0002303": [
+  "MESH:D007606"
+ ],
+ "UBERON:0002347": [
+  "MESH:D013904"
+ ],
+ "UBERON:0002349": [
+  "MESH:D009206"
+ ],
+ "UBERON:0002350": [
+  "MESH:D006329"
+ ],
+ "UBERON:0002351": [
+  "MESH:D012849"
+ ],
+ "UBERON:0002352": [
+  "MESH:D001283"
+ ],
+ "UBERON:0002353": [
+  "MESH:D002036"
+ ],
+ "UBERON:0002354": [
+  "MESH:D011690"
+ ],
+ "UBERON:0002356": [
+  "MESH:D010502"
+ ],
+ "UBERON:0002360": [
+  "MESH:D008578"
+ ],
+ "UBERON:0002361": [
+  "MESH:D010841"
+ ],
+ "UBERON:0002362": [
+  "MESH:D001099"
+ ],
+ "UBERON:0002363": [
+  "MESH:D004388"
+ ],
+ "UBERON:0002365": [
+  "MESH:D005088"
+ ],
+ "UBERON:0002366": [
+  "MESH:D002030"
+ ],
+ "UBERON:0002367": [
+  "MESH:D011467"
+ ],
+ "UBERON:0002368": [
+  "MESH:D004702"
+ ],
+ "UBERON:0002369": [
+  "MESH:D000311"
+ ],
+ "UBERON:0002371": [
+  "MESH:D001853"
+ ],
+ "UBERON:0002377": [
+  "MESH:D009334"
+ ],
+ "UBERON:0002378": [
+  "MESH:D000009"
+ ],
+ "UBERON:0002382": [
+  "MESH:D017568"
+ ],
+ "UBERON:0002384": [
+  "MESH:D003238"
+ ],
+ "UBERON:0002385": [
+  "MESH:D009132"
+ ],
+ "UBERON:0002386": [
+  "MESH:D005542"
+ ],
+ "UBERON:0002387": [
+  "MESH:D005528"
+ ],
+ "UBERON:0002389": [
+  "MESH:D005385"
+ ],
+ "UBERON:0002390": [
+  "MESH:D006413"
+ ],
+ "UBERON:0002392": [
+  "MESH:D009301"
+ ],
+ "UBERON:0002394": [
+  "MESH:D001652"
+ ],
+ "UBERON:0002397": [
+  "MESH:D008437"
+ ],
+ "UBERON:0002398": [
+  "MESH:D006225"
+ ],
+ "UBERON:0002405": [
+  "MESH:D007107"
+ ],
+ "UBERON:0002407": [
+  "MESH:D010496"
+ ],
+ "UBERON:0002410": [
+  "MESH:D001341"
+ ],
+ "UBERON:0002411": [
+  "MESH:D002987"
+ ],
+ "UBERON:0002413": [
+  "MESH:D002574"
+ ],
+ "UBERON:0002414": [
+  "MESH:D008159"
+ ],
+ "UBERON:0002415": [
+  "MESH:D013623"
+ ],
+ "UBERON:0002416": [
+  "MESH:D034582"
+ ],
+ "UBERON:0002418": [
+  "MESH:D002356"
+ ],
+ "UBERON:0002422": [
+  "MESH:D020546"
+ ],
+ "UBERON:0002439": [
+  "MESH:D009197"
+ ],
+ "UBERON:0002441": [
+  "MESH:D013233"
+ ],
+ "UBERON:0002450": [
+  "MESH:D003656"
+ ],
+ "UBERON:0002453": [
+  "MESH:D005005"
+ ],
+ "UBERON:0002466": [
+  "MESH:D007419"
+ ],
+ "UBERON:0002481": [
+  "MESH:D001842"
+ ],
+ "UBERON:0002486": [
+  "MESH:D005931"
+ ],
+ "UBERON:0002494": [
+  "MESH:D010210"
+ ],
+ "UBERON:0002497": [
+  "MESH:D000174"
+ ],
+ "UBERON:0002500": [
+  "MESH:D015050"
+ ],
+ "UBERON:0002501": [
+  "MESH:D010046"
+ ],
+ "UBERON:0002502": [
+  "MESH:D012405"
+ ],
+ "UBERON:0002512": [
+  "MESH:D003338"
+ ],
+ "UBERON:0002515": [
+  "MESH:D010521"
+ ],
+ "UBERON:0002516": [
+  "MESH:D006132"
+ ],
+ "UBERON:0002517": [
+  "MESH:D019291"
+ ],
+ "UBERON:0002518": [
+  "MESH:D012444"
+ ],
+ "UBERON:0002519": [
+  "MESH:D010037"
+ ],
+ "UBERON:0002521": [
+  "MESH:D004547"
+ ],
+ "UBERON:0002522": [
+  "MESH:D017540"
+ ],
+ "UBERON:0002523": [
+  "MESH:D017539"
+ ],
+ "UBERON:0002535": [
+  "MESH:D005880"
+ ],
+ "UBERON:0002606": [
+  "MESH:D019581"
+ ],
+ "UBERON:0002673": [
+  "MESH:D014726"
+ ],
+ "UBERON:0002707": [
+  "MESH:D011712"
+ ],
+ "UBERON:0002741": [
+  "MESH:D020667"
+ ],
+ "UBERON:0002866": [
+  "MESH:D014275"
+ ],
+ "UBERON:0002925": [
+  "MESH:D014278"
+ ],
+ "UBERON:0002944": [
+  "MESH:D013133"
+ ],
+ "UBERON:0003092": [
+  "MESH:D014460"
+ ],
+ "UBERON:0003126": [
+  "MESH:D014132"
+ ],
+ "UBERON:0003129": [
+  "MESH:D012886"
+ ],
+ "UBERON:0003133": [
+  "MESH:D005835"
+ ],
+ "UBERON:0003216": [
+  "MESH:D021362"
+ ],
+ "UBERON:0003473": [
+  "MESH:D013895"
+ ],
+ "UBERON:0003474": [
+  "MESH:D008576"
+ ],
+ "UBERON:0003501": [
+  "MESH:D012171"
+ ],
+ "UBERON:0003631": [
+  "MESH:D006214"
+ ],
+ "UBERON:0003668": [
+  "MESH:D002061"
+ ],
+ "UBERON:0003669": [
+  "MESH:D005206"
+ ],
+ "UBERON:0003670": [
+  "MESH:D012902"
+ ],
+ "UBERON:0003671": [
+  "MESH:D016118"
+ ],
+ "UBERON:0003673": [
+  "MESH:D017843"
+ ],
+ "UBERON:0003676": [
+  "MESH:D017847"
+ ],
+ "UBERON:0003679": [
+  "MESH:D009060"
+ ],
+ "UBERON:0003680": [
+  "MESH:D016119"
+ ],
+ "UBERON:0003681": [
+  "MESH:D008410"
+ ],
+ "UBERON:0003682": [
+  "MESH:D010156"
+ ],
+ "UBERON:0003683": [
+  "MESH:D017006"
+ ],
+ "UBERON:0003685": [
+  "MESH:D003393"
+ ],
+ "UBERON:0003686": [
+  "MESH:D020390"
+ ],
+ "UBERON:0003687": [
+  "MESH:D005539"
+ ],
+ "UBERON:0003689": [
+  "MESH:D012658"
+ ],
+ "UBERON:0003690": [
+  "MESH:D012447"
+ ],
+ "UBERON:0003691": [
+  "MESH:D004824"
+ ],
+ "UBERON:0003692": [
+  "MESH:D000173"
+ ],
+ "UBERON:0003694": [
+  "MESH:D001268"
+ ],
+ "UBERON:0003696": [
+  "MESH:D008683"
+ ],
+ "UBERON:0003698": [
+  "MESH:D013380"
+ ],
+ "UBERON:0003699": [
+  "MESH:D011631"
+ ],
+ "UBERON:0003700": [
+  "MESH:D013704"
+ ],
+ "UBERON:0003701": [
+  "MESH:D000125"
+ ],
+ "UBERON:0003703": [
+  "MESH:D017734"
+ ],
+ "UBERON:0003704": [
+  "MESH:D001653"
+ ],
+ "UBERON:0003706": [
+  "MESH:D014827"
+ ],
+ "UBERON:0003707": [
+  "MESH:D012850"
+ ],
+ "UBERON:0003708": [
+  "MESH:D002346"
+ ],
+ "UBERON:0003709": [
+  "MESH:D002941"
+ ],
+ "UBERON:0003710": [
+  "MESH:D014651"
+ ],
+ "UBERON:0003711": [
+  "MESH:D016121"
+ ],
+ "UBERON:0003712": [
+  "MESH:D002426"
+ ],
+ "UBERON:0003713": [
+  "MESH:D013162"
+ ],
+ "UBERON:0003714": [
+  "MESH:D009417"
+ ],
+ "UBERON:0003715": [
+  "MESH:D013153"
+ ],
+ "UBERON:0003716": [
+  "MESH:D012009"
+ ],
+ "UBERON:0003720": [
+  "MESH:D035262"
+ ],
+ "UBERON:0003721": [
+  "MESH:D008036"
+ ],
+ "UBERON:0003722": [
+  "MESH:D035301"
+ ],
+ "UBERON:0003723": [
+  "MESH:D014725"
+ ],
+ "UBERON:0003724": [
+  "MESH:D009138"
+ ],
+ "UBERON:0003725": [
+  "MESH:D002572"
+ ],
+ "UBERON:0003726": [
+  "MESH:D013900"
+ ],
+ "UBERON:0003727": [
+  "MESH:D007367"
+ ],
+ "UBERON:0003729": [
+  "MESH:D009061"
+ ],
+ "UBERON:0003822": [
+  "MESH:D001132"
+ ],
+ "UBERON:0003823": [
+  "MESH:D007866"
+ ],
+ "UBERON:0003824": [
+  "MESH:D013900"
+ ],
+ "UBERON:0003889": [
+  "MESH:D005187"
+ ],
+ "UBERON:0003903": [
+  "MESH:D002060"
+ ],
+ "UBERON:0003917": [
+  "MESH:D005216"
+ ],
+ "UBERON:0003948": [
+  "MESH:D015824"
+ ],
+ "UBERON:0003951": [
+  "MESH:D005654"
+ ],
+ "UBERON:0003957": [
+  "MESH:D016570"
+ ],
+ "UBERON:0003959": [
+  "MESH:D012152"
+ ],
+ "UBERON:0004019": [
+  "MESH:D011311"
+ ],
+ "UBERON:0004086": [
+  "MESH:D002552"
+ ],
+ "UBERON:0004087": [
+  "MESH:D014684"
+ ],
+ "UBERON:0004096": [
+  "MESH:D009809"
+ ],
+ "UBERON:0004103": [
+  "MESH:D000539"
+ ],
+ "UBERON:0004122": [
+  "MESH:D014566"
+ ],
+ "UBERON:0004134": [
+  "MESH:D007687"
+ ],
+ "UBERON:0004135": [
+  "MESH:D007686"
+ ],
+ "UBERON:0004187": [
+  "MESH:D006243"
+ ],
+ "UBERON:0004237": [
+  "MESH:D009131"
+ ],
+ "UBERON:0004288": [
+  "MESH:D012863"
+ ],
+ "UBERON:0004367": [
+  "MESH:D003886"
+ ],
+ "UBERON:0004449": [
+  "MESH:D002536"
+ ],
+ "UBERON:0004452": [
+  "MESH:D014953"
+ ],
+ "UBERON:0004465": [
+  "MESH:D009334"
+ ],
+ "UBERON:0004478": [
+  "MESH:D007821"
+ ],
+ "UBERON:0004535": [
+  "MESH:D002319"
+ ],
+ "UBERON:0004657": [
+  "MESH:D008335"
+ ],
+ "UBERON:0004670": [
+  "MESH:D004805"
+ ],
+ "UBERON:0004711": [
+  "MESH:D007601"
+ ],
+ "UBERON:0004714": [
+  "MESH:D012688"
+ ],
+ "UBERON:0004727": [
+  "MESH:D003056"
+ ],
+ "UBERON:0004758": [
+  "MESH:D012491"
+ ],
+ "UBERON:0004769": [
+  "MESH:D018483"
+ ],
+ "UBERON:0004785": [
+  "MESH:D020545"
+ ],
+ "UBERON:0004813": [
+  "MESH:D012670"
+ ],
+ "UBERON:0004852": [
+  "MESH:D004730"
+ ],
+ "UBERON:0004864": [
+  "MESH:D012171"
+ ],
+ "UBERON:0005052": [
+  "MESH:D005895"
+ ],
+ "UBERON:0005079": [
+  "MESH:D004528"
+ ],
+ "UBERON:0005094": [
+  "MESH:D001502"
+ ],
+ "UBERON:0005236": [
+  "MESH:D014722"
+ ],
+ "UBERON:0005303": [
+  "MESH:D007001"
+ ],
+ "UBERON:0005304": [
+  "MESH:D013368"
+ ],
+ "UBERON:0005352": [
+  "MESH:D013085"
+ ],
+ "UBERON:0005357": [
+  "MESH:D004805"
+ ],
+ "UBERON:0005363": [
+  "MESH:D009620"
+ ],
+ "UBERON:0005386": [
+  "MESH:D009831"
+ ],
+ "UBERON:0005396": [
+  "MESH:D002339"
+ ],
+ "UBERON:0005413": [
+  "MESH:D020824"
+ ],
+ "UBERON:0005440": [
+  "MESH:D004373"
+ ],
+ "UBERON:0005465": [
+  "MESH:D009776"
+ ],
+ "UBERON:0005609": [
+  "MESH:D007083"
+ ],
+ "UBERON:0005610": [
+  "MESH:D007084"
+ ],
+ "UBERON:0005616": [
+  "MESH:D008638"
+ ],
+ "UBERON:0005617": [
+  "MESH:D008642"
+ ],
+ "UBERON:0005806": [
+  "MESH:D011168"
+ ],
+ "UBERON:0005969": [
+  "MESH:D014129"
+ ],
+ "UBERON:0005974": [
+  "MESH:D002946"
+ ],
+ "UBERON:0005985": [
+  "MESH:D003331"
+ ],
+ "UBERON:0005994": [
+  "MESH:D002815"
+ ],
+ "UBERON:0006314": [
+  "MESH:D001826"
+ ],
+ "UBERON:0006349": [
+  "MESH:D019074"
+ ],
+ "UBERON:0006378": [
+  "MESH:D014738"
+ ],
+ "UBERON:0006517": [
+  "MESH:D007670"
+ ],
+ "UBERON:0006531": [
+  "MESH:D009801"
+ ],
+ "UBERON:0006558": [
+  "MESH:D008208"
+ ],
+ "UBERON:0006720": [
+  "MESH:D011626"
+ ],
+ "UBERON:0006724": [
+  "MESH:D013137"
+ ],
+ "UBERON:0006725": [
+  "MESH:D055493"
+ ],
+ "UBERON:0006761": [
+  "MESH:D016850"
+ ],
+ "UBERON:0006849": [
+  "MESH:D012540"
+ ],
+ "UBERON:0006856": [
+  "MESH:D007401"
+ ],
+ "UBERON:0006869": [
+  "MESH:D004557"
+ ],
+ "UBERON:0006967": [
+  "MESH:D006733"
+ ],
+ "UBERON:0006971": [
+  "MESH:D000999"
+ ],
+ "UBERON:0007108": [
+  "MESH:D014708"
+ ],
+ "UBERON:0007113": [
+  "MESH:D014688"
+ ],
+ "UBERON:0007230": [
+  "MESH:D003689"
+ ],
+ "UBERON:0007311": [
+  "MESH:D013183"
+ ],
+ "UBERON:0007318": [
+  "MESH:D012501"
+ ],
+ "UBERON:0007357": [
+  "MESH:D011531"
+ ],
+ "UBERON:0007358": [
+  "MESH:D000018"
+ ],
+ "UBERON:0007361": [
+  "MESH:D012159"
+ ],
+ "UBERON:0007362": [
+  "MESH:D009851"
+ ],
+ "UBERON:0007365": [
+  "MESH:D012417"
+ ],
+ "UBERON:0007366": [
+  "MESH:D013279"
+ ],
+ "UBERON:0007610": [
+  "MESH:D016909"
+ ],
+ "UBERON:0007623": [
+  "MESH:D003129"
+ ],
+ "UBERON:0007625": [
+  "MESH:D010857"
+ ],
+ "UBERON:0007721": [
+  "MESH:D014033"
+ ],
+ "UBERON:0007779": [
+  "MESH:D005122"
+ ],
+ "UBERON:0007780": [
+  "MESH:D005122"
+ ],
+ "UBERON:0007795": [
+  "MESH:D001202"
+ ],
+ "UBERON:0008199": [
+  "MESH:D002680"
+ ],
+ "UBERON:0008200": [
+  "MESH:D005546"
+ ],
+ "UBERON:0008274": [
+  "MESH:D24.185.926.580.590"
+ ],
+ "UBERON:0008280": [
+  "MESH:D003064"
+ ],
+ "UBERON:0008447": [
+  "MESH:D013640"
+ ],
+ "UBERON:0008450": [
+  "MESH:D016658"
+ ],
+ "UBERON:0008788": [
+  "MESH:D003388"
+ ],
+ "UBERON:0008897": [
+  "MESH:D058500"
+ ],
+ "UBERON:0008962": [
+  "MESH:D001133"
+ ],
+ "UBERON:0008978": [
+  "MESH:D000695"
+ ],
+ "UBERON:0008982": [
+  "MESH:D005205"
+ ],
+ "UBERON:0009025": [
+  "MESH:D024405"
+ ],
+ "UBERON:0009050": [
+  "MESH:D017552"
+ ],
+ "UBERON:0009060": [
+  "MESH:D000400"
+ ],
+ "UBERON:0009472": [
+  "MESH:D001365"
+ ],
+ "UBERON:0009564": [
+  "MESH:D006724"
+ ],
+ "UBERON:0009623": [
+  "MESH:D013126"
+ ],
+ "UBERON:0010074": [
+  "MESH:D002838"
+ ],
+ "UBERON:0010163": [
+  "MESH:D005138"
+ ],
+ "UBERON:0010207": [
+  "MESH:D009541"
+ ],
+ "UBERON:0010211": [
+  "MESH:D006097"
+ ],
+ "UBERON:0010545": [
+  "MESH:D008684"
+ ],
+ "UBERON:0010754": [
+  "MESH:D018858"
+ ],
+ "UBERON:0011123": [
+  "MESH:D013264"
+ ],
+ "UBERON:0011252": [
+  "MESH:D012543"
+ ],
+ "UBERON:0011319": [
+  "MESH:D019224"
+ ],
+ "UBERON:0011818": [
+  "MESH:D040521"
+ ],
+ "UBERON:0011860": [
+  "MESH:D024022"
+ ],
+ "UBERON:0012168": [
+  "MESH:D005312"
+ ],
+ "UBERON:0012279": [
+  "MESH:D010233"
+ ],
+ "UBERON:0012281": [
+  "MESH:D010481"
+ ],
+ "UBERON:0012332": [
+  "MESH:D001956"
+ ],
+ "UBERON:0012337": [
+  "MESH:D002420"
+ ],
+ "UBERON:0012423": [
+  "MESH:D008871"
+ ],
+ "UBERON:0012453": [
+  "MESH:D009411"
+ ],
+ "UBERON:0013076": [
+  "MESH:D012910"
+ ],
+ "UBERON:0013106": [
+  "MESH:D004546"
+ ],
+ "UBERON:0013110": [
+  "MESH:D24.185.965.850.480"
+ ],
+ "UBERON:0013112": [
+  "MESH:D014757"
+ ],
+ "UBERON:0013196": [
+  "MESH:D014935"
+ ],
+ "UBERON:0013691": [
+  "MESH:D002081"
+ ],
+ "UBERON:0014730": [
+  "MESH:D006253"
+ ],
+ "UBERON:0014892": [
+  "MESH:D018482"
+ ],
+ "UBERON:0014908": [
+  "MESH:D002530"
+ ],
+ "UBERON:0015875": [
+  "MESH:D006365"
+ ],
+ "UBERON:0034728": [
+  "MESH:D017776"
+ ],
+ "UBERON:0034931": [
+  "MESH:D019580"
+ ],
+ "CVCL:0123": [
+  "MESH:D041721",
+  "EFO:0001084",
+  "EFO:0001223"
+ ],
+ "CVCL:0120": [
+  "MESH:D041701"
+ ],
+ "CVCL:0023": [
+  "EFO:0001086",
+  "MESH:D000072283"
+ ],
+ "CVCL:0184": [
+  "MESH:D041702"
+ ],
+ "CVCL:0025": [
+  "EFO:0001099",
+  "MESH:D018938"
+ ],
+ "CVCL:0213": [
+  "MESH:D016466"
+ ],
+ "CVCL:0223": [
+  "MESH:D019556"
+ ],
+ "CVCL:0224": [
+  "MESH:D019556"
+ ],
+ "CVCL:0291": [
+  "MESH:D045325",
+  "EFO:0002824"
+ ],
+ "CVCL:0030": [
+  "EFO:0001185",
+  "MESH:D006367"
+ ],
+ "CVCL:0002": [
+  "EFO:0002793",
+  "MESH:D018922"
+ ],
+ "CVCL:0320": [
+  "MESH:D019073",
+  "EFO:0001193"
+ ],
+ "CVCL:0065": [
+  "EFO:0002796",
+  "MESH:D019169"
+ ],
+ "CVCL:0004": [
+  "MESH:D020014",
+  "EFO:0002067"
+ ],
+ "CVCL:0372": [
+  "MESH:D007624"
+ ],
+ "CVCL:0382": [
+  "EFO:0005284",
+  "MESH:D007939"
+ ],
+ "CVCL:0391": [
+  "MESH:D018374"
+ ],
+ "CVCL:0031": [
+  "MESH:D061986",
+  "EFO:0001203"
+ ],
+ "CVCL:0422": [
+  "MESH:D061985"
+ ],
+ "CVCL:0462": [
+  "MESH:D007739"
+ ],
+ "CVCL:0594": [
+  "MESH:D041681",
+  "EFO:0001222"
+ ],
+ "CVCL:0481": [
+  "EFO:0001225",
+  "MESH:D016716"
+ ],
+ "CVCL:0493": [
+  "EFO:0001231",
+  "MESH:D000067996"
+ ],
+ "CVCL:0549": [
+  "MESH:D061987"
+ ],
+ "CVCL:0007": [
+  "MESH:D020298",
+  "EFO:0001257"
+ ],
+ "CVCL:0059": [
+  "MESH:D014709"
+ ],
+ "CVCL:M605": [
+  "EFO:0006354"
+ ],
+ "CVCL:Z708": [
+  "EFO:0005648"
+ ],
+ "CVCL:8987": [
+  "EFO:0007099"
+ ],
+ "CVCL:8988": [
+  "EFO:0007100"
+ ],
+ "CVCL:8989": [
+  "EFO:0007101"
+ ],
+ "CVCL:5239": [
+  "EFO:0002810"
+ ],
+ "CVCL:2270": [
+  "EFO:0006355"
+ ],
+ "CVCL:8990": [
+  "EFO:0007102"
+ ],
+ "CVCL:8991": [
+  "EFO:0007103"
+ ],
+ "CVCL:8992": [
+  "EFO:0007104"
+ ],
+ "CVCL:K049": [
+  "EFO:0001190"
+ ],
+ "CVCL:K053": [
+  "EFO:0009375"
+ ],
+ "CVCL:8993": [
+  "EFO:0007105"
+ ],
+ "CVCL:8994": [
+  "EFO:0007106"
+ ],
+ "CVCL:8995": [
+  "EFO:0007107"
+ ],
+ "CVCL:3480": [
+  "EFO:0002094"
+ ],
+ "CVCL:8996": [
+  "EFO:0007108"
+ ],
+ "CVCL:C522": [
+  "EFO:0002957"
+ ],
+ "CVCL:1045": [
+  "EFO:0002095"
+ ],
+ "CVCL:1046": [
+  "EFO:0006528"
+ ],
+ "CVCL:4827": [
+  "EFO:0001080"
+ ],
+ "CVCL:9871": [
+  "EFO:0001081"
+ ],
+ "CVCL:8997": [
+  "EFO:0007109"
+ ],
+ "CVCL:8998": [
+  "EFO:0007110"
+ ],
+ "CVCL:9705": [
+  "EFO:0001083"
+ ],
+ "CVCL:E266": [
+  "EFO:0006529"
+ ],
+ "CVCL:H641": [
+  "EFO:0007069"
+ ],
+ "CVCL:0122": [
+  "EFO:0002811"
+ ],
+ "CVCL:3983": [
+  "EFO:0005482"
+ ],
+ "CVCL:9669": [
+  "EFO:0002807"
+ ],
+ "CVCL:9670": [
+  "EFO:0002808"
+ ],
+ "CVCL:9671": [
+  "EFO:0002809"
+ ],
+ "CVCL:Y482": [
+  "EFO:0005484"
+ ],
+ "CVCL:0125": [
+  "EFO:0002037"
+ ],
+ "CVCL:8052": [
+  "EFO:0006357"
+ ],
+ "CVCL:0126": [
+  "EFO:0002096"
+ ],
+ "CVCL:2291": [
+  "EFO:0006358"
+ ],
+ "CVCL:G080": [
+  "EFO:0006530"
+ ],
+ "CVCL:9875": [
+  "EFO:0001085"
+ ],
+ "CVCL:8054": [
+  "EFO:0006359"
+ ],
+ "CVCL:1048": [
+  "EFO:0002097"
+ ],
+ "CVCL:1049": [
+  "EFO:0002098"
+ ],
+ "CVCL:9721": [
+  "EFO:0002038"
+ ],
+ "CVCL:9723": [
+  "EFO:0002039"
+ ],
+ "CVCL:1050": [
+  "EFO:0002099"
+ ],
+ "CVCL:1051": [
+  "EFO:0005707"
+ ],
+ "CVCL:4632": [
+  "EFO:0006531"
+ ],
+ "CVCL:1B47": [
+  "EFO:0006288"
+ ],
+ "CVCL:0131": [
+  "EFO:0002101"
+ ],
+ "CVCL:1058": [
+  "EFO:0002102"
+ ],
+ "CVCL:0132": [
+  "EFO:0002103"
+ ],
+ "CVCL:1055": [
+  "EFO:0002104"
+ ],
+ "CVCL:0037": [
+  "EFO:0006268"
+ ],
+ "CVCL:1056": [
+  "EFO:0002105"
+ ],
+ "CVCL:0080": [
+  "EFO:0002106"
+ ],
+ "CVCL:1057": [
+  "EFO:0002100"
+ ],
+ "CVCL:1940": [
+  "EFO:0005285"
+ ],
+ "CVCL:L305": [
+  "EFO:0005702"
+ ],
+ "CVCL:1059": [
+  "EFO:0006361"
+ ],
+ "CVCL:0134": [
+  "EFO:0006362"
+ ],
+ "CVCL:1062": [
+  "EFO:0006532"
+ ],
+ "CVCL:1064": [
+  "EFO:0006533"
+ ],
+ "CVCL:C261": [
+  "EFO:0002812"
+ ],
+ "CVCL:1066": [
+  "EFO:0002813"
+ ],
+ "CVCL:4829": [
+  "EFO:0006269"
+ ],
+ "CVCL:1067": [
+  "EFO:0002108"
+ ],
+ "CVCL:F486": [
+  "EFO:0006270"
+ ],
+ "CVCL:0139": [
+  "EFO:0002109"
+ ],
+ "CVCL:1806": [
+  "EFO:0006534"
+ ],
+ "CVCL:0028": [
+  "EFO:0002110"
+ ],
+ "CVCL:1072": [
+  "EFO:0002111"
+ ],
+ "CVCL:0145": [
+  "EFO:0006271"
+ ],
+ "CVCL:0152": [
+  "EFO:0002112"
+ ],
+ "CVCL:2299": [
+  "EFO:0006535"
+ ],
+ "CVCL:1074": [
+  "EFO:0001087"
+ ],
+ "CVCL:2862": [
+  "EFO:0002814"
+ ],
+ "CVCL:Y506": [
+  "EFO:0002040"
+ ],
+ "CVCL:Y505": [
+  "EFO:0002041"
+ ],
+ "CVCL:Y508": [
+  "EFO:0002042"
+ ],
+ "CVCL:Y507": [
+  "EFO:0002043"
+ ],
+ "CVCL:1079": [
+  "EFO:0002044"
+ ],
+ "CVCL:1856": [
+  "EFO:0002045"
+ ],
+ "CVCL:1080": [
+  "EFO:0002046"
+ ],
+ "CVCL:B040": [
+  "EFO:0002047"
+ ],
+ "CVCL:0165": [
+  "EFO:0002048"
+ ],
+ "CVCL:9637": [
+  "EFO:0002049"
+ ],
+ "CVCL:4613": [
+  "EFO:0002113"
+ ],
+ "CVCL:0168": [
+  "EFO:0001089"
+ ],
+ "CVCL:1082": [
+  "EFO:0006537"
+ ],
+ "CVCL:0044": [
+  "EFO:0002050"
+ ],
+ "CVCL:1083": [
+  "EFO:0002115"
+ ],
+ "CVCL:1084": [
+  "EFO:0006538"
+ ],
+ "CVCL:9726": [
+  "EFO:0007071"
+ ],
+ "CVCL:9729": [
+  "EFO:0002778"
+ ],
+ "CVCL:9730": [
+  "EFO:0002960"
+ ],
+ "CVCL:1085": [
+  "EFO:0002116"
+ ],
+ "CVCL:1086": [
+  "EFO:0006539"
+ ],
+ "CVCL:2307": [
+  "EFO:0006540"
+ ],
+ "CVCL:2310": [
+  "EFO:0006541"
+ ],
+ "CVCL:2312": [
+  "EFO:0006542"
+ ],
+ "CVCL:2315": [
+  "EFO:0006543"
+ ],
+ "CVCL:3653": [
+  "EFO:0002779"
+ ],
+ "CVCL:5711": [
+  "EFO:0002815"
+ ],
+ "CVCL:9876": [
+  "EFO:0001090"
+ ],
+ "CVCL:1966": [
+  "EFO:0005475"
+ ],
+ "CVCL:9667": [
+  "EFO:0001091"
+ ],
+ "CVCL:1968": [
+  "EFO:0002117"
+ ],
+ "CVCL:K037": [
+  "EFO:0005483"
+ ],
+ "CVCL:0178": [
+  "EFO:0001092"
+ ],
+ "CVCL:0179": [
+  "EFO:0001093"
+ ],
+ "CVCL:2319": [
+  "EFO:0001095"
+ ],
+ "CVCL:1092": [
+  "EFO:0001096"
+ ],
+ "CVCL:0181": [
+  "EFO:0002118"
+ ],
+ "CVCL:0186": [
+  "EFO:0002709"
+ ],
+ "CVCL:1094": [
+  "EFO:0002120"
+ ],
+ "CVCL:2253": [
+  "EFO:0002122"
+ ],
+ "CVCL:1095": [
+  "EFO:0002123"
+ ],
+ "CVCL:K467": [
+  "EFO:0007072"
+ ],
+ "CVCL:WJ19": [
+  "EFO:0009494"
+ ],
+ "CVCL:WJ20": [
+  "EFO:0009495"
+ ],
+ "CVCL:WJ21": [
+  "EFO:0009496"
+ ],
+ "CVCL:S959": [
+  "EFO:0006363"
+ ],
+ "CVCL:1096": [
+  "EFO:0006546"
+ ],
+ "CVCL:0188": [
+  "EFO:0001098"
+ ],
+ "CVCL:1097": [
+  "EFO:0006364"
+ ],
+ "CVCL:2324": [
+  "EFO:0002119"
+ ],
+ "CVCL:0190": [
+  "EFO:0002816"
+ ],
+ "CVCL:1100": [
+  "EFO:0006549"
+ ],
+ "CVCL:3495": [
+  "EFO:0002147"
+ ],
+ "CVCL:1101": [
+  "EFO:0002124"
+ ],
+ "CVCL:0233": [
+  "EFO:0002817"
+ ],
+ "CVCL:1103": [
+  "EFO:0002818"
+ ],
+ "CVCL:0234": [
+  "EFO:0002149"
+ ],
+ "CVCL:0235": [
+  "EFO:0002150"
+ ],
+ "CVCL:1104": [
+  "EFO:0005356"
+ ],
+ "CVCL:1105": [
+  "EFO:0006547"
+ ],
+ "CVCL:1106": [
+  "EFO:0005357"
+ ],
+ "CVCL:1107": [
+  "EFO:0006366"
+ ],
+ "CVCL:1110": [
+  "EFO:0005358"
+ ],
+ "CVCL:1111": [
+  "EFO:0002125"
+ ],
+ "CVCL:1112": [
+  "EFO:0002126"
+ ],
+ "CVCL:1114": [
+  "EFO:0005359"
+ ],
+ "CVCL:0608": [
+  "EFO:0002151"
+ ],
+ "CVCL:0609": [
+  "EFO:0002819"
+ ],
+ "CVCL:0236": [
+  "EFO:0002152"
+ ],
+ "CVCL:1115": [
+  "EFO:0001100"
+ ],
+ "CVCL:0201": [
+  "EFO:0002148"
+ ],
+ "CVCL:0237": [
+  "EFO:0002153"
+ ],
+ "CVCL:0026": [
+  "EFO:0002154"
+ ],
+ "CVCL:1116": [
+  "EFO:0006548"
+ ],
+ "CVCL:0206": [
+  "EFO:0001101"
+ ],
+ "CVCL:2349": [
+  "EFO:0005360"
+ ],
+ "CVCL:2377": [
+  "EFO:0005361"
+ ],
+ "CVCL:2378": [
+  "EFO:0005362"
+ ],
+ "CVCL:2382": [
+  "EFO:0005363"
+ ],
+ "CVCL:2383": [
+  "EFO:0005364"
+ ],
+ "CVCL:2386": [
+  "EFO:0005365"
+ ],
+ "CVCL:2390": [
+  "EFO:0005366"
+ ],
+ "CVCL:2398": [
+  "EFO:0005367"
+ ],
+ "CVCL:1118": [
+  "EFO:0002127"
+ ],
+ "CVCL:0207": [
+  "EFO:0002128"
+ ],
+ "CVCL:1860": [
+  "EFO:0006550"
+ ],
+ "CVCL:3496": [
+  "EFO:0001667"
+ ],
+ "CVCL:0209": [
+  "EFO:0002130"
+ ],
+ "CVCL:1119": [
+  "EFO:0006551"
+ ],
+ "CVCL:9641": [
+  "EFO:0001102"
+ ],
+ "CVCL:3987": [
+  "EFO:0006273"
+ ],
+ "CVCL:1120": [
+  "EFO:0002131"
+ ],
+ "CVCL:0211": [
+  "EFO:0005233"
+ ],
+ "CVCL:1121": [
+  "EFO:0002155"
+ ],
+ "CVCL:1122": [
+  "EFO:0002132"
+ ],
+ "CVCL:1125": [
+  "EFO:0002133"
+ ],
+ "CVCL:1861": [
+  "EFO:0006367"
+ ],
+ "CVCL:C316": [
+  "EFO:0005916"
+ ],
+ "CVCL:1978": [
+  "EFO:0006368"
+ ],
+ "CVCL:1980": [
+  "EFO:0006369"
+ ],
+ "CVCL:1982": [
+  "EFO:0006370"
+ ],
+ "CVCL:D045": [
+  "EFO:0002820"
+ ],
+ "CVCL:M486": [
+  "EFO:0006552"
+ ],
+ "CVCL:2G61": [
+  "EFO:0006553"
+ ],
+ "CVCL:Z786": [
+  "EFO:0005650"
+ ],
+ "CVCL:Z790": [
+  "EFO:0005743"
+ ],
+ "CVCL:Z791": [
+  "EFO:0005744"
+ ],
+ "CVCL:0216": [
+  "EFO:0003037"
+ ],
+ "CVCL:1126": [
+  "EFO:0002134"
+ ],
+ "CVCL:1987": [
+  "EFO:0002135"
+ ],
+ "CVCL:0218": [
+  "EFO:0003082"
+ ],
+ "CVCL:1988": [
+  "EFO:0006554"
+ ],
+ "CVCL:0219": [
+  "EFO:0002136"
+ ],
+ "CVCL:0220": [
+  "EFO:0002137"
+ ],
+ "CVCL:0221": [
+  "EFO:0002710"
+ ],
+ "CVCL:1128": [
+  "EFO:0002138"
+ ],
+ "CVCL:1129": [
+  "EFO:0006371"
+ ],
+ "CVCL:1130": [
+  "EFO:0006372"
+ ],
+ "CVCL:1131": [
+  "EFO:0006373"
+ ],
+ "CVCL:1992": [
+  "EFO:0006374"
+ ],
+ "CVCL:1994": [
+  "EFO:0002139"
+ ],
+ "CVCL:1133": [
+  "EFO:0006375"
+ ],
+ "CVCL:1997": [
+  "EFO:0006376"
+ ],
+ "CVCL:1134": [
+  "EFO:0006377"
+ ],
+ "CVCL:1135": [
+  "EFO:0006378"
+ ],
+ "CVCL:1137": [
+  "EFO:0002140"
+ ],
+ "CVCL:2002": [
+  "EFO:0006379"
+ ],
+ "CVCL:2003": [
+  "EFO:0006380"
+ ],
+ "CVCL:2004": [
+  "EFO:0006381"
+ ],
+ "CVCL:1138": [
+  "EFO:0002141"
+ ],
+ "CVCL:1139": [
+  "EFO:0002142"
+ ],
+ "CVCL:2410": [
+  "EFO:0006555"
+ ],
+ "CVCL:1140": [
+  "EFO:0002143"
+ ],
+ "CVCL:2415": [
+  "EFO:0006556"
+ ],
+ "CVCL:1141": [
+  "EFO:0002144"
+ ],
+ "CVCL:2419": [
+  "EFO:0006382"
+ ],
+ "CVCL:2420": [
+  "EFO:0006383"
+ ],
+ "CVCL:2422": [
+  "EFO:0006557"
+ ],
+ "CVCL:2423": [
+  "EFO:0006558"
+ ],
+ "CVCL:2010": [
+  "EFO:0006384"
+ ],
+ "CVCL:2424": [
+  "EFO:0006385"
+ ],
+ "CVCL:2425": [
+  "EFO:0006386"
+ ],
+ "CVCL:1146": [
+  "EFO:0006559"
+ ],
+ "CVCL:1147": [
+  "EFO:0002145"
+ ],
+ "CVCL:1148": [
+  "EFO:0002146"
+ ],
+ "CVCL:0227": [
+  "EFO:0002821"
+ ],
+ "CVCL:1151": [
+  "EFO:0006560"
+ ],
+ "CVCL:2011": [
+  "EFO:0006561"
+ ],
+ "CVCL:B850": [
+  "EFO:0007073"
+ ],
+ "CVCL:0241": [
+  "EFO:0002822"
+ ],
+ "CVCL:1155": [
+  "EFO:0002156"
+ ],
+ "CVCL:0018": [
+  "EFO:0002157"
+ ],
+ "CVCL:7185": [
+  "EFO:0002782"
+ ],
+ "CVCL:7901": [
+  "EFO:0005696"
+ ],
+ "CVCL:0243": [
+  "EFO:0006562"
+ ],
+ "CVCL:1167": [
+  "EFO:0005698"
+ ],
+ "CVCL:0008": [
+  "EFO:0002169"
+ ],
+ "CVCL:1168": [
+  "EFO:0002158"
+ ],
+ "CVCL:1169": [
+  "EFO:0002159"
+ ],
+ "CVCL:4161": [
+  "EFO:0006563"
+ ],
+ "CVCL:1171": [
+  "EFO:0002170"
+ ],
+ "CVCL:0244": [
+  "EFO:0002160"
+ ],
+ "CVCL:1173": [
+  "EFO:0002161"
+ ],
+ "CVCL:0248": [
+  "EFO:0006389"
+ ],
+ "CVCL:1174": [
+  "EFO:0002162"
+ ],
+ "CVCL:1175": [
+  "EFO:0002163"
+ ],
+ "CVCL:1176": [
+  "EFO:0002164"
+ ],
+ "CVCL:2438": [
+  "EFO:0006390"
+ ],
+ "CVCL:1177": [
+  "EFO:0002165"
+ ],
+ "CVCL:1178": [
+  "EFO:0002166"
+ ],
+ "CVCL:2022": [
+  "EFO:0007074"
+ ],
+ "CVCL:1179": [
+  "EFO:0002167"
+ ],
+ "CVCL:1180": [
+  "EFO:0006564"
+ ],
+ "CVCL:1181": [
+  "EFO:0002171"
+ ],
+ "CVCL:0249": [
+  "EFO:0006274"
+ ],
+ "CVCL:0105": [
+  "EFO:0005441"
+ ],
+ "CVCL:1183": [
+  "EFO:0002168"
+ ],
+ "CVCL:1184": [
+  "EFO:0006565"
+ ],
+ "CVCL:3901": [
+  "EFO:0003039"
+ ],
+ "CVCL:2027": [
+  "EFO:0002172"
+ ],
+ "CVCL:1186": [
+  "EFO:0002173"
+ ],
+ "CVCL:1185": [
+  "EFO:0002174"
+ ],
+ "CVCL:2891": [
+  "EFO:0003115"
+ ],
+ "CVCL:7260": [
+  "EFO:0005231"
+ ],
+ "CVCL:9807": [
+  "EFO:0002052"
+ ],
+ "CVCL:3679": [
+  "EFO:0005264"
+ ],
+ "CVCL:0253": [
+  "EFO:0002175"
+ ],
+ "CVCL:1812": [
+  "EFO:0006568"
+ ],
+ "CVCL:1813": [
+  "EFO:0006569"
+ ],
+ "CVCL:1814": [
+  "EFO:0006570"
+ ],
+ "CVCL:1192": [
+  "EFO:0006571"
+ ],
+ "CVCL:2030": [
+  "EFO:0006572"
+ ],
+ "CVCL:1195": [
+  "EFO:0006786"
+ ],
+ "CVCL:C115": [
+  "EFO:0005901"
+ ],
+ "CVCL:1196": [
+  "EFO:0002176"
+ ],
+ "CVCL:1197": [
+  "EFO:0006573"
+ ],
+ "CVCL:3509": [
+  "EFO:0002177"
+ ],
+ "CVCL:4378": [
+  "EFO:0005910"
+ ],
+ "CVCL:C320": [
+  "EFO:0007075"
+ ],
+ "CVCL:9108": [
+  "EFO:0006275"
+ ],
+ "CVCL:Y481": [
+  "EFO:0007751"
+ ],
+ "CVCL:2167": [
+  "EFO:0002076"
+ ],
+ "CVCL:1207": [
+  "EFO:0006574"
+ ],
+ "CVCL:VC43": [
+  "EFO:0009319"
+ ],
+ "CVCL:RZ87": [
+  "EFO:0002711"
+ ],
+ "CVCL:0259": [
+  "EFO:0002053"
+ ],
+ "CVCL:4034": [
+  "EFO:0006392"
+ ],
+ "CVCL:1218": [
+  "EFO:0002178"
+ ],
+ "CVCL:3302": [
+  "EFO:0006393"
+ ],
+ "CVCL:1B45": [
+  "EFO:0005745"
+ ],
+ "CVCL:2908": [
+  "EFO:0002054"
+ ],
+ "CVCL:1220": [
+  "EFO:0006394"
+ ],
+ "CVCL:0270": [
+  "EFO:0002179"
+ ],
+ "CVCL:1221": [
+  "EFO:0002180"
+ ],
+ "CVCL:D046": [
+  "EFO:0002034"
+ ],
+ "CVCL:D047": [
+  "EFO:0002055"
+ ],
+ "CVCL:Z793": [
+  "EFO:0005746"
+ ],
+ "CVCL:L269": [
+  "EFO:0005703"
+ ],
+ "CVCL:1222": [
+  "EFO:0002181"
+ ],
+ "CVCL:1229": [
+  "EFO:0002182"
+ ],
+ "CVCL:1230": [
+  "EFO:0002183"
+ ],
+ "CVCL:7271": [
+  "EFO:0004921"
+ ],
+ "CVCL:7300": [
+  "EFO:0004922"
+ ],
+ "CVCL:7434": [
+  "EFO:0006278"
+ ],
+ "CVCL:9586": [
+  "EFO:0001107"
+ ],
+ "CVCL:9587": [
+  "EFO:0002783"
+ ],
+ "CVCL:9588": [
+  "EFO:0001108"
+ ],
+ "CVCL:9589": [
+  "EFO:0001109"
+ ],
+ "CVCL:5B23": [
+  "EFO:0007077"
+ ],
+ "CVCL:9590": [
+  "EFO:0001110"
+ ],
+ "CVCL:9591": [
+  "EFO:0001111"
+ ],
+ "CVCL:9592": [
+  "EFO:0001112"
+ ],
+ "CVCL:7463": [
+  "EFO:0001113"
+ ],
+ "CVCL:9593": [
+  "EFO:0001114"
+ ],
+ "CVCL:9594": [
+  "EFO:0001115"
+ ],
+ "CVCL:9595": [
+  "EFO:0001116"
+ ],
+ "CVCL:E128": [
+  "EFO:0005333"
+ ],
+ "CVCL:L245": [
+  "EFO:0005334"
+ ],
+ "CVCL:L246": [
+  "EFO:0005335"
+ ],
+ "CVCL:N799": [
+  "EFO:0005336"
+ ],
+ "CVCL:7508": [
+  "EFO:0001117"
+ ],
+ "CVCL:9596": [
+  "EFO:0001118"
+ ],
+ "CVCL:9597": [
+  "EFO:0001119"
+ ],
+ "CVCL:9598": [
+  "EFO:0001120"
+ ],
+ "CVCL:7509": [
+  "EFO:0001121"
+ ],
+ "CVCL:9599": [
+  "EFO:0001122"
+ ],
+ "CVCL:7512": [
+  "EFO:0001123"
+ ],
+ "CVCL:7515": [
+  "EFO:0001124"
+ ],
+ "CVCL:7516": [
+  "EFO:0001125"
+ ],
+ "CVCL:7517": [
+  "EFO:0001126"
+ ],
+ "CVCL:9600": [
+  "EFO:0001127"
+ ],
+ "CVCL:9601": [
+  "EFO:0001128"
+ ],
+ "CVCL:9602": [
+  "EFO:0001129"
+ ],
+ "CVCL:9603": [
+  "EFO:0001130"
+ ],
+ "CVCL:7518": [
+  "EFO:0001131"
+ ],
+ "CVCL:9604": [
+  "EFO:0001132"
+ ],
+ "CVCL:9605": [
+  "EFO:0001133"
+ ],
+ "CVCL:7519": [
+  "EFO:0001134"
+ ],
+ "CVCL:7520": [
+  "EFO:0001135"
+ ],
+ "CVCL:9606": [
+  "EFO:0001136"
+ ],
+ "CVCL:7521": [
+  "EFO:0001137"
+ ],
+ "CVCL:9607": [
+  "EFO:0001138"
+ ],
+ "CVCL:9608": [
+  "EFO:0001139"
+ ],
+ "CVCL:7522": [
+  "EFO:0001140"
+ ],
+ "CVCL:9609": [
+  "EFO:0001141"
+ ],
+ "CVCL:9610": [
+  "EFO:0001142"
+ ],
+ "CVCL:9611": [
+  "EFO:0001143"
+ ],
+ "CVCL:9612": [
+  "EFO:0001144"
+ ],
+ "CVCL:9613": [
+  "EFO:0001145"
+ ],
+ "CVCL:9614": [
+  "EFO:0001146"
+ ],
+ "CVCL:9615": [
+  "EFO:0001147"
+ ],
+ "CVCL:9616": [
+  "EFO:0001148"
+ ],
+ "CVCL:9617": [
+  "EFO:0001149"
+ ],
+ "CVCL:7525": [
+  "EFO:0001150"
+ ],
+ "CVCL:9618": [
+  "EFO:0001151"
+ ],
+ "CVCL:9619": [
+  "EFO:0001152"
+ ],
+ "CVCL:9620": [
+  "EFO:0001153"
+ ],
+ "CVCL:9621": [
+  "EFO:0001154"
+ ],
+ "CVCL:L247": [
+  "EFO:0005353"
+ ],
+ "CVCL:9622": [
+  "EFO:0001155"
+ ],
+ "CVCL:9623": [
+  "EFO:0001156"
+ ],
+ "CVCL:9624": [
+  "EFO:0001157"
+ ],
+ "CVCL:9625": [
+  "EFO:0001158"
+ ],
+ "CVCL:L256": [
+  "EFO:0005337"
+ ],
+ "CVCL:L257": [
+  "EFO:0005338"
+ ],
+ "CVCL:L258": [
+  "EFO:0005339"
+ ],
+ "CVCL:L259": [
+  "EFO:0005340"
+ ],
+ "CVCL:L260": [
+  "EFO:0005341"
+ ],
+ "CVCL:L261": [
+  "EFO:0005342"
+ ],
+ "CVCL:L262": [
+  "EFO:0005343"
+ ],
+ "CVCL:L263": [
+  "EFO:0005344"
+ ],
+ "CVCL:9626": [
+  "EFO:0001159"
+ ],
+ "CVCL:9627": [
+  "EFO:0001160"
+ ],
+ "CVCL:9628": [
+  "EFO:0001161"
+ ],
+ "CVCL:9629": [
+  "EFO:0001162"
+ ],
+ "CVCL:7526": [
+  "EFO:0002784"
+ ],
+ "CVCL:9630": [
+  "EFO:0002785"
+ ],
+ "CVCL:9631": [
+  "EFO:0002786"
+ ],
+ "CVCL:L266": [
+  "EFO:0005345"
+ ],
+ "CVCL:L267": [
+  "EFO:0005346"
+ ],
+ "CVCL:N802": [
+  "EFO:0005347"
+ ],
+ "CVCL:U734": [
+  "EFO:0006276"
+ ],
+ "CVCL:N248": [
+  "EFO:0006277"
+ ],
+ "CVCL:N803": [
+  "EFO:0005332"
+ ],
+ "CVCL:9632": [
+  "EFO:0002787"
+ ],
+ "CVCL:E124": [
+  "EFO:0005348"
+ ],
+ "CVCL:N804": [
+  "EFO:0005349"
+ ],
+ "CVCL:E125": [
+  "EFO:0005350"
+ ],
+ "CVCL:E126": [
+  "EFO:0005351"
+ ],
+ "CVCL:9633": [
+  "EFO:0002788"
+ ],
+ "CVCL:9634": [
+  "EFO:0002789"
+ ],
+ "CVCL:9635": [
+  "EFO:0002790"
+ ],
+ "CVCL:Z795": [
+  "EFO:0005747"
+ ],
+ "CVCL:E127": [
+  "EFO:0005352"
+ ],
+ "CVCL:7659": [
+  "EFO:0009317"
+ ],
+ "CVCL:F183": [
+  "EFO:0005723"
+ ],
+ "CVCL:F182": [
+  "EFO:0007950"
+ ],
+ "CVCL:Y803": [
+  "EFO:0009747"
+ ],
+ "CVCL:2450": [
+  "EFO:0006575"
+ ],
+ "CVCL:1235": [
+  "EFO:0006576"
+ ],
+ "CVCL:2451": [
+  "EFO:0006577"
+ ],
+ "CVCL:1818": [
+  "EFO:0005369"
+ ],
+ "CVCL:7668": [
+  "EFO:0006578"
+ ],
+ "CVCL:D048": [
+  "EFO:0002776"
+ ],
+ "CVCL:1239": [
+  "EFO:0002184"
+ ],
+ "CVCL:1240": [
+  "EFO:0003045"
+ ],
+ "CVCL:0038": [
+  "EFO:0002056"
+ ],
+ "CVCL:5G07": [
+  "EFO:0007598"
+ ],
+ "CVCL:4362": [
+  "EFO:0001167"
+ ],
+ "CVCL:0288": [
+  "EFO:0006414"
+ ],
+ "CVCL:0289": [
+  "EFO:0006415"
+ ],
+ "CVCL:3374": [
+  "EFO:0001168"
+ ],
+ "CVCL:1244": [
+  "EFO:0002057"
+ ],
+ "CVCL:V675": [
+  "EFO:0006422"
+ ],
+ "CVCL:1245": [
+  "EFO:0001169"
+ ],
+ "CVCL:9699": [
+  "EFO:0003127"
+ ],
+ "CVCL:V651": [
+  "EFO:0006423"
+ ],
+ "CVCL:5126": [
+  "EFO:0003126"
+ ],
+ "CVCL:1247": [
+  "EFO:0001170"
+ ],
+ "CVCL:5127": [
+  "EFO:0005371"
+ ],
+ "CVCL:V719": [
+  "EFO:0006416"
+ ],
+ "CVCL:V686": [
+  "EFO:0006424"
+ ],
+ "CVCL:V671": [
+  "EFO:0006425"
+ ],
+ "CVCL:5128": [
+  "EFO:0003128"
+ ],
+ "CVCL:1249": [
+  "EFO:0002185"
+ ],
+ "CVCL:1251": [
+  "EFO:0005372"
+ ],
+ "CVCL:1252": [
+  "EFO:0001171"
+ ],
+ "CVCL:V591": [
+  "EFO:0006426"
+ ],
+ "CVCL:V592": [
+  "EFO:0006427"
+ ],
+ "CVCL:2057": [
+  "EFO:0003129"
+ ],
+ "CVCL:1254": [
+  "EFO:0001172"
+ ],
+ "CVCL:V595": [
+  "EFO:0006428"
+ ],
+ "CVCL:1255": [
+  "EFO:0001173"
+ ],
+ "CVCL:V597": [
+  "EFO:0006429"
+ ],
+ "CVCL:1256": [
+  "EFO:0002186"
+ ],
+ "CVCL:1258": [
+  "EFO:0005373"
+ ],
+ "CVCL:5130": [
+  "EFO:0003130"
+ ],
+ "CVCL:0290": [
+  "EFO:0001174"
+ ],
+ "CVCL:1259": [
+  "EFO:0001175"
+ ],
+ "CVCL:2062": [
+  "EFO:0001176"
+ ],
+ "CVCL:1261": [
+  "EFO:0001177"
+ ],
+ "CVCL:3375": [
+  "EFO:0001178"
+ ],
+ "CVCL:1263": [
+  "EFO:0002187"
+ ],
+ "CVCL:V635": [
+  "EFO:0006430"
+ ],
+ "CVCL:5131": [
+  "EFO:0005374",
+  "EFO:0006431"
+ ],
+ "CVCL:V636": [
+  "EFO:0006432"
+ ],
+ "CVCL:3376": [
+  "EFO:0006433"
+ ],
+ "CVCL:V588": [
+  "EFO:0006434"
+ ],
+ "CVCL:0V16": [
+  "EFO:0006435"
+ ],
+ "CVCL:1265": [
+  "EFO:0005375"
+ ],
+ "CVCL:1266": [
+  "EFO:0005370"
+ ],
+ "CVCL:3377": [
+  "EFO:0001179"
+ ],
+ "CVCL:2058": [
+  "EFO:0006417"
+ ],
+ "CVCL:5134": [
+  "EFO:0006420"
+ ],
+ "CVCL:2059": [
+  "EFO:0003131"
+ ],
+ "CVCL:1267": [
+  "EFO:0001180"
+ ],
+ "CVCL:1269": [
+  "EFO:0003132"
+ ],
+ "CVCL:S700": [
+  "EFO:0006436"
+ ],
+ "CVCL:V579": [
+  "EFO:0006437"
+ ],
+ "CVCL:2060": [
+  "EFO:0003133"
+ ],
+ "CVCL:5135": [
+  "EFO:0003134"
+ ],
+ "CVCL:5136": [
+  "EFO:0003135"
+ ],
+ "CVCL:G002": [
+  "EFO:0006418"
+ ],
+ "CVCL:V729": [
+  "EFO:0006421"
+ ],
+ "CVCL:1270": [
+  "EFO:0001181"
+ ],
+ "CVCL:2061": [
+  "EFO:0003136"
+ ],
+ "CVCL:2063": [
+  "EFO:0003137"
+ ],
+ "CVCL:V731": [
+  "EFO:0006419"
+ ],
+ "CVCL:5137": [
+  "EFO:0003138"
+ ],
+ "CVCL:AQ45": [
+  "EFO:0009500"
+ ],
+ "CVCL:AQ47": [
+  "EFO:0009499"
+ ],
+ "CVCL:9700": [
+  "EFO:0003139"
+ ],
+ "CVCL:0292": [
+  "EFO:0002188"
+ ],
+ "CVCL:2478": [
+  "EFO:0002189"
+ ],
+ "CVCL:1273": [
+  "EFO:0002190"
+ ],
+ "CVCL:0293": [
+  "EFO:0002191"
+ ],
+ "CVCL:0294": [
+  "EFO:0002192"
+ ],
+ "CVCL:D123": [
+  "EFO:0001250"
+ ],
+ "CVCL:D124": [
+  "EFO:0001251"
+ ],
+ "CVCL:D125": [
+  "EFO:0001252"
+ ],
+ "CVCL:D122": [
+  "EFO:0001249"
+ ],
+ "CVCL:0045": [
+  "EFO:0001182"
+ ],
+ "CVCL:6643": [
+  "EFO:0001183"
+ ],
+ "CVCL:0063": [
+  "EFO:0001184",
+  "EFO:0001082"
+ ],
+ "CVCL:0001": [
+  "EFO:0006579"
+ ],
+ "CVCL:2481": [
+  "EFO:0002193"
+ ],
+ "CVCL:0058": [
+  "EFO:0002791"
+ ],
+ "CVCL:0326": [
+  "EFO:0002205"
+ ],
+ "CVCL:1906": [
+  "EFO:0006438"
+ ],
+ "CVCL:0027": [
+  "EFO:0001187"
+ ],
+ "CVCL:1098": [
+  "EFO:0002121"
+ ],
+ "CVCL:9720": [
+  "EFO:0001186"
+ ],
+ "CVCL:Y479": [
+  "EFO:0005382"
+ ],
+ "CVCL:D093": [
+  "EFO:0003048"
+ ],
+ "CVCL:0297": [
+  "EFO:0006580"
+ ],
+ "CVCL:VC41": [
+  "EFO:0009318"
+ ],
+ "CVCL:Y511": [
+  "EFO:0005710"
+ ],
+ "CVCL:C969": [
+  "EFO:0007951"
+ ],
+ "CVCL:C970": [
+  "EFO:0007111"
+ ],
+ "CVCL:0298": [
+  "EFO:0005368"
+ ],
+ "CVCL:1Y92": [
+  "EFO:0005909"
+ ],
+ "CVCL:1279": [
+  "EFO:0006581"
+ ],
+ "CVCL:1280": [
+  "EFO:0002194"
+ ],
+ "CVCL:3317": [
+  "EFO:0002195"
+ ],
+ "CVCL:0307": [
+  "EFO:0005383"
+ ],
+ "CVCL:U508": [
+  "EFO:0007601"
+ ],
+ "CVCL:2499": [
+  "EFO:0001191"
+ ],
+ "CVCL:2950": [
+  "EFO:0006582"
+ ],
+ "CVCL:2071": [
+  "EFO:0006583"
+ ],
+ "CVCL:1285": [
+  "EFO:0006439"
+ ],
+ "CVCL:1286": [
+  "EFO:0006440"
+ ],
+ "CVCL:0312": [
+  "EFO:0002196"
+ ],
+ "CVCL:3517": [
+  "EFO:0002197"
+ ],
+ "CVCL:0313": [
+  "EFO:0002198"
+ ],
+ "CVCL:1Y73": [
+  "EFO:0006280"
+ ],
+ "CVCL:S972": [
+  "EFO:0005711"
+ ],
+ "CVCL:9863": [
+  "EFO:0006907"
+ ],
+ "CVCL:9864": [
+  "EFO:0002705"
+ ],
+ "CVCL:9865": [
+  "EFO:0006908"
+ ],
+ "CVCL:8880": [
+  "EFO:0006909"
+ ],
+ "CVCL:9866": [
+  "EFO:0006910"
+ ],
+ "CVCL:0707": [
+  "EFO:0006584"
+ ],
+ "CVCL:0331": [
+  "EFO:0006585"
+ ],
+ "CVCL:0735": [
+  "EFO:0006586"
+ ],
+ "CVCL:0332": [
+  "EFO:0001192"
+ ],
+ "CVCL:0836": [
+  "EFO:0006587"
+ ],
+ "CVCL:0844": [
+  "EFO:0006441"
+ ],
+ "CVCL:0851": [
+  "EFO:0006588"
+ ],
+ "CVCL:0333": [
+  "EFO:0006589"
+ ],
+ "CVCL:0334": [
+  "EFO:0006590"
+ ],
+ "CVCL:0941": [
+  "EFO:0006591"
+ ],
+ "CVCL:0950": [
+  "EFO:0006592"
+ ],
+ "CVCL:0993": [
+  "EFO:0006593"
+ ],
+ "CVCL:1033": [
+  "EFO:0006594"
+ ],
+ "CVCL:1038": [
+  "EFO:0006595"
+ ],
+ "CVCL:3719": [
+  "EFO:0005283"
+ ],
+ "CVCL:3720": [
+  "EFO:0005282"
+ ],
+ "CVCL:2516": [
+  "EFO:0002199"
+ ],
+ "CVCL:1290": [
+  "EFO:0002200"
+ ],
+ "CVCL:0317": [
+  "EFO:0002059"
+ ],
+ "CVCL:1291": [
+  "EFO:0002202"
+ ],
+ "CVCL:1292": [
+  "EFO:0002203"
+ ],
+ "CVCL:0318": [
+  "EFO:0006443"
+ ],
+ "CVCL:1293": [
+  "EFO:0002204"
+ ],
+ "CVCL:1294": [
+  "EFO:0006444"
+ ],
+ "CVCL:2520": [
+  "EFO:0006442"
+ ],
+ "CVCL:S888": [
+  "EFO:0005912"
+ ],
+ "CVCL:7162": [
+  "EFO:0005709"
+ ],
+ "CVCL:B139": [
+  "EFO:0005355"
+ ],
+ "CVCL:B143": [
+  "EFO:0007078"
+ ],
+ "CVCL:B159": [
+  "EFO:0007079"
+ ],
+ "CVCL:B161": [
+  "EFO:0007080"
+ ],
+ "CVCL:B177": [
+  "EFO:0007081"
+ ],
+ "CVCL:B178": [
+  "EFO:0007082"
+ ],
+ "CVCL:B181": [
+  "EFO:0007083"
+ ],
+ "CVCL:B182": [
+  "EFO:0007084"
+ ],
+ "CVCL:B187": [
+  "EFO:0007085"
+ ],
+ "CVCL:B194": [
+  "EFO:0007086"
+ ],
+ "CVCL:B197": [
+  "EFO:0007087"
+ ],
+ "CVCL:B198": [
+  "EFO:0007088"
+ ],
+ "CVCL:B199": [
+  "EFO:0007089"
+ ],
+ "CVCL:B200": [
+  "EFO:0007091"
+ ],
+ "CVCL:B201": [
+  "EFO:0007092"
+ ],
+ "CVCL:B207": [
+  "EFO:0007093"
+ ],
+ "CVCL:0057": [
+  "EFO:0007094"
+ ],
+ "CVCL:2956": [
+  "EFO:0006445"
+ ],
+ "CVCL:0336": [
+  "EFO:0005384"
+ ],
+ "CVCL:7927": [
+  "EFO:0005704"
+ ],
+ "CVCL:2526": [
+  "EFO:0002207"
+ ],
+ "CVCL:1299": [
+  "EFO:0006596"
+ ],
+ "CVCL:1300": [
+  "EFO:0002208"
+ ],
+ "CVCL:0337": [
+  "EFO:0002209"
+ ],
+ "CVCL:C376": [
+  "EFO:0007076"
+ ],
+ "CVCL:0338": [
+  "EFO:0001194"
+ ],
+ "CVCL:9639": [
+  "EFO:0002060"
+ ],
+ "CVCL:2075": [
+  "EFO:0006597"
+ ],
+ "CVCL:1304": [
+  "EFO:0005385"
+ ],
+ "CVCL:2961": [
+  "EFO:0006446"
+ ],
+ "CVCL:2962": [
+  "EFO:0006598"
+ ],
+ "CVCL:0346": [
+  "EFO:0001195"
+ ],
+ "CVCL:0347": [
+  "EFO:0001196"
+ ],
+ "CVCL:5209": [
+  "EFO:0005386"
+ ],
+ "CVCL:0352": [
+  "EFO:0002529"
+ ],
+ "CVCL:1307": [
+  "EFO:0006447"
+ ],
+ "CVCL:W123": [
+  "EFO:0009501"
+ ],
+ "CVCL:W121": [
+  "EFO:0007952"
+ ],
+ "CVCL:W122": [
+  "EFO:0007953"
+ ],
+ "CVCL:K054": [
+  "EFO:0007096"
+ ],
+ "CVCL:K055": [
+  "EFO:0007095"
+ ],
+ "CVCL:K056": [
+  "EFO:0007097"
+ ],
+ "CVCL:4T90": [
+  "EFO:0007098"
+ ],
+ "CVCL:2529": [
+  "EFO:0005718"
+ ],
+ "CVCL:U244": [
+  "EFO:0002061"
+ ],
+ "CVCL:U245": [
+  "EFO:0002062"
+ ],
+ "CVCL:U246": [
+  "EFO:0002063"
+ ],
+ "CVCL:U247": [
+  "EFO:0002064"
+ ],
+ "CVCL:U243": [
+  "EFO:0002065"
+ ],
+ "CVCL:1316": [
+  "EFO:0002213"
+ ],
+ "CVCL:6412": [
+  "EFO:0004990"
+ ],
+ "CVCL:Y501": [
+  "EFO:0005486"
+ ],
+ "CVCL:0359": [
+  "EFO:0002210"
+ ],
+ "CVCL:0360": [
+  "EFO:0002211"
+ ],
+ "CVCL:0363": [
+  "EFO:0002066"
+ ],
+ "CVCL:1865": [
+  "EFO:0005387"
+ ],
+ "CVCL:2785": [
+  "EFO:0006599"
+ ],
+ "CVCL:2786": [
+  "EFO:0006600"
+ ],
+ "CVCL:2787": [
+  "EFO:0006601"
+ ],
+ "CVCL:0364": [
+  "EFO:0006602"
+ ],
+ "CVCL:2805": [
+  "EFO:0006603"
+ ],
+ "CVCL:2077": [
+  "EFO:0005388"
+ ],
+ "CVCL:1Y74": [
+  "EFO:0006281"
+ ],
+ "CVCL:1317": [
+  "EFO:0002215"
+ ],
+ "CVCL:D605": [
+  "EFO:0006604"
+ ],
+ "CVCL:2078": [
+  "EFO:0006605"
+ ],
+ "CVCL:2080": [
+  "EFO:0006448"
+ ],
+ "CVCL:3532": [
+  "EFO:0002212"
+ ],
+ "CVCL:1319": [
+  "EFO:0005476"
+ ],
+ "CVCL:1320": [
+  "EFO:0002214"
+ ],
+ "CVCL:1821": [
+  "EFO:0006606"
+ ],
+ "CVCL:1822": [
+  "EFO:0005389"
+ ],
+ "CVCL:1324": [
+  "EFO:0005390"
+ ],
+ "CVCL:1325": [
+  "EFO:0005719"
+ ],
+ "CVCL:1823": [
+  "EFO:0006449"
+ ],
+ "CVCL:0589": [
+  "EFO:0006607"
+ ],
+ "CVCL:0590": [
+  "EFO:0002224"
+ ],
+ "CVCL:0371": [
+  "EFO:0002217"
+ ],
+ "CVCL:A426": [
+  "EFO:0005903"
+ ],
+ "CVCL:Z833": [
+  "EFO:0002068"
+ ],
+ "CVCL:Z834": [
+  "EFO:0005819"
+ ],
+ "CVCL:2090": [
+  "EFO:0006608"
+ ],
+ "CVCL:2092": [
+  "EFO:0002069"
+ ],
+ "CVCL:0374": [
+  "EFO:0002218"
+ ],
+ "CVCL:2972": [
+  "EFO:0006609"
+ ],
+ "CVCL:2544": [
+  "EFO:0002219"
+ ],
+ "CVCL:Y515": [
+  "EFO:0002712"
+ ],
+ "CVCL:1329": [
+  "EFO:0002220"
+ ],
+ "CVCL:5146": [
+  "EFO:0006610"
+ ],
+ "CVCL:1331": [
+  "EFO:0006282"
+ ],
+ "CVCL:2981": [
+  "EFO:0006611"
+ ],
+ "CVCL:2989": [
+  "EFO:0005694"
+ ],
+ "CVCL:1334": [
+  "EFO:0006612"
+ ],
+ "CVCL:1333": [
+  "EFO:0006613"
+ ],
+ "CVCL:2991": [
+  "EFO:0006614"
+ ],
+ "CVCL:2992": [
+  "EFO:0006615"
+ ],
+ "CVCL:2993": [
+  "EFO:0006616"
+ ],
+ "CVCL:2994": [
+  "EFO:0006617"
+ ],
+ "CVCL:2995": [
+  "EFO:0006618"
+ ],
+ "CVCL:2996": [
+  "EFO:0006619"
+ ],
+ "CVCL:1335": [
+  "EFO:0006620"
+ ],
+ "CVCL:4965": [
+  "EFO:0006283"
+ ],
+ "CVCL:3004": [
+  "EFO:0006621"
+ ],
+ "CVCL:3005": [
+  "EFO:0006622"
+ ],
+ "CVCL:1338": [
+  "EFO:0006623"
+ ],
+ "CVCL:2094": [
+  "EFO:0002221"
+ ],
+ "CVCL:5310": [
+  "EFO:0006624"
+ ],
+ "CVCL:9805": [
+  "EFO:0002826"
+ ],
+ "CVCL:0379": [
+  "EFO:0002222"
+ ],
+ "CVCL:1345": [
+  "EFO:0006625"
+ ],
+ "CVCL:1347": [
+  "EFO:0006626"
+ ],
+ "CVCL:1348": [
+  "EFO:0006627"
+ ],
+ "CVCL:1349": [
+  "EFO:0006628"
+ ],
+ "CVCL:1350": [
+  "EFO:0006629"
+ ],
+ "CVCL:1351": [
+  "EFO:0002223"
+ ],
+ "CVCL:1353": [
+  "EFO:0006630"
+ ],
+ "CVCL:1354": [
+  "EFO:0006631"
+ ],
+ "CVCL:1355": [
+  "EFO:0006632"
+ ],
+ "CVCL:1356": [
+  "EFO:0006633"
+ ],
+ "CVCL:1357": [
+  "EFO:0006450"
+ ],
+ "CVCL:1361": [
+  "EFO:0002225"
+ ],
+ "CVCL:AV88": [
+  "EFO:0007599"
+ ],
+ "CVCL:AV89": [
+  "EFO:0007600"
+ ],
+ "CVCL:9668": [
+  "EFO:0001198"
+ ],
+ "CVCL:1827": [
+  "EFO:0005391"
+ ],
+ "CVCL:4744": [
+  "EFO:0005392"
+ ],
+ "CVCL:4746": [
+  "EFO:0005393"
+ ],
+ "CVCL:0398": [
+  "EFO:0002070"
+ ],
+ "CVCL:1372": [
+  "EFO:0002827"
+ ],
+ "CVCL:1373": [
+  "EFO:0003140"
+ ],
+ "CVCL:1375": [
+  "EFO:0006634"
+ ],
+ "CVCL:1376": [
+  "EFO:0006635"
+ ],
+ "CVCL:8890": [
+  "EFO:0005714"
+ ],
+ "CVCL:1377": [
+  "EFO:0003141"
+ ],
+ "CVCL:0392": [
+  "EFO:0006636"
+ ],
+ "CVCL:0393": [
+  "EFO:0006637"
+ ],
+ "CVCL:0395": [
+  "EFO:0002071"
+ ],
+ "CVCL:4784": [
+  "EFO:0006365"
+ ],
+ "CVCL:1379": [
+  "EFO:0005726"
+ ],
+ "CVCL:2104": [
+  "EFO:0006638"
+ ],
+ "CVCL:1380": [
+  "EFO:0007112"
+ ],
+ "CVCL:0399": [
+  "EFO:0006639"
+ ],
+ "CVCL:1381": [
+  "EFO:0006284"
+ ],
+ "CVCL:0012": [
+  "EFO:0003055"
+ ],
+ "CVCL:1382": [
+  "EFO:0002226"
+ ],
+ "CVCL:1384": [
+  "EFO:0002227"
+ ],
+ "CVCL:6670": [
+  "EFO:0006787"
+ ],
+ "CVCL:0397": [
+  "EFO:0006640"
+ ],
+ "CVCL:6862": [
+  "EFO:0003142"
+ ],
+ "CVCL:1389": [
+  "EFO:0002828"
+ ],
+ "CVCL:1394": [
+  "EFO:0006641"
+ ],
+ "CVCL:D085": [
+  "EFO:0006642"
+ ],
+ "CVCL:0400": [
+  "EFO:0005697"
+ ],
+ "CVCL:0401": [
+  "EFO:0006451"
+ ],
+ "CVCL:1395": [
+  "EFO:0003056"
+ ],
+ "CVCL:3486": [
+  "EFO:0002107"
+ ],
+ "CVCL:1438": [
+  "EFO:0002243"
+ ],
+ "CVCL:Z706": [
+  "EFO:0005820"
+ ],
+ "CVCL:1397": [
+  "EFO:0002229"
+ ],
+ "CVCL:1399": [
+  "EFO:0002228"
+ ],
+ "CVCL:3020": [
+  "EFO:0006453"
+ ],
+ "CVCL:0598": [
+  "EFO:0001200"
+ ],
+ "CVCL:3744": [
+  "EFO:0001202"
+ ],
+ "CVCL:9579": [
+  "EFO:0001199"
+ ],
+ "CVCL:9580": [
+  "EFO:0002072"
+ ],
+ "CVCL:5552": [
+  "EFO:0006643"
+ ],
+ "CVCL:0617": [
+  "EFO:0001205"
+ ],
+ "CVCL:0618": [
+  "EFO:0001206"
+ ],
+ "CVCL:1400": [
+  "EFO:0001208"
+ ],
+ "CVCL:0062": [
+  "EFO:0001209"
+ ],
+ "CVCL:0619": [
+  "EFO:0006454"
+ ],
+ "CVCL:0620": [
+  "EFO:0001211"
+ ],
+ "CVCL:0621": [
+  "EFO:0001212"
+ ],
+ "CVCL:0417": [
+  "EFO:0001213"
+ ],
+ "CVCL:0623": [
+  "EFO:0001214"
+ ],
+ "CVCL:0418": [
+  "EFO:0001215"
+ ],
+ "CVCL:0419": [
+  "EFO:0001216"
+ ],
+ "CVCL:4542": [
+  "EFO:0002659"
+ ],
+ "CVCL:2588": [
+  "EFO:0006644"
+ ],
+ "CVCL:2110": [
+  "EFO:0006645"
+ ],
+ "CVCL:1401": [
+  "EFO:0006646"
+ ],
+ "CVCL:1870": [
+  "EFO:0002231"
+ ],
+ "CVCL:1871": [
+  "EFO:0006285"
+ ],
+ "CVCL:0425": [
+  "EFO:0002232"
+ ],
+ "CVCL:C694": [
+  "EFO:0006360"
+ ],
+ "CVCL:1402": [
+  "EFO:0006647"
+ ],
+ "CVCL:L268": [
+  "EFO:0005706"
+ ],
+ "CVCL:2111": [
+  "EFO:0003971"
+ ],
+ "CVCL:Y480": [
+  "EFO:0005480"
+ ],
+ "CVCL:0V14": [
+  "EFO:0006356"
+ ],
+ "CVCL:1404": [
+  "EFO:0002233"
+ ],
+ "CVCL:3749": [
+  "EFO:0001218"
+ ],
+ "CVCL:0445": [
+  "EFO:0006648"
+ ],
+ "CVCL:1408": [
+  "EFO:0006649"
+ ],
+ "CVCL:0426": [
+  "EFO:0002234"
+ ],
+ "CVCL:5334": [
+  "EFO:0006286"
+ ],
+ "CVCL:1411": [
+  "EFO:0006650"
+ ],
+ "CVCL:1412": [
+  "EFO:0006651"
+ ],
+ "CVCL:1413": [
+  "EFO:0002235"
+ ],
+ "CVCL:0428": [
+  "EFO:0002236"
+ ],
+ "CVCL:0429": [
+  "EFO:0002073"
+ ],
+ "CVCL:0431": [
+  "EFO:0002829"
+ ],
+ "CVCL:1414": [
+  "EFO:0002237"
+ ],
+ "CVCL:1415": [
+  "EFO:0002830"
+ ],
+ "CVCL:1416": [
+  "EFO:0002831"
+ ],
+ "CVCL:0434": [
+  "EFO:0002832"
+ ],
+ "CVCL:1417": [
+  "EFO:0002895"
+ ],
+ "CVCL:2791": [
+  "EFO:0002834"
+ ],
+ "CVCL:1418": [
+  "EFO:0002238"
+ ],
+ "CVCL:Z857": [
+  "EFO:0005821"
+ ],
+ "CVCL:Z719": [
+  "EFO:0005822"
+ ],
+ "CVCL:Z728": [
+  "EFO:0005823"
+ ],
+ "CVCL:Z738": [
+  "EFO:0005824"
+ ],
+ "CVCL:Z766": [
+  "EFO:0005825"
+ ],
+ "CVCL:Z772": [
+  "EFO:0005826"
+ ],
+ "CVCL:Z774": [
+  "EFO:0005827"
+ ],
+ "CVCL:Z776": [
+  "EFO:0005828"
+ ],
+ "CVCL:Z744": [
+  "EFO:0005829"
+ ],
+ "CVCL:Z745": [
+  "EFO:0007113"
+ ],
+ "CVCL:Z780": [
+  "EFO:0007114"
+ ],
+ "CVCL:Z749": [
+  "EFO:0005830"
+ ],
+ "CVCL:Z784": [
+  "EFO:0005831"
+ ],
+ "CVCL:Z754": [
+  "EFO:0005832"
+ ],
+ "CVCL:Z755": [
+  "EFO:0005833"
+ ],
+ "CVCL:M098": [
+  "EFO:0005394"
+ ],
+ "CVCL:5801": [
+  "EFO:0001219"
+ ],
+ "CVCL:8792": [
+  "EFO:0005724"
+ ],
+ "CVCL:M067": [
+  "EFO:0006455"
+ ],
+ "CVCL:0439": [
+  "EFO:0002866"
+ ],
+ "CVCL:2120": [
+  "EFO:0006652"
+ ],
+ "CVCL:2123": [
+  "EFO:0006653"
+ ],
+ "CVCL:2124": [
+  "EFO:0006654"
+ ],
+ "CVCL:1424": [
+  "EFO:0002239"
+ ],
+ "CVCL:0624": [
+  "EFO:0005265"
+ ],
+ "CVCL:0013": [
+  "EFO:0001220"
+ ],
+ "CVCL:1426": [
+  "EFO:0006287"
+ ],
+ "CVCL:2618": [
+  "EFO:0006655"
+ ],
+ "CVCL:2G62": [
+  "EFO:0006656"
+ ],
+ "CVCL:0440": [
+  "EFO:0002835"
+ ],
+ "CVCL:1429": [
+  "EFO:0002836"
+ ],
+ "CVCL:9835": [
+  "EFO:0002837"
+ ],
+ "CVCL:9836": [
+  "EFO:0002838"
+ ],
+ "CVCL:4996": [
+  "EFO:0006456"
+ ],
+ "CVCL:WJ18": [
+  "EFO:0009498"
+ ],
+ "CVCL:WJ17": [
+  "EFO:0009497"
+ ],
+ "CVCL:1430": [
+  "EFO:0002839"
+ ],
+ "CVCL:2129": [
+  "EFO:0002241"
+ ],
+ "CVCL:1433": [
+  "EFO:0005395"
+ ],
+ "CVCL:0064": [
+  "EFO:0002242"
+ ],
+ "CVCL:4774": [
+  "EFO:0006457"
+ ],
+ "CVCL:0091": [
+  "EFO:0002244"
+ ],
+ "CVCL:0092": [
+  "EFO:0002245"
+ ],
+ "CVCL:0067": [
+  "EFO:0002246"
+ ],
+ "CVCL:0005": [
+  "EFO:0002798"
+ ],
+ "CVCL:3042": [
+  "EFO:0002247"
+ ],
+ "CVCL:1874": [
+  "EFO:0007115"
+ ],
+ "CVCL:N739": [
+  "EFO:0006395"
+ ],
+ "CVCL:N740": [
+  "EFO:0006396"
+ ],
+ "CVCL:N741": [
+  "EFO:0006397"
+ ],
+ "CVCL:N742": [
+  "EFO:0006398"
+ ],
+ "CVCL:N743": [
+  "EFO:0006399"
+ ],
+ "CVCL:N744": [
+  "EFO:0006400"
+ ],
+ "CVCL:N746": [
+  "EFO:0006401"
+ ],
+ "CVCL:N747": [
+  "EFO:0006402"
+ ],
+ "CVCL:N748": [
+  "EFO:0006403"
+ ],
+ "CVCL:N749": [
+  "EFO:0006404"
+ ],
+ "CVCL:N750": [
+  "EFO:0006405"
+ ],
+ "CVCL:N723": [
+  "EFO:0006406"
+ ],
+ "CVCL:0V15": [
+  "EFO:0006407"
+ ],
+ "CVCL:N727": [
+  "EFO:0006408"
+ ],
+ "CVCL:N729": [
+  "EFO:0006409"
+ ],
+ "CVCL:N731": [
+  "EFO:0006410"
+ ],
+ "CVCL:N735": [
+  "EFO:0006411"
+ ],
+ "CVCL:N736": [
+  "EFO:0006412"
+ ],
+ "CVCL:1453": [
+  "EFO:0002248"
+ ],
+ "CVCL:1454": [
+  "EFO:0002249"
+ ],
+ "CVCL:1456": [
+  "EFO:0002250"
+ ],
+ "CVCL:3968": [
+  "EFO:0003116"
+ ],
+ "CVCL:0060": [
+  "EFO:0003043"
+ ],
+ "CVCL:3971": [
+  "EFO:0003117"
+ ],
+ "CVCL:1464": [
+  "EFO:0002251"
+ ],
+ "CVCL:1465": [
+  "EFO:0006657"
+ ],
+ "CVCL:1467": [
+  "EFO:0002252"
+ ],
+ "CVCL:1470": [
+  "EFO:0006658"
+ ],
+ "CVCL:1471": [
+  "EFO:0002253"
+ ],
+ "CVCL:1472": [
+  "EFO:0002254"
+ ],
+ "CVCL:1473": [
+  "EFO:0006659"
+ ],
+ "CVCL:1475": [
+  "EFO:0002255"
+ ],
+ "CVCL:1476": [
+  "EFO:0006660"
+ ],
+ "CVCL:0463": [
+  "EFO:0003118"
+ ],
+ "CVCL:1478": [
+  "EFO:0002256"
+ ],
+ "CVCL:1479": [
+  "EFO:0002257"
+ ],
+ "CVCL:1480": [
+  "EFO:0002258"
+ ],
+ "CVCL:1481": [
+  "EFO:0002259"
+ ],
+ "CVCL:1482": [
+  "EFO:0003119"
+ ],
+ "CVCL:1483": [
+  "EFO:0002260"
+ ],
+ "CVCL:1484": [
+  "EFO:0002261"
+ ],
+ "CVCL:1485": [
+  "EFO:0002262"
+ ],
+ "CVCL:1488": [
+  "EFO:0006661"
+ ],
+ "CVCL:1489": [
+  "EFO:0002263"
+ ],
+ "CVCL:1490": [
+  "EFO:0002264"
+ ],
+ "CVCL:1491": [
+  "EFO:0006662"
+ ],
+ "CVCL:1493": [
+  "EFO:0002265"
+ ],
+ "CVCL:1494": [
+  "EFO:0006663"
+ ],
+ "CVCL:1495": [
+  "EFO:0002266"
+ ],
+ "CVCL:1496": [
+  "EFO:0002267"
+ ],
+ "CVCL:1499": [
+  "EFO:0002268"
+ ],
+ "CVCL:1500": [
+  "EFO:0006664"
+ ],
+ "CVCL:1501": [
+  "EFO:0002269"
+ ],
+ "CVCL:1504": [
+  "EFO:0006665"
+ ],
+ "CVCL:1505": [
+  "EFO:0006666"
+ ],
+ "CVCL:1507": [
+  "EFO:0002270"
+ ],
+ "CVCL:1508": [
+  "EFO:0006667"
+ ],
+ "CVCL:1509": [
+  "EFO:0006668"
+ ],
+ "CVCL:1511": [
+  "EFO:0002271"
+ ],
+ "CVCL:1512": [
+  "EFO:0002272"
+ ],
+ "CVCL:1514": [
+  "EFO:0002273"
+ ],
+ "CVCL:1515": [
+  "EFO:0006669"
+ ],
+ "CVCL:1517": [
+  "EFO:0002274"
+ ],
+ "CVCL:1518": [
+  "EFO:0002275"
+ ],
+ "CVCL:1521": [
+  "EFO:0006670"
+ ],
+ "CVCL:1522": [
+  "EFO:0002276"
+ ],
+ "CVCL:1524": [
+  "EFO:0002277"
+ ],
+ "CVCL:1525": [
+  "EFO:0006671"
+ ],
+ "CVCL:1526": [
+  "EFO:0006672"
+ ],
+ "CVCL:1527": [
+  "EFO:0002278"
+ ],
+ "CVCL:1530": [
+  "EFO:0006673"
+ ],
+ "CVCL:1531": [
+  "EFO:0002279"
+ ],
+ "CVCL:1532": [
+  "EFO:0002280"
+ ],
+ "CVCL:1533": [
+  "EFO:0006674"
+ ],
+ "CVCL:1535": [
+  "EFO:0002281"
+ ],
+ "CVCL:1536": [
+  "EFO:0002282"
+ ],
+ "CVCL:1537": [
+  "EFO:0006675"
+ ],
+ "CVCL:1538": [
+  "EFO:0002283"
+ ],
+ "CVCL:1539": [
+  "EFO:0006676"
+ ],
+ "CVCL:1540": [
+  "EFO:0006677"
+ ],
+ "CVCL:1543": [
+  "EFO:0002284"
+ ],
+ "CVCL:1544": [
+  "EFO:0002285"
+ ],
+ "CVCL:9642": [
+  "EFO:0003120"
+ ],
+ "CVCL:9643": [
+  "EFO:0003121"
+ ],
+ "CVCL:9644": [
+  "EFO:0003122"
+ ],
+ "CVCL:1547": [
+  "EFO:0002286"
+ ],
+ "CVCL:1550": [
+  "EFO:0002287"
+ ],
+ "CVCL:A532": [
+  "EFO:0006678"
+ ],
+ "CVCL:A533": [
+  "EFO:0006679"
+ ],
+ "CVCL:1551": [
+  "EFO:0002288"
+ ],
+ "CVCL:1553": [
+  "EFO:0006680"
+ ],
+ "CVCL:A536": [
+  "EFO:0006681"
+ ],
+ "CVCL:A545": [
+  "EFO:0006682"
+ ],
+ "CVCL:A546": [
+  "EFO:0006683"
+ ],
+ "CVCL:U994": [
+  "EFO:0006684"
+ ],
+ "CVCL:U996": [
+  "EFO:0006685"
+ ],
+ "CVCL:1555": [
+  "EFO:0006686"
+ ],
+ "CVCL:U997": [
+  "EFO:0006687"
+ ],
+ "CVCL:U998": [
+  "EFO:0006688"
+ ],
+ "CVCL:U999": [
+  "EFO:0006689"
+ ],
+ "CVCL:0455": [
+  "EFO:0006690"
+ ],
+ "CVCL:0458": [
+  "EFO:0002289"
+ ],
+ "CVCL:1556": [
+  "EFO:0006691"
+ ],
+ "CVCL:6831": [
+  "EFO:0003123"
+ ],
+ "CVCL:1558": [
+  "EFO:0006692"
+ ],
+ "CVCL:1559": [
+  "EFO:0002291"
+ ],
+ "CVCL:1561": [
+  "EFO:0002292"
+ ],
+ "CVCL:1562": [
+  "EFO:0002293"
+ ],
+ "CVCL:0459": [
+  "EFO:0003044"
+ ],
+ "CVCL:1564": [
+  "EFO:0002294"
+ ],
+ "CVCL:1565": [
+  "EFO:0006693"
+ ],
+ "CVCL:1566": [
+  "EFO:0003124"
+ ],
+ "CVCL:1567": [
+  "EFO:0002295"
+ ],
+ "CVCL:1568": [
+  "EFO:0002296"
+ ],
+ "CVCL:1571": [
+  "EFO:0006694"
+ ],
+ "CVCL:1572": [
+  "EFO:0002297"
+ ],
+ "CVCL:1575": [
+  "EFO:0002298"
+ ],
+ "CVCL:1577": [
+  "EFO:0002299"
+ ],
+ "CVCL:1579": [
+  "EFO:0002300"
+ ],
+ "CVCL:1581": [
+  "EFO:0002301"
+ ],
+ "CVCL:1583": [
+  "EFO:0001166",
+  "EFO:0002302"
+ ],
+ "CVCL:1584": [
+  "EFO:0006695"
+ ],
+ "CVCL:1587": [
+  "EFO:0002303"
+ ],
+ "CVCL:1588": [
+  "EFO:0002304"
+ ],
+ "CVCL:1590": [
+  "EFO:0002305"
+ ],
+ "CVCL:1591": [
+  "EFO:0002306"
+ ],
+ "CVCL:1592": [
+  "EFO:0003125"
+ ],
+ "CVCL:1594": [
+  "EFO:0002307"
+ ],
+ "CVCL:1596": [
+  "EFO:0006696"
+ ],
+ "CVCL:1598": [
+  "EFO:0006697"
+ ],
+ "CVCL:1599": [
+  "EFO:0006698"
+ ],
+ "CVCL:1600": [
+  "EFO:0001221"
+ ],
+ "CVCL:A788": [
+  "EFO:0002840"
+ ],
+ "CVCL:1603": [
+  "EFO:0002841"
+ ],
+ "CVCL:2G73": [
+  "EFO:0006699"
+ ],
+ "CVCL:3407": [
+  "EFO:0005236"
+ ],
+ "CVCL:0034": [
+  "EFO:0002959"
+ ],
+ "CVCL:1877": [
+  "EFO:0006700"
+ ],
+ "CVCL:1611": [
+  "EFO:0006701"
+ ],
+ "CVCL:1612": [
+  "EFO:0006702"
+ ],
+ "CVCL:3082": [
+  "EFO:0006703"
+ ],
+ "CVCL:1614": [
+  "EFO:0006704"
+ ],
+ "CVCL:1615": [
+  "EFO:0006705"
+ ],
+ "CVCL:1619": [
+  "EFO:0006706"
+ ],
+ "CVCL:1844": [
+  "EFO:0006289"
+ ],
+ "CVCL:1620": [
+  "EFO:0006707"
+ ],
+ "CVCL:1879": [
+  "EFO:0005907"
+ ],
+ "CVCL:8795": [
+  "EFO:0006708"
+ ],
+ "CVCL:1878": [
+  "EFO:0006709"
+ ],
+ "CVCL:8800": [
+  "EFO:0006710"
+ ],
+ "CVCL:1881": [
+  "EFO:0006711"
+ ],
+ "CVCL:2149": [
+  "EFO:0006712"
+ ],
+ "CVCL:2150": [
+  "EFO:0006713"
+ ],
+ "CVCL:3084": [
+  "EFO:0006714"
+ ],
+ "CVCL:1622": [
+  "EFO:0002308"
+ ],
+ "CVCL:2661": [
+  "EFO:0002309"
+ ],
+ "CVCL:0471": [
+  "EFO:0002310"
+ ],
+ "CVCL:9815": [
+  "EFO:0006715"
+ ],
+ "CVCL:1625": [
+  "EFO:0006716"
+ ],
+ "CVCL:IY73": [
+  "EFO:0005834"
+ ],
+ "CVCL:1B46": [
+  "EFO:0005835"
+ ],
+ "CVCL:3088": [
+  "EFO:0006717"
+ ],
+ "CVCL:3768": [
+  "EFO:0002311"
+ ],
+ "CVCL:2673": [
+  "EFO:0006458"
+ ],
+ "CVCL:2675": [
+  "EFO:0006459"
+ ],
+ "CVCL:3935": [
+  "EFO:0006720"
+ ],
+ "CVCL:3936": [
+  "EFO:0006721"
+ ],
+ "CVCL:3769": [
+  "EFO:0006722"
+ ],
+ "CVCL:0475": [
+  "EFO:0006723"
+ ],
+ "CVCL:0465": [
+  "EFO:0003061"
+ ],
+ "CVCL:1627": [
+  "EFO:0005442"
+ ],
+ "CVCL:1628": [
+  "EFO:0005443"
+ ],
+ "CVCL:1629": [
+  "EFO:0005444"
+ ],
+ "CVCL:3116": [
+  "EFO:0006724"
+ ],
+ "CVCL:3110": [
+  "EFO:0006725"
+ ],
+ "CVCL:3111": [
+  "EFO:0006726"
+ ],
+ "CVCL:3114": [
+  "EFO:0006727"
+ ],
+ "CVCL:3117": [
+  "EFO:0006728"
+ ],
+ "CVCL:2676": [
+  "EFO:0002312"
+ ],
+ "CVCL:0479": [
+  "EFO:0006465"
+ ],
+ "CVCL:5853": [
+  "EFO:0001224"
+ ],
+ "CVCL:1633": [
+  "EFO:0006466"
+ ],
+ "CVCL:1635": [
+  "EFO:0006467"
+ ],
+ "CVCL:1636": [
+  "EFO:0006468"
+ ],
+ "CVCL:1637": [
+  "EFO:0006469"
+ ],
+ "CVCL:1638": [
+  "EFO:0006470"
+ ],
+ "CVCL:0480": [
+  "EFO:0002713"
+ ],
+ "CVCL:4012": [
+  "EFO:0002715"
+ ],
+ "CVCL:Y494": [
+  "EFO:0005481"
+ ],
+ "CVCL:1845": [
+  "EFO:0006729"
+ ],
+ "CVCL:1846": [
+  "EFO:0006730"
+ ],
+ "CVCL:1847": [
+  "EFO:0005713"
+ ],
+ "CVCL:S978": [
+  "EFO:0002842"
+ ],
+ "CVCL:7088": [
+  "EFO:0002843"
+ ],
+ "CVCL:1640": [
+  "EFO:0002844"
+ ],
+ "CVCL:0035": [
+  "EFO:0002074"
+ ],
+ "CVCL:C002": [
+  "EFO:0002845"
+ ],
+ "CVCL:A786": [
+  "EFO:0002846"
+ ],
+ "CVCL:B260": [
+  "EFO:0002847"
+ ],
+ "CVCL:2678": [
+  "EFO:0006733"
+ ],
+ "CVCL:9583": [
+  "EFO:0002075"
+ ],
+ "CVCL:2686": [
+  "EFO:0005445"
+ ],
+ "CVCL:2687": [
+  "EFO:0005446"
+ ],
+ "CVCL:2689": [
+  "EFO:0005447"
+ ],
+ "CVCL:2690": [
+  "EFO:0005448"
+ ],
+ "CVCL:2691": [
+  "EFO:0005449"
+ ],
+ "CVCL:3326": [
+  "EFO:0006472"
+ ],
+ "CVCL:1642": [
+  "EFO:0005234"
+ ],
+ "CVCL:6748": [
+  "EFO:0006734"
+ ],
+ "CVCL:6749": [
+  "EFO:0006735"
+ ],
+ "CVCL:4897": [
+  "EFO:0006736"
+ ],
+ "CVCL:4718": [
+  "EFO:0006737"
+ ],
+ "CVCL:2161": [
+  "EFO:0006473"
+ ],
+ "CVCL:2162": [
+  "EFO:0002313"
+ ],
+ "CVCL:0485": [
+  "EFO:0006291"
+ ],
+ "CVCL:E123": [
+  "EFO:0002797"
+ ],
+ "CVCL:1644": [
+  "EFO:0006739"
+ ],
+ "CVCL:8408": [
+  "EFO:0002716"
+ ],
+ "CVCL:6943": [
+  "EFO:0002848"
+ ],
+ "CVCL:3143": [
+  "EFO:0006741"
+ ],
+ "CVCL:0511": [
+  "EFO:0002324"
+ ],
+ "CVCL:0597": [
+  "EFO:0002077"
+ ],
+ "CVCL:1883": [
+  "EFO:0006742"
+ ],
+ "CVCL:1851": [
+  "EFO:0002314"
+ ],
+ "CVCL:1648": [
+  "EFO:0006476"
+ ],
+ "CVCL:1649": [
+  "EFO:0002315"
+ ],
+ "CVCL:2169": [
+  "EFO:0002316"
+ ],
+ "CVCL:1884": [
+  "EFO:0002317"
+ ],
+ "CVCL:3152": [
+  "EFO:0006743"
+ ],
+ "CVCL:4402": [
+  "EFO:0002850"
+ ],
+ "CVCL:1654": [
+  "EFO:0002851"
+ ],
+ "CVCL:1655": [
+  "EFO:0002852"
+ ],
+ "CVCL:3154": [
+  "EFO:0006744"
+ ],
+ "CVCL:0041": [
+  "EFO:0005722",
+  "EFO:0002329"
+ ],
+ "CVCL:1885": [
+  "EFO:0006477"
+ ],
+ "CVCL:3156": [
+  "EFO:0006745"
+ ],
+ "CVCL:0504": [
+  "EFO:0001232"
+ ],
+ "CVCL:3787": [
+  "EFO:0002318"
+ ],
+ "CVCL:1660": [
+  "EFO:0002319"
+ ],
+ "CVCL:0505": [
+  "EFO:0002320"
+ ],
+ "CVCL:9714": [
+  "EFO:0002853"
+ ],
+ "CVCL:1662": [
+  "EFO:0006746"
+ ],
+ "CVCL:3158": [
+  "EFO:0006747"
+ ],
+ "CVCL:1664": [
+  "EFO:0006478"
+ ],
+ "CVCL:1665": [
+  "EFO:0002321"
+ ],
+ "CVCL:1666": [
+  "EFO:0005712"
+ ],
+ "CVCL:0014": [
+  "EFO:0002322"
+ ],
+ "CVCL:1670": [
+  "EFO:0006479"
+ ],
+ "CVCL:0036": [
+  "EFO:0006480"
+ ],
+ "CVCL:2G64": [
+  "EFO:0006748"
+ ],
+ "CVCL:B810": [
+  "EFO:0009320"
+ ],
+ "CVCL:3791": [
+  "EFO:0002323"
+ ],
+ "CVCL:3792": [
+  "EFO:0007610"
+ ],
+ "CVCL:Z992": [
+  "EFO:0005836"
+ ],
+ "CVCL:Z831": [
+  "EFO:0005837"
+ ],
+ "CVCL:1Y70": [
+  "EFO:0006292"
+ ],
+ "CVCL:D198": [
+  "EFO:0001197"
+ ],
+ "CVCL:6519": [
+  "EFO:0001234"
+ ],
+ "CVCL:1678": [
+  "EFO:0002854"
+ ],
+ "CVCL:1679": [
+  "EFO:0002855"
+ ],
+ "CVCL:1888": [
+  "EFO:0006481"
+ ],
+ "CVCL:3599": [
+  "EFO:0002325"
+ ],
+ "CVCL:1681": [
+  "EFO:0006482"
+ ],
+ "CVCL:1682": [
+  "EFO:0006483"
+ ],
+ "CVCL:1683": [
+  "EFO:0006484"
+ ],
+ "CVCL:1685": [
+  "EFO:0006485"
+ ],
+ "CVCL:1687": [
+  "EFO:0002856"
+ ],
+ "CVCL:Z231": [
+  "EFO:0002078"
+ ],
+ "CVCL:Z232": [
+  "EFO:0001233"
+ ],
+ "CVCL:Z233": [
+  "EFO:0005838"
+ ],
+ "CVCL:0024": [
+  "EFO:0006749"
+ ],
+ "CVCL:2186": [
+  "EFO:0006750"
+ ],
+ "CVCL:D050": [
+  "EFO:0002708"
+ ],
+ "CVCL:0095": [
+  "EFO:0002326"
+ ],
+ "CVCL:2187": [
+  "EFO:0006486"
+ ],
+ "CVCL:Y495": [
+  "EFO:0003972"
+ ],
+ "CVCL:1688": [
+  "EFO:0005450"
+ ],
+ "CVCL:1689": [
+  "EFO:0005451"
+ ],
+ "CVCL:1690": [
+  "EFO:0005452"
+ ],
+ "CVCL:1691": [
+  "EFO:0005453"
+ ],
+ "CVCL:Z707": [
+  "EFO:0005839"
+ ],
+ "CVCL:0520": [
+  "EFO:0006293"
+ ],
+ "CVCL:0524": [
+  "EFO:0006294"
+ ],
+ "CVCL:0019": [
+  "EFO:0002717"
+ ],
+ "CVCL:7702": [
+  "EFO:0002327"
+ ],
+ "CVCL:9788": [
+  "EFO:0005454"
+ ],
+ "CVCL:9789": [
+  "EFO:0005456"
+ ],
+ "CVCL:9790": [
+  "EFO:0005455"
+ ],
+ "CVCL:2A38": [
+  "EFO:0002857"
+ ],
+ "CVCL:1693": [
+  "EFO:0002328"
+ ],
+ "CVCL:1694": [
+  "EFO:0006751"
+ ],
+ "CVCL:0032": [
+  "EFO:0002379"
+ ],
+ "CVCL:1697": [
+  "EFO:0002330"
+ ],
+ "CVCL:0033": [
+  "EFO:0001236"
+ ],
+ "CVCL:0626": [
+  "EFO:0006752"
+ ],
+ "CVCL:0627": [
+  "EFO:0002858"
+ ],
+ "CVCL:2195": [
+  "EFO:0001237"
+ ],
+ "CVCL:0628": [
+  "EFO:0002331"
+ ],
+ "CVCL:0068": [
+  "EFO:0002332"
+ ],
+ "CVCL:0069": [
+  "EFO:0002079"
+ ],
+ "CVCL:6027": [
+  "EFO:0006490"
+ ],
+ "CVCL:0599": [
+  "EFO:0006487"
+ ],
+ "CVCL:0526": [
+  "EFO:0003081"
+ ],
+ "CVCL:0550": [
+  "EFO:0002333"
+ ],
+ "CVCL:0039": [
+  "EFO:0006488"
+ ],
+ "CVCL:0600": [
+  "EFO:0006489"
+ ],
+ "CVCL:0527": [
+  "EFO:0005720"
+ ],
+ "CVCL:0630": [
+  "EFO:0002334"
+ ],
+ "CVCL:A478": [
+  "EFO:0005457"
+ ],
+ "CVCL:1699": [
+  "EFO:0005458"
+ ],
+ "CVCL:1700": [
+  "EFO:0002859"
+ ],
+ "CVCL:0529": [
+  "EFO:0005725"
+ ],
+ "CVCL:1701": [
+  "EFO:0005721"
+ ],
+ "CVCL:1702": [
+  "EFO:0002338"
+ ],
+ "CVCL:0530": [
+  "EFO:0002860"
+ ],
+ "CVCL:1398": [
+  "EFO:0002230"
+ ],
+ "CVCL:0531": [
+  "EFO:0003072"
+ ],
+ "CVCL:D044": [
+  "EFO:0002802"
+ ],
+ "CVCL:0631": [
+  "EFO:0002337"
+ ],
+ "CVCL:0532": [
+  "EFO:0002340"
+ ],
+ "CVCL:0533": [
+  "EFO:0002341"
+ ],
+ "CVCL:E053": [
+  "EFO:0005460"
+ ],
+ "CVCL:0098": [
+  "EFO:0006753"
+ ],
+ "CVCL:4974": [
+  "EFO:0002339"
+ ],
+ "CVCL:IU19": [
+  "EFO:0002706"
+ ],
+ "CVCL:4456": [
+  "EFO:0002081"
+ ],
+ "CVCL:0535": [
+  "EFO:0002342"
+ ],
+ "CVCL:0099": [
+  "EFO:0002343"
+ ],
+ "CVCL:0076": [
+  "EFO:0002344"
+ ],
+ "CVCL:0090": [
+  "EFO:0002345"
+ ],
+ "CVCL:3946": [
+  "EFO:0006754"
+ ],
+ "CVCL:0250": [
+  "EFO:0002346"
+ ],
+ "CVCL:0077": [
+  "EFO:0002347"
+ ],
+ "CVCL:0366": [
+  "EFO:0002348"
+ ],
+ "CVCL:0454": [
+  "EFO:0002349"
+ ],
+ "CVCL:0497": [
+  "EFO:0002350"
+ ],
+ "CVCL:0100": [
+  "EFO:0006755"
+ ],
+ "CVCL:0078": [
+  "EFO:0002351"
+ ],
+ "CVCL:0101": [
+  "EFO:0006756"
+ ],
+ "CVCL:5079": [
+  "EFO:0006757"
+ ],
+ "CVCL:0102": [
+  "EFO:0006758"
+ ],
+ "CVCL:5081": [
+  "EFO:0006759"
+ ],
+ "CVCL:5086": [
+  "EFO:0006760"
+ ],
+ "CVCL:1708": [
+  "EFO:0006761"
+ ],
+ "CVCL:8273": [
+  "EFO:0002861"
+ ],
+ "CVCL:1711": [
+  "EFO:0006491",
+  "EFO:0002352"
+ ],
+ "CVCL:1712": [
+  "EFO:0002353"
+ ],
+ "CVCL:8916": [
+  "EFO:0006295"
+ ],
+ "CVCL:9681": [
+  "EFO:0002862"
+ ],
+ "CVCL:9686": [
+  "EFO:0002863"
+ ],
+ "CVCL:8917": [
+  "EFO:0006296"
+ ],
+ "CVCL:0538": [
+  "EFO:0005461"
+ ],
+ "CVCL:1889": [
+  "EFO:0002354"
+ ],
+ "CVCL:1890": [
+  "EFO:0002355"
+ ],
+ "CVCL:9550": [
+  "EFO:0007611"
+ ],
+ "CVCL:0539": [
+  "EFO:0006492"
+ ],
+ "CVCL:1735": [
+  "EFO:0002356"
+ ],
+ "CVCL:2206": [
+  "EFO:0002357"
+ ],
+ "CVCL:2207": [
+  "EFO:0006493"
+ ],
+ "CVCL:3881": [
+  "EFO:0006494"
+ ],
+ "CVCL:3172": [
+  "EFO:0006495"
+ ],
+ "CVCL:5589": [
+  "EFO:0001239"
+ ],
+ "CVCL:3422": [
+  "EFO:0001240"
+ ],
+ "CVCL:5423": [
+  "EFO:0001241"
+ ],
+ "CVCL:5591": [
+  "EFO:0001242"
+ ],
+ "CVCL:3423": [
+  "EFO:0001243"
+ ],
+ "CVCL:5593": [
+  "EFO:0001244"
+ ],
+ "CVCL:5594": [
+  "EFO:0006762"
+ ],
+ "CVCL:3424": [
+  "EFO:0001245"
+ ],
+ "CVCL:3425": [
+  "EFO:0001246"
+ ],
+ "CVCL:0103": [
+  "EFO:0006763"
+ ],
+ "CVCL:1715": [
+  "EFO:0002358"
+ ],
+ "CVCL:0544": [
+  "EFO:0002359"
+ ],
+ "CVCL:0543": [
+  "EFO:0002360"
+ ],
+ "CVCL:1717": [
+  "EFO:0002361"
+ ],
+ "CVCL:1718": [
+  "EFO:0002362"
+ ],
+ "CVCL:1720": [
+  "EFO:0002363"
+ ],
+ "CVCL:1722": [
+  "EFO:0002364"
+ ],
+ "CVCL:1723": [
+  "EFO:0002365"
+ ],
+ "CVCL:0545": [
+  "EFO:0002366"
+ ],
+ "CVCL:1724": [
+  "EFO:0002367"
+ ],
+ "CVCL:0546": [
+  "EFO:0002083"
+ ],
+ "CVCL:3799": [
+  "EFO:0005462"
+ ],
+ "CVCL:0547": [
+  "EFO:0002368"
+ ],
+ "CVCL:1726": [
+  "EFO:0002369"
+ ],
+ "CVCL:1727": [
+  "EFO:0002370"
+ ],
+ "CVCL:1728": [
+  "EFO:0002371"
+ ],
+ "CVCL:1729": [
+  "EFO:0002372"
+ ],
+ "CVCL:1730": [
+  "EFO:0002373"
+ ],
+ "CVCL:1731": [
+  "EFO:0002374"
+ ],
+ "CVCL:0632": [
+  "EFO:0002375"
+ ],
+ "CVCL:1732": [
+  "EFO:0002376"
+ ],
+ "CVCL:1733": [
+  "EFO:0002377"
+ ],
+ "CVCL:1734": [
+  "EFO:0002378"
+ ],
+ "CVCL:1Y75": [
+  "EFO:0006297"
+ ],
+ "CVCL:1Y76": [
+  "EFO:0006298"
+ ],
+ "CVCL:1Y78": [
+  "EFO:0006299"
+ ],
+ "CVCL:1Y80": [
+  "EFO:0006300"
+ ],
+ "CVCL:1Y83": [
+  "EFO:0006301"
+ ],
+ "CVCL:1Y84": [
+  "EFO:0006302"
+ ],
+ "CVCL:1Y85": [
+  "EFO:0006303"
+ ],
+ "CVCL:0553": [
+  "EFO:0001247"
+ ],
+ "CVCL:0554": [
+  "EFO:0002864"
+ ],
+ "CVCL:S805": [
+  "EFO:0006304"
+ ],
+ "CVCL:4056": [
+  "EFO:0002714"
+ ],
+ "CVCL:0555": [
+  "EFO:0002084"
+ ],
+ "CVCL:0556": [
+  "EFO:0002085"
+ ],
+ "CVCL:1852": [
+  "EFO:0002380"
+ ],
+ "CVCL:2213": [
+  "EFO:0002865"
+ ],
+ "CVCL:3178": [
+  "EFO:0006764"
+ ],
+ "CVCL:0006": [
+  "EFO:0001253"
+ ],
+ "CVCL:2G60": [
+  "EFO:0002086"
+ ],
+ "CVCL:1773": [
+  "EFO:0006765"
+ ],
+ "CVCL:A442": [
+  "EFO:0006496"
+ ],
+ "CVCL:4384": [
+  "EFO:0002867"
+ ],
+ "CVCL:3611": [
+  "EFO:0002383"
+ ],
+ "CVCL:3612": [
+  "EFO:0005263"
+ ],
+ "CVCL:1774": [
+  "EFO:0002382"
+ ],
+ "CVCL:C318": [
+  "EFO:0005485"
+ ],
+ "CVCL:9808": [
+  "EFO:0002868"
+ ],
+ "CVCL:8005": [
+  "EFO:0005700"
+ ],
+ "CVCL:2A33": [
+  "EFO:0006306"
+ ],
+ "CVCL:1776": [
+  "EFO:0006766"
+ ],
+ "CVCL:3221": [
+  "EFO:0006767"
+ ],
+ "CVCL:0021": [
+  "EFO:0006498"
+ ],
+ "CVCL:1896": [
+  "EFO:0006499"
+ ],
+ "CVCL:2219": [
+  "EFO:0001255"
+ ],
+ "CVCL:0017": [
+  "EFO:0006768"
+ ],
+ "CVCL:0022": [
+  "EFO:0005237"
+ ],
+ "CVCL:4988": [
+  "EFO:0004389"
+ ],
+ "CVCL:0566": [
+  "EFO:0001254"
+ ],
+ "CVCL:0042": [
+  "EFO:0002869"
+ ],
+ "CVCL:1779": [
+  "EFO:0005376"
+ ],
+ "CVCL:1780": [
+  "EFO:0005377"
+ ],
+ "CVCL:1781": [
+  "EFO:0001258"
+ ],
+ "CVCL:1782": [
+  "EFO:0002385"
+ ],
+ "CVCL:9636": [
+  "EFO:0001259"
+ ],
+ "CVCL:M009": [
+  "EFO:0006769"
+ ],
+ "CVCL:A022": [
+  "EFO:0007116"
+ ],
+ "CVCL:0104": [
+  "EFO:0006307"
+ ],
+ "CVCL:2743": [
+  "EFO:0006770"
+ ],
+ "CVCL:1783": [
+  "EFO:0006771"
+ ],
+ "CVCL:1784": [
+  "EFO:0002386"
+ ],
+ "CVCL:Y492": [
+  "EFO:0007070"
+ ],
+ "CVCL:C865": [
+  "EFO:0006308"
+ ],
+ "CVCL:2235": [
+  "EFO:0007752"
+ ],
+ "CVCL:9672": [
+  "EFO:0002870"
+ ],
+ "CVCL:1787": [
+  "EFO:0006773"
+ ],
+ "CVCL:9771": [
+  "EFO:0003042"
+ ],
+ "CVCL:9772": [
+  "EFO:0005904"
+ ],
+ "CVCL:9806": [
+  "EFO:0002871"
+ ],
+ "CVCL:9717": [
+  "EFO:0002872"
+ ],
+ "CVCL:1792": [
+  "EFO:0005715"
+ ],
+ "CVCL:0579": [
+  "EFO:0001260"
+ ],
+ "CVCL:2760": [
+  "EFO:0002389"
+ ],
+ "CVCL:0040": [
+  "EFO:0002390"
+ ],
+ "CVCL:2765": [
+  "EFO:0006774"
+ ],
+ "CVCL:8787": [
+  "EFO:0002873"
+ ],
+ "CVCL:A800": [
+  "EFO:0002874"
+ ],
+ "CVCL:A803": [
+  "EFO:0002875"
+ ],
+ "CVCL:1902": [
+  "EFO:0006775"
+ ],
+ "CVCL:1903": [
+  "EFO:0006776"
+ ],
+ "CVCL:1793": [
+  "EFO:0006777"
+ ],
+ "CVCL:N783": [
+  "EFO:0005915"
+ ],
+ "CVCL:1893": [
+  "EFO:0002392"
+ ],
+ "CVCL:1794": [
+  "EFO:0006778"
+ ],
+ "CVCL:9646": [
+  "EFO:0002876"
+ ],
+ "CVCL:9647": [
+  "EFO:0002877"
+ ],
+ "CVCL:9648": [
+  "EFO:0002878"
+ ],
+ "CVCL:9649": [
+  "EFO:0002879"
+ ],
+ "CVCL:9657": [
+  "EFO:0002880"
+ ],
+ "CVCL:9662": [
+  "EFO:0002881"
+ ],
+ "CVCL:9663": [
+  "EFO:0002882"
+ ],
+ "CVCL:2814": [
+  "EFO:0006779"
+ ],
+ "CVCL:2815": [
+  "EFO:0006780"
+ ],
+ "CVCL:B077": [
+  "EFO:0005479"
+ ],
+ "CVCL:3275": [
+  "EFO:0001261"
+ ],
+ "CVCL:C715": [
+  "EFO:0005914"
+ ],
+ "CVCL:0588": [
+  "EFO:0001262"
+ ],
+ "CVCL:1661": [
+  "EFO:0001263"
+ ],
+ "CVCL:5614": [
+  "EFO:0001264"
+ ],
+ "CL:0000583": [
+  "MESH:D016676"
+ ],
+ "CL:0000127": [
+  "MESH:D001253"
+ ],
+ "CL:0000236": [
+  "MESH:D001402"
+ ],
+ "CL:0002092": [
+  "MESH:D001854"
+ ],
+ "CL:0000746": [
+  "MESH:D032383"
+ ],
+ "CL:0000451": [
+  "MESH:D003713"
+ ],
+ "CL:0000115": [
+  "MESH:D042783"
+ ],
+ "CL:0000771": [
+  "MESH:D004804"
+ ],
+ "CL:0000057": [
+  "MESH:D005347"
+ ],
+ "CL:0000468": [
+  "MESH:D005909"
+ ],
+ "CL:0000586": [
+  "MESH:D005854"
+ ],
+ "CL:0000557": [
+  "MESH:D055014"
+ ],
+ "CL:0000182": [
+  "MESH:D022781"
+ ],
+ "CL:0002618": [
+  "MESH:D061307"
+ ],
+ "CL:0000312": [
+  "MESH:D015603"
+ ],
+ "CL:0000091": [
+  "MESH:D007728"
+ ],
+ "CL:0000824": [
+  "MESH:D015979"
+ ],
+ "CL:0000738": [
+  "MESH:D007962"
+ ],
+ "CL:0000235": [
+  "MESH:D008264"
+ ],
+ "CL:0000129": [
+  "MESH:D017628"
+ ],
+ "CL:0000576": [
+  "MESH:D009000"
+ ],
+ "CL:0000100": [
+  "MESH:D009046"
+ ],
+ "CL:0002372": [
+  "MESH:D018485"
+ ],
+ "CL:0000623": [
+  "MESH:D007694"
+ ],
+ "CL:0000047": [
+  "EFO:0004041"
+ ],
+ "CL:0000540": [
+  "MESH:D009474"
+ ],
+ "CL:0000775": [
+  "MESH:D009504"
+ ],
+ "CL:0000128": [
+  "MESH:D009836"
+ ],
+ "CL:0000062": [
+  "MESH:D010006"
+ ],
+ "CL:0000510": [
+  "MESH:D019879"
+ ],
+ "CL:0000669": [
+  "MESH:D020286"
+ ],
+ "CL:0000233": [
+  "MESH:D001792"
+ ],
+ "CL:0000371": [
+  "MESH:D011523"
+ ],
+ "CL:0000121": [
+  "MESH:D011689"
+ ],
+ "CL:0000598": [
+  "MESH:D017966"
+ ],
+ "CL:0000558": [
+  "MESH:D012156"
+ ],
+ "CL:0000019": [
+  "MESH:D013094"
+ ],
+ "CL:0000524": [
+  "MESH:D013104"
+ ],
+ "CL:0000596": [
+  "MESH:D013170"
+ ],
+ "CL:0000084": [
+  "MESH:D013601"
+ ],
+ "CL:0000136": [
+  "MESH:D017667"
+ ],
+ "CL:0000561": [
+  "MESH:D025042"
+ ],
+ "CL:0000145": [
+  "MESH:D000938"
+ ],
+ "CL:0000353": [
+  "MESH:D001755"
+ ],
+ "CL:0000081": [
+  "MESH:D001773"
+ ],
+ "CL:0002476": [
+  "MESH:D008264"
+ ],
+ "CL:0000449": [
+  "MESH:D052437"
+ ],
+ "CL:0000000": [
+  "MESH:D002477"
+ ],
+ "CL:0000700": [
+  "MESH:D059290"
+ ],
+ "CL:0002322": [
+  "MESH:D053595"
+ ],
+ "CL:0000584": [
+  "MESH:D020895"
+ ],
+ "CL:0000164": [
+  "MESH:D019858"
+ ],
+ "CL:0000362": [
+  "MESH:D000078404"
+ ],
+ "CL:0000066": [
+  "MESH:D004847"
+ ],
+ "CL:0000232": [
+  "MESH:D004912"
+ ],
+ "CL:0000125": [
+  "MESH:D009457"
+ ],
+ "CL:0000094": [
+  "MESH:D006098"
+ ],
+ "CL:0000037": [
+  "MESH:D006412"
+ ],
+ "CL:0000387": [
+  "MESH:D006434"
+ ],
+ "CL:0000632": [
+  "MESH:D055166"
+ ],
+ "CL:0002248": [
+  "MESH:D057026"
+ ],
+ "CL:0000099": [
+  "MESH:D007395"
+ ],
+ "CL:0000542": [
+  "MESH:D008214"
+ ],
+ "CL:0000097": [
+  "MESH:D008407"
+ ],
+ "CL:0000556": [
+  "MESH:D008533"
+ ],
+ "CL:0000148": [
+  "MESH:D008544"
+ ],
+ "CL:0000187": [
+  "MESH:D032342"
+ ],
+ "CL:0000763": [
+  "MESH:D022423"
+ ],
+ "CL:0000056": [
+  "MESH:D032446"
+ ],
+ "CL:0000186": [
+  "MESH:D058628"
+ ],
+ "CL:0000023": [
+  "MESH:D009865"
+ ],
+ "CL:0000601": [
+  "MESH:D018072"
+ ],
+ "CL:0000581": [
+  "MESH:D017737"
+ ],
+ "CL:0000786": [
+  "MESH:D010950"
+ ],
+ "CL:0000653": [
+  "MESH:D050199"
+ ],
+ "CL:0000740": [
+  "MESH:D012165"
+ ],
+ "CL:0000604": [
+  "MESH:D017948"
+ ],
+ "CL:0000101": [
+  "MESH:D011984"
+ ],
+ "CL:0000216": [
+  "MESH:D012708"
+ ],
+ "CL:0000192": [
+  "MESH:D032389"
+ ],
+ "CL:0000018": [
+  "MESH:D013087"
+ ],
+ "CL:0000017": [
+  "MESH:D013090"
+ ],
+ "CL:0000034": [
+  "MESH:D013234"
+ ],
+ "CL:0000893": [
+  "MESH:D060168"
+ ],
+ "CL:0000448": [
+  "MESH:D052438"
+ ],
+ "NCBI taxon:3702": [
+  "MESH:D017360"
+ ],
+ "NCBI taxon:976": [
+  "MESH:D041963"
+ ],
+ "NCBI taxon:40559": [
+  "MESH:D020171"
+ ],
+ "NCBI taxon:235": [
+  "MESH:D002002"
+ ],
+ "NCBI taxon:6239": [
+  "MESH:D017173"
+ ],
+ "NCBI taxon:9541": [
+  "MESH:D008252"
+ ],
+ "NCBI taxon:7227": [
+  "MESH:D004331"
+ ],
+ "NCBI taxon:10090": [
+  "MESH:D016513",
+  "EFO:0005184",
+  "MESH:D051379"
+ ],
+ "NCBI taxon:7215": [
+  "MESH:D004330"
+ ],
+ "NCBI taxon:10376": [
+  "MESH:D004854"
+ ],
+ "NCBI taxon:562": [
+  "MESH:D004926"
+ ],
+ "NCBI taxon:1239": [
+  "MESH:D000068536"
+ ],
+ "NCBI taxon:11676": [
+  "MESH:D015497"
+ ],
+ "NCBI taxon:10566": [
+  "MESH:D030361"
+ ],
+ "NCBI taxon:333760": [
+  "MESH:D052162"
+ ],
+ "NCBI taxon:333761": [
+  "MESH:D052161"
+ ],
+ "NCBI taxon:10298": [
+  "MESH:D018259"
+ ],
+ "NCBI taxon:10310": [
+  "MESH:D018258"
+ ],
+ "NCBI taxon:9606": [
+  "MESH:D006801"
+ ],
+ "NCBI taxon:11623": [
+  "MESH:D008217"
+ ],
+ "NCBI taxon:1357": [
+  "MESH:D017045"
+ ],
+ "NCBI taxon:446": [
+  "MESH:D016952"
+ ],
+ "NCBI taxon:5658": [
+  "MESH:D007891"
+ ],
+ "NCBI taxon:1637": [
+  "MESH:D008087"
+ ],
+ "NCBI taxon:1639": [
+  "MESH:D008089"
+ ],
+ "NCBI taxon:1280": [
+  "MESH:D055624"
+ ],
+ "NCBI taxon:10114": [
+  "MESH:D051381"
+ ],
+ "NCBI taxon:4932": [
+  "MESH:D012441"
+ ],
+ "NCBI taxon:90371": [
+  "MESH:D012475"
+ ],
+ "NCBI taxon:6182": [
+  "MESH:D012549"
+ ],
+ "NCBI taxon:4113": [
+  "MESH:D011198"
+ ],
+ "NCBI taxon:10665": [
+  "MESH:D017122"
+ ],
+ "NCBI taxon:5911": [
+  "MESH:D013768"
+ ],
+ "NCBI taxon:5810": [
+  "MESH:D014122"
+ ],
+ "NCBI taxon:5691": [
+  "MESH:D014345"
+ ],
+ "NCBI taxon:1220511": [
+  "MESH:D020577"
+ ],
+ "NCBI taxon:8355": [
+  "MESH:D014981"
+ ],
+ "NCBI taxon:64320": [
+  "MESH:D000071244"
+ ],
+ "NCBI taxon:7955": [
+  "MESH:D015027"
+ ],
+ "NCBI taxon:10535": [
+  "MESH:D000256"
+ ],
+ "NCBI taxon:2": [
+  "MESH:D001419"
+ ],
+ "NCBI taxon:9031": [
+  "MESH:D002645"
+ ],
+ "NCBI taxon:9615": [
+  "MESH:D004285"
+ ],
+ "NCBI taxon:11646": [
+  "MESH:D016086"
+ ],
+ "NCBI taxon:10088": [
+  "MESH:D051379"
+ ],
+ "NCBI taxon:85007": [
+  "MESH:D009161"
+ ],
+ "NCBI taxon:138950": [
+  "MESH:D017955"
+ ],
+ "NCBI taxon:9986": [
+  "MESH:D011817"
+ ],
+ "NCBI taxon:10116": [
+  "MESH:D051381"
+ ],
+ "NCBI taxon:31931": [
+  "MESH:D012190"
+ ],
+ "NCBI taxon:9940": [
+  "MESH:D012756"
+ ],
+ "PubChem:2052": [
+  "CHEBI:CHEBI:92862"
+ ],
+ "PubChem:5717066": [
+  "CHEBI:CHEBI:132754"
+ ],
+ "PubChem:72271": [
+  "CHEBI:CHEBI:46153"
+ ],
+ "PubChem:9444": [
+  "CHEBI:CHEBI:2038"
+ ],
+ "PubChem:10200390": [
+  "CHEBI:CHEBI:91426"
+ ],
+ "PubChem:42611257": [
+  "CHEBI:CHEBI:63637"
+ ],
+ "PubChem:54708532": [
+  "CHEBI:CHEBI:91429"
+ ],
+ "PubChem:5717801": [
+  "CHEBI:CHEBI:131923"
+ ],
+ "PubChem:9930049": [
+  "CHEBI:CHEBI:135956"
+ ],
+ "PubChem:11364421": [
+  "CHEBI:CHEBI:49868"
+ ],
+ "PubChem:65628": [
+  "CHEBI:CHEBI:135515"
+ ],
+ "PubChem:5459322": [
+  "CHEBI:CHEBI:95064"
+ ],
+ "PubChem:65015": [
+  "CHEBI:CHEBI:125354"
+ ],
+ "PubChem:6878030": [
+  "CHEBI:CHEBI:93466"
+ ],
+ "PubChem:5311501": [
+  "CHEBI:CHEBI:73295"
+ ],
+ "PubChem:5154691": [
+  "CHEBI:CHEBI:52309"
+ ],
+ "PubChem:76044": [
+  "CHEBI:CHEBI:91461"
+ ],
+ "PubChem:6075": [
+  "CHEBI:CHEBI:135324"
+ ],
+ "PubChem:409805": [
+  "CHEBI:CHEBI:91883"
+ ],
+ "PubChem:10071166": [
+  "CHEBI:CHEBI:91677"
+ ],
+ "PubChem:57340686": [
+  "CHEBI:CHEBI:124918"
+ ],
+ "PubChem:24856436": [
+  "CHEBI:CHEBI:91414"
+ ],
+ "PubChem:5287844": [
+  "CHEBI:CHEBI:86290"
+ ],
+ "PubChem:9956222": [
+  "CHEBI:CHEBI:91382"
+ ],
+ "PubChem:5311042": [
+  "CHEBI:CHEBI:91949"
+ ],
+ "PubChem:24905147": [
+  "CHEBI:CHEBI:90679"
+ ],
+ "PubChem:445091": [
+  "CHEBI:CHEBI:132571"
+ ],
+ "PubChem:5957": [
+  "CHEBI:CHEBI:15422"
+ ],
+ "PubChem:5234": [
+  "CHEBI:CHEBI:26710"
+ ],
+ "PubChem:2719": [
+  "CHEBI:CHEBI:3638"
+ ],
+ "BEL:14-3-3 Family": [
+  "FPLX:p14_3_3"
+ ],
+ "BEL:9-1-1 Complex": [
+  "FPLX:9_1_1"
+ ],
+ "BEL:ACAD Family": [
+  "FPLX:ACAD"
+ ],
+ "BEL:Acetyl CoA Carboxylase Complex": [
+  "FPLX:ACC"
+ ],
+ "BEL:Acetyl-CoA Synthetase Family": [
+  "FPLX:Acetyl_CoA_synthetase"
+ ],
+ "BEL:ACOX Family": [
+  "FPLX:ACOX"
+ ],
+ "BEL:ACSL Family": [
+  "FPLX:ACSL"
+ ],
+ "BEL:ACT Family": [
+  "FPLX:Actin"
+ ],
+ "BEL:ACTN Family": [
+  "FPLX:ACTN"
+ ],
+ "BEL:Adaptor Protein II Complex": [
+  "FPLX:Adaptor_protein_II"
+ ],
+ "BEL:Adaptor Protein III Complex": [
+  "FPLX:Adaptor_protein_III"
+ ],
+ "BEL:ADCY Family": [
+  "FPLX:ADCY"
+ ],
+ "BEL:ADH Family": [
+  "FPLX:ADH"
+ ],
+ "BEL:ADRA Family": [
+  "FPLX:ADRA"
+ ],
+ "BEL:ADRA2 Family": [
+  "FPLX:ADRA2"
+ ],
+ "BEL:ADRB Family": [
+  "FPLX:ADRB"
+ ],
+ "BEL:ADRBK Family": [
+  "FPLX:ADRBK"
+ ],
+ "BEL:AKT Family": [
+  "FPLX:AKT"
+ ],
+ "BEL:ALDH Family": [
+  "FPLX:ALDH"
+ ],
+ "BEL:ALDO Family": [
+  "FPLX:ALDO"
+ ],
+ "BEL:AMP Activated Protein Kinase Complex": [
+  "FPLX:AMPK"
+ ],
+ "BEL:Annexin II Heterotetramer Complex": [
+  "FPLX:Annexin_II_heterotetramer"
+ ],
+ "BEL:AP-1 Complex": [
+  "FPLX:AP1"
+ ],
+ "BEL:APOA Family": [
+  "FPLX:APOA"
+ ],
+ "BEL:Arp2/3 Protein Complex": [
+  "FPLX:Arp2_3_protein"
+ ],
+ "BEL:ARRB Family": [
+  "FPLX:ARRB"
+ ],
+ "BEL:ATP2A Family": [
+  "FPLX:SERCA"
+ ],
+ "BEL:ATP5G Family": [
+  "FPLX:ATP5G"
+ ],
+ "BEL:AXIN Family": [
+  "FPLX:AXIN"
+ ],
+ "BEL:BIRC Family": [
+  "FPLX:BIRC"
+ ],
+ "BEL:BMP Family": [
+  "FPLX:BMP"
+ ],
+ "BEL:BMP Receptor Type I Family": [
+  "FPLX:BMP_receptor_type_I"
+ ],
+ "BEL:BMP Receptor Type II Family": [
+  "FPLX:BMP_receptor_type_II"
+ ],
+ "BEL:Branched Chain Alpha Keto Acid Dehydrogenase Complex": [
+  "FPLX:BCKDC"
+ ],
+ "BEL:C1 Complex": [
+  "FPLX:C1"
+ ],
+ "BEL:C1q Complex": [
+  "FPLX:C1q"
+ ],
+ "BEL:Calcineurin Complex": [
+  "FPLX:PPP3"
+ ],
+ "BEL:CALM Family": [
+  "FPLX:CALM"
+ ],
+ "BEL:CAMK Family": [
+  "FPLX:CAMK"
+ ],
+ "BEL:CAMK2 Complex": [
+  "FPLX:CAMK2_complex"
+ ],
+ "BEL:CAMK2 Family": [
+  "FPLX:CAMK2_family"
+ ],
+ "BEL:CAPN Family": [
+  "FPLX:CAPN"
+ ],
+ "BEL:Carboxylesterase Family": [
+  "FPLX:Carboxylesterase"
+ ],
+ "BEL:CASP Family": [
+  "FPLX:Caspase"
+ ],
+ "BEL:CAV Family": [
+  "FPLX:CAV"
+ ],
+ "BEL:CBF3 Complex": [
+  "FPLX:CBF3"
+ ],
+ "BEL:CCNA Family": [
+  "FPLX:Cyclin_A"
+ ],
+ "BEL:CCND Family": [
+  "FPLX:Cyclin_D"
+ ],
+ "BEL:CCNE Family": [
+  "FPLX:Cyclin_E"
+ ],
+ "BEL:CCT Complex": [
+  "FPLX:CCT_complex"
+ ],
+ "BEL:CD16 Family": [
+  "FPLX:CD16"
+ ],
+ "BEL:CD3 Complex": [
+  "FPLX:CD3"
+ ],
+ "BEL:CD32 Family": [
+  "FPLX:CD32"
+ ],
+ "BEL:CD64 Family": [
+  "FPLX:CD64"
+ ],
+ "BEL:CDC25 Family": [
+  "FPLX:CDC25"
+ ],
+ "BEL:CDH Family": [
+  "FPLX:Cadherin"
+ ],
+ "BEL:CEBP Family": [
+  "FPLX:CEBP"
+ ],
+ "BEL:Chemokine Receptor Family": [
+  "FPLX:Chemokine_receptor"
+ ],
+ "BEL:Cholinesterase Family": [
+  "FPLX:Cholinesterase"
+ ],
+ "BEL:CHRM Family": [
+  "FPLX:CHRM"
+ ],
+ "BEL:CHRN Complex": [
+  "FPLX:CHRN"
+ ],
+ "BEL:CK II Complex": [
+  "FPLX:CK2"
+ ],
+ "BEL:Clathrin Complex": [
+  "FPLX:Clathrin"
+ ],
+ "BEL:Cohesin Complex": [
+  "FPLX:Cohesin"
+ ],
+ "BEL:COL1 Family": [
+  "FPLX:COL1"
+ ],
+ "BEL:COL4 Family": [
+  "FPLX:COL4"
+ ],
+ "BEL:COL5 Family": [
+  "FPLX:COL5"
+ ],
+ "BEL:COX4 Family": [
+  "FPLX:COX4"
+ ],
+ "BEL:COX6A Family": [
+  "FPLX:COX6A"
+ ],
+ "BEL:COX6B Family": [
+  "FPLX:COX6B"
+ ],
+ "BEL:COX7A Family": [
+  "FPLX:COX7A"
+ ],
+ "BEL:COX7B Family": [
+  "FPLX:COX7B"
+ ],
+ "BEL:COX8 Family": [
+  "FPLX:COX8"
+ ],
+ "BEL:CREB Family": [
+  "FPLX:CREB"
+ ],
+ "BEL:CRISP Family": [
+  "FPLX:CRISP"
+ ],
+ "BEL:CRSP Complex": [
+  "FPLX:CRSP"
+ ],
+ "BEL:CSNK1 Family": [
+  "FPLX:CSNK1"
+ ],
+ "BEL:CSNK2 Family": [
+  "FPLX:CSNK2"
+ ],
+ "BEL:CTNNA Family": [
+  "FPLX:CTNNA"
+ ],
+ "BEL:Cu-Zn SOD Family": [
+  "FPLX:SOD"
+ ],
+ "BEL:CUL Family": [
+  "FPLX:CUL"
+ ],
+ "BEL:CXCL ELR-Negative Family": [
+  "FPLX:CXCL_ELR_negative"
+ ],
+ "BEL:CXCL ELR-Positive Family": [
+  "FPLX:CXCL_ELR_positive"
+ ],
+ "BEL:Cyclophilin Family": [
+  "FPLX:Cyclophilin"
+ ],
+ "BEL:Cytochrome C Oxidase Complex Muscle": [
+  "FPLX:COX"
+ ],
+ "BEL:Cytochrome C Oxidase Complex Non Muscle": [
+  "FPLX:COX"
+ ],
+ "BEL:Cytoplasmic Dynein Complex": [
+  "FPLX:Cytoplasmic_dynein"
+ ],
+ "BEL:DDR Family": [
+  "FPLX:DDR"
+ ],
+ "BEL:Desmoglein Family": [
+  "FPLX:Desmoglein"
+ ],
+ "BEL:DGK Family": [
+  "FPLX:DGK"
+ ],
+ "BEL:DNA Polymerase delta Complex": [
+  "FPLX:DNA_polymerase_delta"
+ ],
+ "BEL:DNM Family": [
+  "FPLX:DNM"
+ ],
+ "BEL:DRD Family": [
+  "FPLX:DRD"
+ ],
+ "BEL:DVL Family": [
+  "FPLX:DVL"
+ ],
+ "BEL:Dystrophin Associated Glycoprotein Complex": [
+  "FPLX:DGC"
+ ],
+ "BEL:E2F Family": [
+  "FPLX:E2F"
+ ],
+ "BEL:EDN Family": [
+  "FPLX:EDN"
+ ],
+ "BEL:EGFR Ligand Family": [
+  "FPLX:EGFR_ligand"
+ ],
+ "BEL:EGFR/ERBB Family": [
+  "FPLX:ERBB"
+ ],
+ "BEL:EGR Family": [
+  "FPLX:EGR"
+ ],
+ "BEL:EIF2B Complex": [
+  "FPLX:EIF2B"
+ ],
+ "BEL:EIF4A Family": [
+  "FPLX:EIF4A"
+ ],
+ "BEL:EIF4EBP Family": [
+  "FPLX:EIF4EBP"
+ ],
+ "BEL:ELA Family": [
+  "FPLX:ELA"
+ ],
+ "BEL:ENO Family": [
+  "FPLX:ENO"
+ ],
+ "BEL:Ephrin Receptor Family": [
+  "FPLX:Ephrin_receptor"
+ ],
+ "BEL:EPN Family": [
+  "FPLX:EPN"
+ ],
+ "BEL:ESR Family": [
+  "FPLX:ESR"
+ ],
+ "BEL:ETS Family": [
+  "FPLX:ETS"
+ ],
+ "BEL:FGF Family": [
+  "FPLX:FGF"
+ ],
+ "BEL:FGFR Family": [
+  "FPLX:FGFR"
+ ],
+ "BEL:Fibrinogen Complex": [
+  "FPLX:Fibrinogen"
+ ],
+ "BEL:FLOT Family": [
+  "FPLX:FLOT"
+ ],
+ "BEL:FLRT Family": [
+  "FPLX:FLRT"
+ ],
+ "BEL:Follicle Stimulating Hormone Complex": [
+  "FPLX:FSH"
+ ],
+ "BEL:FOXO Family": [
+  "FPLX:FOXO"
+ ],
+ "BEL:FZD Family": [
+  "FPLX:FZD"
+ ],
+ "BEL:GABR Family": [
+  "FPLX:GABR"
+ ],
+ "BEL:gamma Secretase Complex": [
+  "FPLX:Gamma_secretase"
+ ],
+ "BEL:GAS6 Receptor Family": [
+  "FPLX:GAS6_receptor"
+ ],
+ "BEL:GATA Family": [
+  "FPLX:GATA"
+ ],
+ "BEL:GNA Gq Family": [
+  "FPLX:G_q"
+ ],
+ "BEL:GNA Gs Family": [
+  "FPLX:G_s"
+ ],
+ "BEL:GNAI Family": [
+  "FPLX:G_i"
+ ],
+ "BEL:GNB Family": [
+  "FPLX:G_beta"
+ ],
+ "BEL:GNG Family": [
+  "FPLX:G_gamma"
+ ],
+ "BEL:GPIT Complex": [
+  "FPLX:GPIT"
+ ],
+ "BEL:GPX Family": [
+  "FPLX:GPX"
+ ],
+ "BEL:GRIA Family": [
+  "FPLX:GRIA"
+ ],
+ "BEL:GRK Family": [
+  "FPLX:GRK"
+ ],
+ "BEL:GRM Family": [
+  "FPLX:GRM"
+ ],
+ "BEL:GSK3 Family": [
+  "FPLX:GSK3"
+ ],
+ "BEL:GST Family": [
+  "FPLX:GST"
+ ],
+ "BEL:GTF2E Complex": [
+  "FPLX:GTF2E"
+ ],
+ "BEL:GTF2F Complex": [
+  "FPLX:GTF2F"
+ ],
+ "BEL:GUCY Family": [
+  "FPLX:GUCY"
+ ],
+ "BEL:GYS Family": [
+  "FPLX:GYS"
+ ],
+ "BEL:HDAC Class I Family": [
+  "FPLX:HDAC_I"
+ ],
+ "BEL:HDAC Class II Family": [
+  "FPLX:HDAC_II"
+ ],
+ "BEL:HDAC Family": [
+  "FPLX:HDAC"
+ ],
+ "BEL:HDL Complex": [
+  "FPLX:HDL"
+ ],
+ "BEL:Hedgehog Family": [
+  "FPLX:Hedgehog"
+ ],
+ "BEL:Hemoglobin Complex": [
+  "FPLX:Hemoglobin"
+ ],
+ "BEL:HES Family": [
+  "FPLX:HES"
+ ],
+ "BEL:Histone Family": [
+  "FPLX:Histone"
+ ],
+ "BEL:Histone H1 Family": [
+  "FPLX:Histone_H1"
+ ],
+ "BEL:Histone H2A Family": [
+  "FPLX:Histone_H2A"
+ ],
+ "BEL:Histone H2B Family": [
+  "FPLX:Histone_H2B"
+ ],
+ "BEL:Histone H3 Family": [
+  "FPLX:Histone_H3"
+ ],
+ "BEL:Histone H4 Family": [
+  "FPLX:Histone_H4"
+ ],
+ "BEL:HLA-DR Family": [
+  "FPLX:HLA_DR"
+ ],
+ "BEL:HMOX Family": [
+  "FPLX:HMOX"
+ ],
+ "BEL:HSP90 Family": [
+  "FPLX:HSP90"
+ ],
+ "BEL:HSPA Family": [
+  "FPLX:HSPA"
+ ],
+ "BEL:HSPB Family": [
+  "FPLX:HSPB"
+ ],
+ "BEL:Ib-V-IX Complex": [
+  "FPLX:GPIb_IX_V"
+ ],
+ "BEL:IFNA Family": [
+  "FPLX:IFNA"
+ ],
+ "BEL:IGFBP Family": [
+  "FPLX:IGFBP"
+ ],
+ "BEL:IkappaB Kinase Complex": [
+  "FPLX:IKK_complex"
+ ],
+ "BEL:IkappaB Kinase Family": [
+  "FPLX:IKK_family"
+ ],
+ "BEL:IL1 Family": [
+  "FPLX:IL1"
+ ],
+ "BEL:INSR Family": [
+  "FPLX:INSR"
+ ],
+ "BEL:Interferon Gamma Receptor Complex": [
+  "FPLX:Interferon_gamma_receptor"
+ ],
+ "BEL:IRS Family": [
+  "FPLX:IRS"
+ ],
+ "BEL:IRX Family": [
+  "FPLX:IRX"
+ ],
+ "BEL:JAK Family": [
+  "FPLX:JAK"
+ ],
+ "BEL:Kinetochore Complex": [
+  "FPLX:Kinetochore"
+ ],
+ "BEL:KLK Family": [
+  "FPLX:KLK"
+ ],
+ "BEL:Laminin 1 Complex": [
+  "FPLX:Laminin_111"
+ ],
+ "BEL:Laminin 5 Complex": [
+  "FPLX:Laminin_332"
+ ],
+ "BEL:LDH Family": [
+  "FPLX:LDH"
+ ],
+ "BEL:Luteinizing Hormone Complex": [
+  "FPLX:LH"
+ ],
+ "BEL:MAF Family": [
+  "FPLX:MAF"
+ ],
+ "BEL:MAPK Erk1/2 Family": [
+  "FPLX:ERK"
+ ],
+ "BEL:MAPK Erk1/3 Family": [
+  "FPLX:ERK"
+ ],
+ "BEL:MAPK JNK Family": [
+  "FPLX:JNK"
+ ],
+ "BEL:MAPK p38 Family": [
+  "FPLX:p38"
+ ],
+ "BEL:MEF2 Family": [
+  "FPLX:MEF2"
+ ],
+ "BEL:MEK1/2 Family": [
+  "FPLX:MEK"
+ ],
+ "BEL:Membrane Attack Complex": [
+  "FPLX:MAC"
+ ],
+ "BEL:MMP Family": [
+  "FPLX:MMP"
+ ],
+ "BEL:MYH Family": [
+  "FPLX:MYH"
+ ],
+ "BEL:MYL Alkali Family": [
+  "FPLX:MYL_alkali"
+ ],
+ "BEL:MYL Family": [
+  "FPLX:MYL"
+ ],
+ "BEL:MYL Regulatory Family": [
+  "FPLX:MYL_regulatory"
+ ],
+ "BEL:MYL Slow Family": [
+  "FPLX:MYL_slow"
+ ],
+ "BEL:MYST Family": [
+  "FPLX:MYST"
+ ],
+ "BEL:Na/K Exchanging ATPase Complex": [
+  "FPLX:Na_K_ATPase"
+ ],
+ "BEL:NADH Dehydrogenase Complex": [
+  "FPLX:NADH_dehydrogenase"
+ ],
+ "BEL:NADPH Oxidase Complex": [
+  "FPLX:NADPH_oxidase"
+ ],
+ "BEL:NCOR Family": [
+  "FPLX:NCOR"
+ ],
+ "BEL:NDRG Family": [
+  "FPLX:NDRG"
+ ],
+ "BEL:NFAT Family": [
+  "FPLX:NFAT"
+ ],
+ "BEL:Nfkb Complex": [
+  "FPLX:NFkappaB"
+ ],
+ "BEL:Nfy Complex": [
+  "FPLX:NFY"
+ ],
+ "BEL:NKD Family": [
+  "FPLX:NKD"
+ ],
+ "BEL:NOS Family": [
+  "FPLX:NOS"
+ ],
+ "BEL:NOTCH Family": [
+  "FPLX:Notch"
+ ],
+ "BEL:NRG1/2 Family": [
+  "FPLX:NRG_1_2"
+ ],
+ "BEL:NRG3/4 Family": [
+  "FPLX:NRG_3_4"
+ ],
+ "BEL:NTRK Family": [
+  "FPLX:NTRK"
+ ],
+ "BEL:p160/SRC Family": [
+  "FPLX:NCOA"
+ ],
+ "BEL:P2RX Family": [
+  "FPLX:P2RX"
+ ],
+ "BEL:P2RY Family": [
+  "FPLX:P2RY"
+ ],
+ "BEL:p85/p110 PI3Kinase Complex": [
+  "FPLX:PI3K"
+ ],
+ "BEL:PAK Family": [
+  "FPLX:PAK"
+ ],
+ "BEL:PARV Family": [
+  "FPLX:PARV"
+ ],
+ "BEL:PBX Family": [
+  "FPLX:PBX"
+ ],
+ "BEL:PDE Family": [
+  "FPLX:PDE"
+ ],
+ "BEL:PDE1 Family": [
+  "FPLX:PDE1"
+ ],
+ "BEL:PDE3 Family": [
+  "FPLX:PDE3"
+ ],
+ "BEL:PDE4 Family": [
+  "FPLX:PDE4"
+ ],
+ "BEL:PDE6 Family": [
+  "FPLX:PDE6"
+ ],
+ "BEL:PDGF Family": [
+  "FPLX:PDGF"
+ ],
+ "BEL:PDGFR Family": [
+  "FPLX:PDGFR"
+ ],
+ "BEL:PDK Family": [
+  "FPLX:PDK"
+ ],
+ "BEL:PFN Family": [
+  "FPLX:PFN"
+ ],
+ "BEL:Phosphorylase B Kinase Complex": [
+  "FPLX:PhK"
+ ],
+ "BEL:PIK3C Class IA Family": [
+  "FPLX:PI3K_p110"
+ ],
+ "BEL:PIK3R Class IA Family": [
+  "FPLX:PIK3R_I"
+ ],
+ "BEL:PKI Family": [
+  "FPLX:PKI"
+ ],
+ "BEL:PLA2 Family": [
+  "FPLX:PLA2"
+ ],
+ "BEL:PLA2G2 Family": [
+  "FPLX:PLA2G2"
+ ],
+ "BEL:PLC Family": [
+  "FPLX:PLC"
+ ],
+ "BEL:PLCB Family": [
+  "FPLX:PLCB"
+ ],
+ "BEL:PLCG Family": [
+  "FPLX:PLCG"
+ ],
+ "BEL:PLD Family": [
+  "FPLX:PLD"
+ ],
+ "BEL:PPAP2 Family": [
+  "FPLX:PPAP2"
+ ],
+ "BEL:PPAR Family": [
+  "FPLX:PPAR"
+ ],
+ "BEL:PPP1C Family": [
+  "FPLX:PPP1C"
+ ],
+ "BEL:PPP1R Family": [
+  "FPLX:PPP1R"
+ ],
+ "BEL:PPP2C Family": [
+  "FPLX:PPP2C"
+ ],
+ "BEL:PPP2R Subunit A Family": [
+  "FPLX:PPP2R_A"
+ ],
+ "BEL:PPP2R Subunit B Family": [
+  "FPLX:PPP2R_B"
+ ],
+ "BEL:PPP3 Family": [
+  "FPLX:PPP3"
+ ],
+ "BEL:PPP3C Family": [
+  "FPLX:PPP3C"
+ ],
+ "BEL:PPP3R Family": [
+  "FPLX:PPP3R"
+ ],
+ "BEL:PRC1 Maintenance Complex": [
+  "FPLX:PRC1_complex"
+ ],
+ "BEL:PRC2 Initiation Complex": [
+  "FPLX:PRC2_complex"
+ ],
+ "BEL:PRDX Family": [
+  "FPLX:PRDX"
+ ],
+ "BEL:PRKA Family": [
+  "FPLX:PRKAC"
+ ],
+ "BEL:PRKAA Family": [
+  "FPLX:AMPK_alpha"
+ ],
+ "BEL:PRKAB Family": [
+  "FPLX:AMPK_beta"
+ ],
+ "BEL:PRKAG Family": [
+  "FPLX:AMPK_gamma"
+ ],
+ "BEL:PRKAR Family": [
+  "FPLX:PRKAR"
+ ],
+ "BEL:PRKC Family": [
+  "FPLX:PKC"
+ ],
+ "BEL:PRKG Family": [
+  "FPLX:PRKG"
+ ],
+ "BEL:Propionyl CoA Carboxylase Complex": [
+  "FPLX:Propionyl_CoA_carboxylase"
+ ],
+ "BEL:Proteasome Complex": [
+  "FPLX:Proteasome"
+ ],
+ "BEL:Proton Transporting ATP Synthase Complex": [
+  "FPLX:ATP_synthase"
+ ],
+ "BEL:PTGER Family": [
+  "FPLX:PTGER"
+ ],
+ "BEL:Pyruvate Dehydrogenase Complex": [
+  "FPLX:PDH"
+ ],
+ "BEL:RAB Family": [
+  "FPLX:RAB"
+ ],
+ "BEL:RAC Family": [
+  "FPLX:RAC"
+ ],
+ "BEL:RAF Family": [
+  "FPLX:RAF"
+ ],
+ "BEL:RAR Family": [
+  "FPLX:RAR"
+ ],
+ "BEL:RAS Family": [
+  "FPLX:RAS"
+ ],
+ "BEL:Respiratory Chain Complex II": [
+  "FPLX:ETC_complex_II"
+ ],
+ "BEL:Respiratory Chain Complex III": [
+  "FPLX:ETC_complex_III"
+ ],
+ "BEL:RFC Complex": [
+  "FPLX:RFC"
+ ],
+ "BEL:RFX Family": [
+  "FPLX:RFX"
+ ],
+ "BEL:RHO Family": [
+  "FPLX:RHO"
+ ],
+ "BEL:RNApo I Complex": [
+  "FPLX:RNApo_I"
+ ],
+ "BEL:RNApo II Complex": [
+  "FPLX:RNApo_II"
+ ],
+ "BEL:ROCK Family": [
+  "FPLX:ROCK"
+ ],
+ "BEL:ROR Family": [
+  "FPLX:ROR"
+ ],
+ "BEL:RPS6KA Family": [
+  "FPLX:P90RSK"
+ ],
+ "BEL:RPS6KB Family": [
+  "FPLX:P70S6K"
+ ],
+ "BEL:RXR Family": [
+  "FPLX:RXR"
+ ],
+ "BEL:S100A Family": [
+  "FPLX:S100A"
+ ],
+ "BEL:S1PR Family": [
+  "FPLX:S1PR"
+ ],
+ "BEL:SAA Family": [
+  "FPLX:SAA"
+ ],
+ "BEL:SCD Family": [
+  "FPLX:SCD"
+ ],
+ "BEL:SERPINB Family": [
+  "FPLX:SERPINB"
+ ],
+ "BEL:SLC2A Family": [
+  "FPLX:SLC2A"
+ ],
+ "BEL:SMAD Family": [
+  "FPLX:SMAD"
+ ],
+ "BEL:SMC1 Family": [
+  "FPLX:SMC1"
+ ],
+ "BEL:SNAI Family": [
+  "FPLX:SNAI"
+ ],
+ "BEL:SOS Family": [
+  "FPLX:SOS"
+ ],
+ "BEL:SRC Family": [
+  "FPLX:SRC"
+ ],
+ "BEL:SREBF Family": [
+  "FPLX:SREBF"
+ ],
+ "BEL:STAT Family": [
+  "FPLX:STAT"
+ ],
+ "BEL:STAT5 Family": [
+  "FPLX:STAT5"
+ ],
+ "BEL:Sulfonylurea Receptor Family": [
+  "FPLX:Sulfonylurea_receptor"
+ ],
+ "BEL:SWI/SNF Complex": [
+  "FPLX:SWI_SNF"
+ ],
+ "BEL:TAP Family": [
+  "FPLX:TAP"
+ ],
+ "BEL:TCF/LEF Family": [
+  "FPLX:TCF_LEF"
+ ],
+ "BEL:TFAP2 Family": [
+  "FPLX:TFAP2"
+ ],
+ "BEL:TFDP Family": [
+  "FPLX:TFDP"
+ ],
+ "BEL:TGFB Family": [
+  "FPLX:TGFB"
+ ],
+ "BEL:THBS Family": [
+  "FPLX:THBS"
+ ],
+ "BEL:THR Family": [
+  "FPLX:THR"
+ ],
+ "BEL:Thrombin Antithrombin Complex": [
+  "FPLX:Thrombin_antithrombin"
+ ],
+ "BEL:TIF IB Complex": [
+  "FPLX:TIF_IB"
+ ],
+ "BEL:TN Family": [
+  "FPLX:TN"
+ ],
+ "BEL:TNFRSF Family": [
+  "FPLX:TNFRSF"
+ ],
+ "BEL:TOP2 Family": [
+  "FPLX:TOP2"
+ ],
+ "BEL:TORC1 Complex": [
+  "FPLX:mTORC1"
+ ],
+ "BEL:TORC2 Complex": [
+  "FPLX:mTORC2"
+ ],
+ "BEL:Tryptase Family": [
+  "FPLX:Tryptase"
+ ],
+ "BEL:TUBA Family": [
+  "FPLX:TUBA"
+ ],
+ "BEL:TUBB Family": [
+  "FPLX:TUBB"
+ ],
+ "BEL:TXN Family": [
+  "FPLX:TXN"
+ ],
+ "BEL:TXNRD Family": [
+  "FPLX:TXNRD"
+ ],
+ "BEL:UBE2 Family": [
+  "FPLX:UBE2"
+ ],
+ "BEL:VAV Family": [
+  "FPLX:VAV"
+ ],
+ "BEL:VEGF Family": [
+  "FPLX:VEGF"
+ ],
+ "BEL:VEGFR Family": [
+  "FPLX:VEGFR"
+ ],
+ "BEL:WNT Family": [
+  "FPLX:Wnt"
+ ],
+ "COMPLEXPORTAL:CPX-560": [
+  "FPLX:ETC_complex_III"
+ ],
+ "COMPLEXPORTAL:CPX-561": [
+  "FPLX:ETC_complex_II"
+ ],
+ "COMPLEXPORTAL:CPX-577": [
+  "FPLX:ETC_complex_I"
+ ],
+ "ECCODE:1.1.1.1": [
+  "FPLX:ADH"
+ ],
+ "ECCODE:1.10.2.2": [
+  "FPLX:ETC_complex_III"
+ ],
+ "ECCODE:1.11.1.15": [
+  "FPLX:PRDX"
+ ],
+ "ECCODE:1.11.1.9": [
+  "FPLX:GPX"
+ ],
+ "ECCODE:1.14.19.1": [
+  "FPLX:SCD"
+ ],
+ "ECCODE:1.14.99.3": [
+  "FPLX:HMOX"
+ ],
+ "ECCODE:1.2.1.3": [
+  "FPLX:ALDH"
+ ],
+ "ECCODE:1.2.4.1": [
+  "FPLX:PDK"
+ ],
+ "ECCODE:1.3.5.1": [
+  "FPLX:ETC_complex_II"
+ ],
+ "ECCODE:1.3.8.7": [
+  "FPLX:ACAD"
+ ],
+ "ECCODE:1.6.5.3": [
+  "FPLX:ETC_complex_I",
+  "FPLX:NADH_dehydrogenase"
+ ],
+ "ECCODE:1.9.3.1": [
+  "FPLX:ETC_complex_IV",
+  "FPLX:COX"
+ ],
+ "ECCODE:2.3.2.23": [
+  "FPLX:UBE2"
+ ],
+ "ECCODE:2.5.1.58": [
+  "FPLX:FNT"
+ ],
+ "ECCODE:2.7.1.107": [
+  "FPLX:DGK"
+ ],
+ "ECCODE:2.7.11.11": [
+  "FPLX:PKA"
+ ],
+ "ECCODE:2.7.11.12": [
+  "FPLX:PRKG"
+ ],
+ "ECCODE:2.7.11.13": [
+  "FPLX:PKC"
+ ],
+ "ECCODE:2.7.11.16": [
+  "FPLX:GRK"
+ ],
+ "ECCODE:2.7.11.17": [
+  "FPLX:CAMK"
+ ],
+ "ECCODE:2.7.11.19": [
+  "FPLX:PhK"
+ ],
+ "ECCODE:2.7.11.22": [
+  "FPLX:CDK"
+ ],
+ "ECCODE:2.7.11.24": [
+  "FPLX:MAPK"
+ ],
+ "ECCODE:2.7.11.25": [
+  "FPLX:MAP3K"
+ ],
+ "ECCODE:2.7.11.31": [
+  "FPLX:AMPK"
+ ],
+ "ECCODE:2.7.12.2": [
+  "FPLX:MAPK"
+ ],
+ "ECCODE:3.1.1.1": [
+  "FPLX:Carboxylesterase"
+ ],
+ "ECCODE:3.1.1.4": [
+  "FPLX:PLA2"
+ ],
+ "ECCODE:3.1.4.-": [
+  "FPLX:PDE"
+ ],
+ "ECCODE:3.1.4.4": [
+  "FPLX:PLD"
+ ],
+ "ECCODE:3.4.21.35": [
+  "FPLX:KLK"
+ ],
+ "ECCODE:3.4.21.59": [
+  "FPLX:Tryptase"
+ ],
+ "ECCODE:3.4.25.1": [
+  "FPLX:Proteasome"
+ ],
+ "ECCODE:3.5.1.98": [
+  "FPLX:HDAC"
+ ],
+ "ECCODE:3.6.3.14": [
+  "FPLX:ETC_complex_V"
+ ],
+ "ECCODE:3.6.3.9": [
+  "FPLX:Na_K_ATPase"
+ ],
+ "ECCODE:3.6.5.-": [
+  "FPLX:GTPase"
+ ],
+ "ECCODE:4.1.2.13": [
+  "FPLX:ALDO"
+ ],
+ "ECCODE:4.6.1.2": [
+  "FPLX:GUCY"
+ ],
+ "ECCODE:6.4.1.2": [
+  "FPLX:ACC"
+ ],
+ "ECCODE:6.4.1.3": [
+  "FPLX:Propionyl_CoA_carboxylase"
+ ],
+ "GO:GO:0000145": [
+  "FPLX:EXOC"
+ ],
+ "GO:GO:0000502": [
+  "FPLX:Proteasome"
+ ],
+ "GO:GO:0000776": [
+  "FPLX:Kinetochore"
+ ],
+ "GO:GO:0000930": [
+  "FPLX:TUBG"
+ ],
+ "GO:GO:0004117": [
+  "FPLX:PDE1"
+ ],
+ "GO:GO:0004198": [
+  "FPLX:CAPN"
+ ],
+ "GO:GO:0004199": [
+  "FPLX:Caspase"
+ ],
+ "GO:GO:0004886": [
+  "FPLX:RXR"
+ ],
+ "GO:GO:0004890": [
+  "FPLX:GABR"
+ ],
+ "GO:GO:0004931": [
+  "FPLX:P2RX"
+ ],
+ "GO:GO:0004936": [
+  "FPLX:ADRA"
+ ],
+ "GO:GO:0004937": [
+  "FPLX:ADRA"
+ ],
+ "GO:GO:0004938": [
+  "FPLX:ADRA2"
+ ],
+ "GO:GO:0004952": [
+  "FPLX:DRD"
+ ],
+ "GO:GO:0005007": [
+  "FPLX:FGFR"
+ ],
+ "GO:GO:0005035": [
+  "FPLX:Death_receptor"
+ ],
+ "GO:GO:0005094": [
+  "FPLX:RhoGDI"
+ ],
+ "GO:GO:0005096": [
+  "FPLX:GAP"
+ ],
+ "GO:GO:0005154": [
+  "FPLX:EGFR_ligand"
+ ],
+ "GO:GO:0005161": [
+  "FPLX:PDGF"
+ ],
+ "GO:GO:0005162": [
+  "FPLX:FGF"
+ ],
+ "GO:GO:0005172": [
+  "FPLX:VEGFR"
+ ],
+ "GO:GO:0005355": [
+  "FPLX:SLC2A"
+ ],
+ "GO:GO:0005577": [
+  "FPLX:Fibrinogen"
+ ],
+ "GO:GO:0005579": [
+  "FPLX:MAC"
+ ],
+ "GO:GO:0005584": [
+  "FPLX:COL1"
+ ],
+ "GO:GO:0005587": [
+  "FPLX:COL4"
+ ],
+ "GO:GO:0005588": [
+  "FPLX:COL5"
+ ],
+ "GO:GO:0005610": [
+  "FPLX:Laminin_332"
+ ],
+ "GO:GO:0005663": [
+  "FPLX:RFC"
+ ],
+ "GO:GO:0005665": [
+  "FPLX:RNApo_II"
+ ],
+ "GO:GO:0005673": [
+  "FPLX:GTF2E"
+ ],
+ "GO:GO:0005674": [
+  "FPLX:GTF2F"
+ ],
+ "GO:GO:0005680": [
+  "FPLX:APC_C"
+ ],
+ "GO:GO:0005736": [
+  "FPLX:RNApo_I"
+ ],
+ "GO:GO:0005747": [
+  "FPLX:ETC_complex_I"
+ ],
+ "GO:GO:0005749": [
+  "FPLX:ETC_complex_II"
+ ],
+ "GO:GO:0005750": [
+  "FPLX:ETC_complex_III"
+ ],
+ "GO:GO:0005751": [
+  "FPLX:ETC_complex_IV"
+ ],
+ "GO:GO:0005753": [
+  "FPLX:ETC_complex_V"
+ ],
+ "GO:GO:0005761": [
+  "FPLX:Mitochondrial_Ribosome"
+ ],
+ "GO:GO:0005762": [
+  "FPLX:MRPL"
+ ],
+ "GO:GO:0005763": [
+  "FPLX:MRPS"
+ ],
+ "GO:GO:0005832": [
+  "FPLX:CCT_complex"
+ ],
+ "GO:GO:0005861": [
+  "FPLX:Troponin"
+ ],
+ "GO:GO:0005868": [
+  "FPLX:Cytoplasmic_dynein"
+ ],
+ "GO:GO:0005884": [
+  "FPLX:Actin"
+ ],
+ "GO:GO:0005956": [
+  "FPLX:CK2"
+ ],
+ "GO:GO:0008190": [
+  "FPLX:EIF4EBP"
+ ],
+ "GO:GO:0008278": [
+  "FPLX:Cohesin"
+ ],
+ "GO:GO:0008279": [
+  "FPLX:Cohesin"
+ ],
+ "GO:GO:0008281": [
+  "FPLX:Sulfonylurea_receptor"
+ ],
+ "GO:GO:0008433": [
+  "FPLX:GEF"
+ ],
+ "GO:GO:0008599": [
+  "FPLX:PPP1"
+ ],
+ "GO:GO:0016010": [
+  "FPLX:DGC"
+ ],
+ "GO:GO:0016190": [
+  "FPLX:Clathrin"
+ ],
+ "GO:GO:0016904": [
+  "FPLX:CHRN"
+ ],
+ "GO:GO:0016914": [
+  "FPLX:FSH"
+ ],
+ "GO:GO:0019787": [
+  "FPLX:UBE2"
+ ],
+ "GO:GO:0030122": [
+  "FPLX:Adaptor_protein_II"
+ ],
+ "GO:GO:0031518": [
+  "FPLX:CBF3"
+ ],
+ "GO:GO:0031931": [
+  "FPLX:mTORC1"
+ ],
+ "GO:GO:0031941": [
+  "FPLX:F_actin"
+ ],
+ "GO:GO:0032281": [
+  "FPLX:GRIA"
+ ],
+ "GO:GO:0034364": [
+  "FPLX:HDL"
+ ],
+ "GO:GO:0008305": [
+  "FPLX:Integrins"
+ ],
+ "GO:GO:0035098": [
+  "FPLX:PRC2_complex"
+ ],
+ "GO:GO:0035102": [
+  "FPLX:PRC1_complex"
+ ],
+ "GO:GO:0038036": [
+  "FPLX:S1PR"
+ ],
+ "GO:GO:0042555": [
+  "FPLX:MCM"
+ ],
+ "GO:GO:0042825": [
+  "FPLX:TAP"
+ ],
+ "GO:GO:0043509": [
+  "FPLX:Activin_A"
+ ],
+ "GO:GO:0043511": [
+  "FPLX:Inhibin"
+ ],
+ "GO:GO:0043625": [
+  "FPLX:DNA_polymerase_delta"
+ ],
+ "GO:GO:0045275": [
+  "FPLX:ETC_complex_III"
+ ],
+ "GO:GO:0048180": [
+  "FPLX:Activin"
+ ],
+ "GO:GO:0070652": [
+  "FPLX:Augmin"
+ ],
+ "GO:GO:0070765": [
+  "FPLX:Gamma_secretase"
+ ],
+ "GO:GO:1990779": [
+  "FPLX:GPIb_IX_V"
+ ],
+ "HGNC_GROUP:141": [
+  "FPLX:OR"
+ ],
+ "HGNC_GROUP:147": [
+  "FPLX:OR1"
+ ],
+ "HGNC_GROUP:149": [
+  "FPLX:OR2"
+ ],
+ "HGNC_GROUP:150": [
+  "FPLX:OR3"
+ ],
+ "HGNC_GROUP:151": [
+  "FPLX:OR4"
+ ],
+ "HGNC_GROUP:152": [
+  "FPLX:OR5"
+ ],
+ "HGNC_GROUP:153": [
+  "FPLX:OR6"
+ ],
+ "HGNC_GROUP:154": [
+  "FPLX:OR7"
+ ],
+ "HGNC_GROUP:155": [
+  "FPLX:OR8"
+ ],
+ "HGNC_GROUP:156": [
+  "FPLX:OR9"
+ ],
+ "HGNC_GROUP:157": [
+  "FPLX:OR10"
+ ],
+ "HGNC_GROUP:159": [
+  "FPLX:OR11"
+ ],
+ "HGNC_GROUP:160": [
+  "FPLX:OR12"
+ ],
+ "HGNC_GROUP:161": [
+  "FPLX:Ligand_gated_ion_channels"
+ ],
+ "HGNC_GROUP:162": [
+  "FPLX:OR13"
+ ],
+ "HGNC_GROUP:163": [
+  "FPLX:OR14"
+ ],
+ "HGNC_GROUP:164": [
+  "FPLX:OR51"
+ ],
+ "HGNC_GROUP:165": [
+  "FPLX:OR52"
+ ],
+ "HGNC_GROUP:167": [
+  "FPLX:OR56"
+ ],
+ "HGNC_GROUP:172": [
+  "FPLX:5_hydroxytryptamine_receptors_ionotropic"
+ ],
+ "HGNC_GROUP:173": [
+  "FPLX:CHRN"
+ ],
+ "HGNC_GROUP:178": [
+  "FPLX:Voltage_gated_ion_channels"
+ ],
+ "HGNC_GROUP:179": [
+  "FPLX:Sodium_channels"
+ ],
+ "HGNC_GROUP:182": [
+  "FPLX:Calcium_channels"
+ ],
+ "HGNC_GROUP:183": [
+  "FPLX:KCN"
+ ],
+ "HGNC_GROUP:184": [
+  "FPLX:SCN"
+ ],
+ "HGNC_GROUP:185": [
+  "FPLX:SCNN"
+ ],
+ "HGNC_GROUP:186": [
+  "FPLX:CATSPER"
+ ],
+ "HGNC_GROUP:198": [
+  "FPLX:FPR"
+ ],
+ "HGNC_GROUP:214": [
+  "FPLX:P2RX"
+ ],
+ "HGNC_GROUP:223": [
+  "FPLX:BDKR"
+ ],
+ "HGNC_GROUP:247": [
+  "FPLX:TPCN"
+ ],
+ "HGNC_GROUP:249": [
+  "FPLX:TRP"
+ ],
+ "HGNC_GROUP:250": [
+  "FPLX:CNG"
+ ],
+ "HGNC_GROUP:253": [
+  "FPLX:CACN"
+ ],
+ "HGNC_GROUP:254": [
+  "FPLX:HVCN"
+ ],
+ "HGNC_GROUP:255": [
+  "FPLX:Potassium_calcium_activated_channels"
+ ],
+ "HGNC_GROUP:274": [
+  "FPLX:Potassium_voltage_gated_channels"
+ ],
+ "HGNC_GROUP:276": [
+  "FPLX:KCNJ"
+ ],
+ "HGNC_GROUP:277": [
+  "FPLX:KCNK"
+ ],
+ "HGNC_GROUP:278": [
+  "FPLX:Chloride_channels"
+ ],
+ "HGNC_GROUP:284": [
+  "FPLX:GRI"
+ ],
+ "HGNC_GROUP:287": [
+  "FPLX:RYR"
+ ],
+ "HGNC_GROUP:290": [
+  "FPLX:ASIC"
+ ],
+ "HGNC_GROUP:297": [
+  "FPLX:ITPR"
+ ],
+ "HGNC_GROUP:301": [
+  "FPLX:Chloride_calcium_activated_channels"
+ ],
+ "HGNC_GROUP:302": [
+  "FPLX:CLCN"
+ ],
+ "HGNC_GROUP:304": [
+  "FPLX:Porins"
+ ],
+ "HGNC_GROUP:305": [
+  "FPLX:AQP"
+ ],
+ "HGNC_GROUP:306": [
+  "FPLX:VDAC"
+ ],
+ "HGNC_GROUP:307": [
+  "FPLX:CLIC"
+ ],
+ "HGNC_GROUP:314": [
+  "FPLX:GJ"
+ ],
+ "HGNC_GROUP:470": [
+  "FPLX:Cathepsin"
+ ],
+ "HGNC_GROUP:480": [
+  "FPLX:CLK"
+ ],
+ "HGNC_GROUP:546": [
+  "FPLX:EFN"
+ ],
+ "HGNC_GROUP:563": [
+  "FPLX:GABR"
+ ],
+ "HGNC_GROUP:581": [
+  "FPLX:Augmin"
+ ],
+ "HGNC_GROUP:622": [
+  "FPLX:Kinesin"
+ ],
+ "HGNC_GROUP:640": [
+  "FPLX:ETC_complex_I"
+ ],
+ "HGNC_GROUP:641": [
+  "FPLX:ETC_complex_II"
+ ],
+ "HGNC_GROUP:642": [
+  "FPLX:ETC_complex_III"
+ ],
+ "HGNC_GROUP:643": [
+  "FPLX:ETC_complex_IV"
+ ],
+ "HGNC_GROUP:644": [
+  "FPLX:ETC_complex_V"
+ ],
+ "HGNC_GROUP:647": [
+  "FPLX:MOB"
+ ],
+ "HGNC_GROUP:854": [
+  "FPLX:Neuropeptide_receptor"
+ ],
+ "HGNC_GROUP:856": [
+  "FPLX:KCNT"
+ ],
+ "HGNC_GROUP:865": [
+  "FPLX:ANO"
+ ],
+ "HGNC_GROUP:866": [
+  "FPLX:BEST"
+ ],
+ "HGNC_GROUP:868": [
+  "FPLX:GLRA_GLRB"
+ ],
+ "HGNC_GROUP:1021": [
+  "FPLX:DAPK"
+ ],
+ "HGNC_GROUP:1050": [
+  "FPLX:TOP"
+ ],
+ "HGNC_GROUP:1149": [
+  "FPLX:ETC_complex_I_core"
+ ],
+ "HGNC_GROUP:1150": [
+  "FPLX:ETC_complex_I_supernumerary"
+ ],
+ "HGNC_GROUP:1158": [
+  "FPLX:LRRC8"
+ ],
+ "HGNC_GROUP:1199": [
+  "FPLX:Kainate_family"
+ ],
+ "HGNC_GROUP:1200": [
+  "FPLX:GRIA"
+ ],
+ "HGNC_GROUP:1201": [
+  "FPLX:GRIN"
+ ],
+ "HGNC_GROUP:1202": [
+  "FPLX:GRID"
+ ],
+ "HGNC_GROUP:1203": [
+  "FPLX:Sodium_voltage_gated_channel_alpha_subunits"
+ ],
+ "HGNC_GROUP:1204": [
+  "FPLX:Sodium_voltage_gated_channel_beta_subunits"
+ ],
+ "HGNC_GROUP:1511": [
+  "FPLX:CACNG"
+ ],
+ "HGNC_GROUP:1512": [
+  "FPLX:CACNA1"
+ ],
+ "HGNC_GROUP:1514": [
+  "FPLX:CACNA2D"
+ ],
+ "HGNC_GROUP:1515": [
+  "FPLX:CACNB"
+ ],
+ "HGNC_GROUP:1582": [
+  "FPLX:Neurexins"
+ ],
+ "HGNC_GROUP:1699": [
+  "FPLX:Deoxyribonucleoside_kinases"
+ ],
+ "HGNC_GROUP:1901": [
+  "FPLX:TAC"
+ ],
+ "HGNC_GROUP:1902": [
+  "FPLX:Neuropeptides"
+ ],
+ "HGNC_GROUP:1908": [
+  "FPLX:EDN"
+ ],
+ "IP:IPR000074": [
+  "FPLX:Apolipoprotein"
+ ],
+ "IP:IPR000096": [
+  "FPLX:SAA"
+ ],
+ "IP:IPR000162": [
+  "FPLX:GRM"
+ ],
+ "IP:IPR000164": [
+  "FPLX:Histone_H3"
+ ],
+ "IP:IPR000239": [
+  "FPLX:GRK"
+ ],
+ "IP:IPR000308": [
+  "FPLX:p14_3_3"
+ ],
+ "IP:IPR000320": [
+  "FPLX:Hedgehog"
+ ],
+ "IP:IPR000381": [
+  "FPLX:Activin_B"
+ ],
+ "IP:IPR000388": [
+  "FPLX:Sulfonylurea_receptor"
+ ],
+ "IP:IPR000406": [
+  "FPLX:RhoGDI"
+ ],
+ "IP:IPR000451": [
+  "FPLX:NFkappaB"
+ ],
+ "IP:IPR000454": [
+  "FPLX:ATP5G"
+ ],
+ "IP:IPR000469": [
+  "FPLX:G_12_alpha",
+  "FPLX:G_12"
+ ],
+ "IP:IPR000491": [
+  "FPLX:Activin_A"
+ ],
+ "IP:IPR000496": [
+  "FPLX:BDKR"
+ ],
+ "IP:IPR000611": [
+  "FPLX:NPYR"
+ ],
+ "IP:IPR000654": [
+  "FPLX:G_q",
+  "FPLX:G_q_alpha"
+ ],
+ "IP:IPR000741": [
+  "FPLX:ALDO"
+ ],
+ "IP:IPR000751": [
+  "FPLX:CDC25"
+ ],
+ "IP:IPR000756": [
+  "FPLX:DGK"
+ ],
+ "IP:IPR000889": [
+  "FPLX:GPX"
+ ],
+ "IP:IPR000929": [
+  "FPLX:DRD"
+ ],
+ "IP:IPR000941": [
+  "FPLX:ENO"
+ ],
+ "IP:IPR000995": [
+  "FPLX:CHRM"
+ ],
+ "IP:IPR000997": [
+  "FPLX:Cholinesterase"
+ ],
+ "IP:IPR001090": [
+  "FPLX:Ephrin_receptor"
+ ],
+ "IP:IPR001132": [
+  "FPLX:SMAD"
+ ],
+ "IP:IPR001154": [
+  "FPLX:TOP2"
+ ],
+ "IP:IPR001208": [
+  "FPLX:MCM"
+ ],
+ "IP:IPR001217": [
+  "FPLX:STAT"
+ ],
+ "IP:IPR001241": [
+  "FPLX:TOP2"
+ ],
+ "IP:IPR001349": [
+  "FPLX:COX6A"
+ ],
+ "IP:IPR001370": [
+  "FPLX:BIRC"
+ ],
+ "IP:IPR001408": [
+  "FPLX:G_i",
+  "FPLX:G_i_alpha"
+ ],
+ "IP:IPR001426": [
+  "FPLX:Ephrin_receptor"
+ ],
+ "IP:IPR001429": [
+  "FPLX:P2RX"
+ ],
+ "IP:IPR001442": [
+  "FPLX:COL4"
+ ],
+ "IP:IPR001522": [
+  "FPLX:SCD"
+ ],
+ "IP:IPR001612": [
+  "FPLX:CAV"
+ ],
+ "IP:IPR001657": [
+  "FPLX:Hedgehog"
+ ],
+ "IP:IPR001767": [
+  "FPLX:Hedgehog"
+ ],
+ "IP:IPR001770": [
+  "FPLX:G_gamma"
+ ],
+ "IP:IPR001928": [
+  "FPLX:EDN"
+ ],
+ "IP:IPR001951": [
+  "FPLX:Histone_H4"
+ ],
+ "IP:IPR002051": [
+  "FPLX:HMOX"
+ ],
+ "IP:IPR002112": [
+  "FPLX:JUN_family"
+ ],
+ "IP:IPR002117": [
+  "FPLX:p53_family"
+ ],
+ "IP:IPR002138": [
+  "FPLX:Caspase"
+ ],
+ "IP:IPR002194": [
+  "FPLX:CCT_complex"
+ ],
+ "IP:IPR002205": [
+  "FPLX:TOP2"
+ ],
+ "IP:IPR002209": [
+  "FPLX:FGF"
+ ],
+ "IP:IPR002374": [
+  "FPLX:PRKG"
+ ],
+ "IP:IPR002453": [
+  "FPLX:TUBB"
+ ],
+ "IP:IPR002454": [
+  "FPLX:TUBG"
+ ],
+ "IP:IPR002655": [
+  "FPLX:ACOX"
+ ],
+ "IP:IPR002717": [
+  "FPLX:MYST"
+ ],
+ "IP:IPR003000": [
+  "FPLX:HDAC_III"
+ ],
+ "IP:IPR003074": [
+  "FPLX:PPAR"
+ ],
+ "IP:IPR003084": [
+  "FPLX:HDAC_I",
+  "FPLX:HDAC"
+ ],
+ "IP:IPR003113": [
+  "FPLX:PI3K_p110"
+ ],
+ "IP:IPR003175": [
+  "FPLX:CDKN1"
+ ],
+ "IP:IPR003205": [
+  "FPLX:COX8"
+ ],
+ "IP:IPR003367": [
+  "FPLX:THBS"
+ ],
+ "IP:IPR003502": [
+  "FPLX:IL1"
+ ],
+ "IP:IPR003586": [
+  "FPLX:Hedgehog"
+ ],
+ "IP:IPR003587": [
+  "FPLX:Hedgehog"
+ ],
+ "IP:IPR004000": [
+  "FPLX:Actin"
+ ],
+ "IP:IPR004030": [
+  "FPLX:NOS"
+ ],
+ "IP:IPR004061": [
+  "FPLX:S1PR"
+ ],
+ "IP:IPR004142": [
+  "FPLX:NDRG"
+ ],
+ "IP:IPR004171": [
+  "FPLX:PKI"
+ ],
+ "IP:IPR004203": [
+  "FPLX:COX4"
+ ],
+ "IP:IPR004241": [
+  "FPLX:MAP1LC3"
+ ],
+ "IP:IPR004766": [
+  "FPLX:Patched"
+ ],
+ "IP:IPR004826": [
+  "FPLX:MAF"
+ ],
+ "IP:IPR004979": [
+  "FPLX:TFAP2"
+ ],
+ "IP:IPR005395": [
+  "FPLX:NPFFR"
+ ],
+ "IP:IPR005455": [
+  "FPLX:PFN"
+ ],
+ "IP:IPR005542": [
+  "FPLX:PBX"
+ ],
+ "IP:IPR005643": [
+  "FPLX:JUN_family"
+ ],
+ "IP:IPR005782": [
+  "FPLX:SERCA"
+ ],
+ "IP:IPR005817": [
+  "FPLX:Wnt"
+ ],
+ "IP:IPR006019": [
+  "FPLX:SHC"
+ ],
+ "IP:IPR006338": [
+  "FPLX:TXNRD"
+ ],
+ "IP:IPR006828": [
+  "FPLX:AMPK_beta"
+ ],
+ "IP:IPR008297": [
+  "FPLX:Notch"
+ ],
+ "IP:IPR008349": [
+  "FPLX:ERK"
+ ],
+ "IP:IPR008351": [
+  "FPLX:JNK"
+ ],
+ "IP:IPR008352": [
+  "FPLX:p38"
+ ],
+ "IP:IPR008366": [
+  "FPLX:NFAT"
+ ],
+ "IP:IPR008433": [
+  "FPLX:COX7B"
+ ],
+ "IP:IPR008606": [
+  "FPLX:EIF4EBP"
+ ],
+ "IP:IPR008631": [
+  "FPLX:GYS"
+ ],
+ "IP:IPR008859": [
+  "FPLX:THBS"
+ ],
+ "IP:IPR009045": [
+  "FPLX:Hedgehog"
+ ],
+ "IP:IPR009123": [
+  "FPLX:Desmoglein"
+ ],
+ "IP:IPR009150": [
+  "FPLX:NPBWR"
+ ],
+ "IP:IPR010011": [
+  "FPLX:NCOA"
+ ],
+ "IP:IPR010660": [
+  "FPLX:Notch"
+ ],
+ "IP:IPR010991": [
+  "FPLX:p53_family"
+ ],
+ "IP:IPR011039": [
+  "FPLX:GTF2F"
+ ],
+ "IP:IPR011615": [
+  "FPLX:p53_family"
+ ],
+ "IP:IPR011656": [
+  "FPLX:Notch"
+ ],
+ "IP:IPR012144": [
+  "FPLX:NOS"
+ ],
+ "IP:IPR012198": [
+  "FPLX:PRKAR"
+ ],
+ "IP:IPR012233": [
+  "FPLX:PKC"
+ ],
+ "IP:IPR012290": [
+  "FPLX:Fibrinogen"
+ ],
+ "IP:IPR012345": [
+  "FPLX:STAT"
+ ],
+ "IP:IPR012542": [
+  "FPLX:TOP2"
+ ],
+ "IP:IPR013019": [
+  "FPLX:SMAD"
+ ],
+ "IP:IPR013288": [
+  "FPLX:COX4"
+ ],
+ "IP:IPR013506": [
+  "FPLX:TOP2"
+ ],
+ "IP:IPR013537": [
+  "FPLX:ACC"
+ ],
+ "IP:IPR013543": [
+  "FPLX:CAMK2_complex",
+  "FPLX:CAMK2_family"
+ ],
+ "IP:IPR013558": [
+  "FPLX:TCF_LEF"
+ ],
+ "IP:IPR013706": [
+  "FPLX:PDE1"
+ ],
+ "IP:IPR013757": [
+  "FPLX:TOP2"
+ ],
+ "IP:IPR013758": [
+  "FPLX:TOP2"
+ ],
+ "IP:IPR013759": [
+  "FPLX:TOP2"
+ ],
+ "IP:IPR013760": [
+  "FPLX:TOP2"
+ ],
+ "IP:IPR013790": [
+  "FPLX:SMAD"
+ ],
+ "IP:IPR013799": [
+  "FPLX:STAT"
+ ],
+ "IP:IPR013800": [
+  "FPLX:STAT"
+ ],
+ "IP:IPR013801": [
+  "FPLX:STAT"
+ ],
+ "IP:IPR013854": [
+  "FPLX:TFAP2"
+ ],
+ "IP:IPR013871": [
+  "FPLX:CRISP"
+ ],
+ "IP:IPR014788": [
+  "FPLX:Cholinesterase"
+ ],
+ "IP:IPR014920": [
+  "FPLX:NCOA"
+ ],
+ "IP:IPR014935": [
+  "FPLX:NCOA"
+ ],
+ "IP:IPR014936": [
+  "FPLX:AXIN"
+ ],
+ "IP:IPR015008": [
+  "FPLX:ROCK"
+ ],
+ "IP:IPR015015": [
+  "FPLX:ABL_family"
+ ],
+ "IP:IPR015451": [
+  "FPLX:Cyclin_D"
+ ],
+ "IP:IPR015583": [
+  "FPLX:PDGF_BB"
+ ],
+ "IP:IPR015588": [
+  "FPLX:IFNB"
+ ],
+ "IP:IPR015615": [
+  "FPLX:TGFB"
+ ],
+ "IP:IPR015633": [
+  "FPLX:E2F"
+ ],
+ "IP:IPR015679": [
+  "FPLX:PLD"
+ ],
+ "IP:IPR015876": [
+  "FPLX:SCD"
+ ],
+ "IP:IPR015988": [
+  "FPLX:STAT"
+ ],
+ "IP:IPR016053": [
+  "FPLX:HMOX"
+ ],
+ "IP:IPR016072": [
+  "FPLX:CBF3"
+ ],
+ "IP:IPR016084": [
+  "FPLX:HMOX"
+ ],
+ "IP:IPR016239": [
+  "FPLX:P90RSK"
+ ],
+ "IP:IPR016245": [
+  "FPLX:ERBB"
+ ],
+ "IP:IPR016246": [
+  "FPLX:INSR"
+ ],
+ "IP:IPR016247": [
+  "FPLX:ROR"
+ ],
+ "IP:IPR016248": [
+  "FPLX:FGFR"
+ ],
+ "IP:IPR016251": [
+  "FPLX:JAK"
+ ],
+ "IP:IPR016257": [
+  "FPLX:Ephrin_receptor"
+ ],
+ "IP:IPR016279": [
+  "FPLX:PLCG"
+ ],
+ "IP:IPR016280": [
+  "FPLX:PLCB"
+ ],
+ "IP:IPR016311": [
+  "FPLX:ETS"
+ ],
+ "IP:IPR016319": [
+  "FPLX:TGFB"
+ ],
+ "IP:IPR016346": [
+  "FPLX:G_beta"
+ ],
+ "IP:IPR016897": [
+  "FPLX:CBF3"
+ ],
+ "IP:IPR017104": [
+  "FPLX:AP2A"
+ ],
+ "IP:IPR017348": [
+  "FPLX:PIM"
+ ],
+ "IP:IPR017426": [
+  "FPLX:NCOA"
+ ],
+ "IP:IPR017897": [
+  "FPLX:THBS"
+ ],
+ "IP:IPR017904": [
+  "FPLX:Cofilin"
+ ],
+ "IP:IPR018161": [
+  "FPLX:Wnt"
+ ],
+ "IP:IPR018207": [
+  "FPLX:HMOX"
+ ],
+ "IP:IPR018361": [
+  "FPLX:CAV"
+ ],
+ "IP:IPR018507": [
+  "FPLX:COX6A"
+ ],
+ "IP:IPR018522": [
+  "FPLX:TOP2"
+ ],
+ "IP:IPR019764": [
+  "FPLX:EDN"
+ ],
+ "IP:IPR020475": [
+  "FPLX:EDN"
+ ],
+ "IP:IPR020537": [
+  "FPLX:ATP5G"
+ ],
+ "IP:IPR020684": [
+  "FPLX:ROCK"
+ ],
+ "IP:IPR020777": [
+  "FPLX:NTRK"
+ ],
+ "IP:IPR020810": [
+  "FPLX:ENO"
+ ],
+ "IP:IPR020811": [
+  "FPLX:ENO"
+ ],
+ "IP:IPR022684": [
+  "FPLX:CAPN"
+ ],
+ "IP:IPR023272": [
+  "FPLX:COX7B"
+ ],
+ "IP:IPR023337": [
+  "FPLX:SPRED"
+ ],
+ "IP:IPR023409": [
+  "FPLX:p14_3_3"
+ ],
+ "IP:IPR023410": [
+  "FPLX:p14_3_3"
+ ],
+ "IP:IPR024940": [
+  "FPLX:TCF_LEF"
+ ],
+ "IP:IPR024946": [
+  "FPLX:TOP2"
+ ],
+ "IP:IPR025561": [
+  "FPLX:KSR"
+ ],
+ "IP:IPR026590": [
+  "FPLX:HDAC_III"
+ ],
+ "IP:IPR027288": [
+  "FPLX:PDGFR_BB"
+ ],
+ "IP:IPR027290": [
+  "FPLX:PDGFR_AA"
+ ],
+ "IP:IPR027309": [
+  "FPLX:P2RX"
+ ],
+ "IP:IPR027705": [
+  "FPLX:FLOT"
+ ],
+ "IP:IPR027707": [
+  "FPLX:Troponin_T"
+ ],
+ "IP:IPR027936": [
+  "FPLX:Ephrin_receptor"
+ ],
+ "IP:IPR028412": [
+  "FPLX:RAL"
+ ],
+ "IP:IPR028433": [
+  "FPLX:PARV"
+ ],
+ "IP:IPR028858": [
+  "FPLX:Cyclin_E"
+ ],
+ "IP:IPR028974": [
+  "FPLX:THBS"
+ ],
+ "IP:IPR028992": [
+  "FPLX:Hedgehog"
+ ],
+ "IP:IPR029760": [
+  "FPLX:GPX"
+ ],
+ "IP:IPR029768": [
+  "FPLX:ALDO"
+ ],
+ "IP:IPR030492": [
+  "FPLX:NFkappaB"
+ ],
+ "IP:IPR031327": [
+  "FPLX:MCM"
+ ],
+ "IP:IPR031635": [
+  "FPLX:NTRK"
+ ],
+ "IP:IPR031660": [
+  "FPLX:TOP2"
+ ],
+ "IP:IPR031675": [
+  "FPLX:PPP1C"
+ ],
+ "IP:IPR031905": [
+  "FPLX:FLOT"
+ ],
+ "IP:IPR032067": [
+  "FPLX:FOXO"
+ ],
+ "IP:IPR032101": [
+  "FPLX:AXIN"
+ ],
+ "IP:IPR032270": [
+  "FPLX:AMPK_alpha"
+ ],
+ "IP:IPR032640": [
+  "FPLX:AMPK_beta"
+ ],
+ "IP:IPR033139": [
+  "FPLX:Caspase"
+ ],
+ "IP:IPR033614": [
+  "FPLX:RASSF"
+ ],
+ "IP:IPR033896": [
+  "FPLX:MEF2"
+ ],
+ "IP:IPR033923": [
+  "FPLX:PAK"
+ ],
+ "IP:IPR033926": [
+  "FPLX:NFkappaB"
+ ],
+ "IP:IPR034117": [
+  "FPLX:CRISP"
+ ],
+ "IP:IPR034157": [
+  "FPLX:TOP2"
+ ],
+ "IP:IPR035014": [
+  "FPLX:PRKG"
+ ],
+ "IP:IPR035023": [
+  "FPLX:PLCG"
+ ],
+ "IP:IPR035024": [
+  "FPLX:PLCG"
+ ],
+ "IP:IPR023257": [
+  "FPLX:LXR"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000094": [
+  "FPLX:CREB"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000099": [
+  "FPLX:E2F"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000105": [
+  "FPLX:GATA"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000142": [
+  "FPLX:MAF"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000143": [
+  "FPLX:MEF2"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000150": [
+  "FPLX:NFE"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000156": [
+  "FPLX:NFkappaB"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000157": [
+  "FPLX:RFX"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000159": [
+  "FPLX:SMAD"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000163": [
+  "FPLX:STAT"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000197": [
+  "FPLX:FZD"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000252": [
+  "FPLX:DDR"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000264": [
+  "FPLX:INSR"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000278": [
+  "FPLX:NTRK"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000279": [
+  "FPLX:Notch"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000281": [
+  "FPLX:Patched"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000286": [
+  "FPLX:ROR"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000294": [
+  "FPLX:TGFBR"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000295": [
+  "FPLX:TNFRSF"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000296": [
+  "FPLX:TLR"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000311": [
+  "FPLX:GPCR"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000391": [
+  "FPLX:Chemokine"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000423": [
+  "FPLX:TGFB"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000426": [
+  "FPLX:Wnt"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000434": [
+  "FPLX:GSK3"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000439": [
+  "FPLX:AKT"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000447": [
+  "FPLX:PI3K"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000452": [
+  "FPLX:CALM"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000455": [
+  "FPLX:PLA2"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000458": [
+  "FPLX:ERK"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000462": [
+  "FPLX:MEK"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000464": [
+  "FPLX:JAK"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000465": [
+  "FPLX:RAS"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000468": [
+  "FPLX:PAK"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000473": [
+  "FPLX:JNK"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000477": [
+  "FPLX:p38"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000479": [
+  "FPLX:NADPH_oxidase"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000494": [
+  "FPLX:NOS"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000499": [
+  "FPLX:RHO"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000504": [
+  "FPLX:VAV"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000509": [
+  "FPLX:SRC"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000551": [
+  "FPLX:CDC25"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000567": [
+  "FPLX:ABL_family"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000571": [
+  "FPLX:APC_C"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000585": [
+  "FPLX:IRS"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000586": [
+  "FPLX:IGFBP"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000587": [
+  "FPLX:Hedgehog"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000615": [
+  "FPLX:IL1"
+ ],
+ "MEDSCAN:urn:agi-aopfc:0000704": [
+  "FPLX:PDE6"
+ ],
+ "MEDSCAN:urn:agi-complex:CaM%20kinase%20II": [
+  "FPLX:CAMK2_complex"
+ ],
+ "MEDSCAN:urn:agi-complex:CD3%20complex": [
+  "FPLX:CD3"
+ ],
+ "MEDSCAN:urn:agi-complex:CD8": [
+  "FPLX:CD8"
+ ],
+ "MEDSCAN:urn:agi-complex:HIF-1": [
+  "FPLX:HIF1"
+ ],
+ "MEDSCAN:urn:agi-complex:IFNGR": [
+  "FPLX:Interferon_gamma_receptor"
+ ],
+ "MEDSCAN:urn:agi-complex:IKK%20complex": [
+  "FPLX:IKK_complex"
+ ],
+ "MEDSCAN:urn:agi-complex:IL12": [
+  "FPLX:IL12"
+ ],
+ "MEDSCAN:urn:agi-complex:inhibin%20A": [
+  "FPLX:Inhibin_A"
+ ],
+ "MEDSCAN:urn:agi-complex:Luteinizing%20hormone": [
+  "FPLX:LH"
+ ],
+ "MEDSCAN:urn:agi-complex:MAC-1%20(integrin)": [
+  "FPLX:Integrins"
+ ],
+ "MEDSCAN:urn:agi-complex:NF-E2": [
+  "FPLX:NFE"
+ ],
+ "MEDSCAN:urn:agi-complex:platelet%20derived%20growth%20factor%20AA": [
+  "FPLX:PDGF_AA"
+ ],
+ "MEDSCAN:urn:agi-complex:platelet%20derived%20growth%20factor%20AB": [
+  "FPLX:PDGF_AB"
+ ],
+ "MEDSCAN:urn:agi-complex:platelet%20derived%20growth%20factor%20BB": [
+  "FPLX:PDGF_BB"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-047b61fab6d7e7445346cc84dafcb267": [
+  "FPLX:FZD"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-0d528c29d63997f87f62e4fbd9f0b168": [
+  "FPLX:mTORC2"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-0f8242e28423189d7ef714808fdcc121": [
+  "FPLX:Histone"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-285b9ff3749679e4d6266406a20973aa": [
+  "FPLX:PI3K"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-2b612daa76feb2db86ff39e70449df6b": [
+  "FPLX:PRC2_complex"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-2de597c3f4a807f3caeaf02e5f93ce15": [
+  "FPLX:STAT"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-40bc2e4348830d6f7bdacd573fd7c388": [
+  "FPLX:E2F"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-44f61960049704dc2afb23ff7c324b85": [
+  "FPLX:HIF1"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-4dda466320b1a32b046d823accadbaee": [
+  "FPLX:CDK"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-50bd08479c3770278693a51fe379babd": [
+  "FPLX:Ubiquitin"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-72ef5fc0ab431a39e0e2915bf55b6e28": [
+  "FPLX:SMAD"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-7629c2cdfdf4908b72f13917a7c1551e": [
+  "FPLX:RFC"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-763d31b31e177311583df0ac1ea015da": [
+  "FPLX:GPCR"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-7e8823afb9ca7870b95633dcb782500b": [
+  "FPLX:HDAC"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-8a9e47ee0ee03d8d8b6e029e2fba6896": [
+  "FPLX:Cadherin"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-8cfce9bfac3857e6f068d517deadfeaa": [
+  "FPLX:NFkappaB"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-8d885376e30916afd0b47ccf1b044e75": [
+  "FPLX:JUN_family"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-90a087d4e73b3992c65edfd9f71c6802": [
+  "FPLX:Tubulin"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-9e456bf1de2c5eb1107156c96a1450e6": [
+  "FPLX:TGFBR"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-aba0c4130764ae7a26054736114e65cd": [
+  "FPLX:PRC1_complex"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-bd459ca2937257c9e3f2b75abf22f422": [
+  "FPLX:RXR"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-c3bac0781a4430da4cf6721b8f7537d9": [
+  "FPLX:CUL"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-cd6413d79122d5489ee4b4e339245b61": [
+  "FPLX:CCT_complex"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-d39afef40daf23ad8376b53904c7092c": [
+  "FPLX:PPP1"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-d9fbae788d60df23b6be4a3ead2cbab4": [
+  "FPLX:RNApo_II"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-dd63d0a558770b12c9149b4955828f35": [
+  "FPLX:APC_C"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-e4ec238e69c3d3292966ac97dbc11086": [
+  "FPLX:Troponin"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-e6be10f6a8e79aed1daa4ec2ac191db1": [
+  "FPLX:MCM"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-e9fbfd73e486bda4d99b348f72bb4196": [
+  "FPLX:GTPase"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-f2e03d3bf1f747adab17ce77b9b5e5b3": [
+  "FPLX:PPP2"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-f472fef3f59301aee0b776702a30f03e": [
+  "FPLX:mTORC1"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-f7a9dc05e48afd7a93466cfbd5504861": [
+  "FPLX:SWI_SNF"
+ ],
+ "MEDSCAN:urn:agi-complex:prophash-f7e292d6e30998b81cf5f772ab430f11": [
+  "FPLX:CALM"
+ ],
+ "MEDSCAN:urn:agi-complex:protein%20phosphatase%203": [
+  "FPLX:PPP3"
+ ],
+ "MEDSCAN:urn:agi-complex:protein%20phosphatase%20type%201%20complex": [
+  "FPLX:PPP1"
+ ],
+ "MEDSCAN:urn:agi-complex:protein%20phosphatase%20type%202A%20complex": [
+  "FPLX:PPP2"
+ ],
+ "MEDSCAN:urn:agi-complex:SMAD2%2f3": [
+  "FPLX:SMAD2_3"
+ ],
+ "MEDSCAN:urn:agi-protfc:14-3-3": [
+  "FPLX:p14_3_3"
+ ],
+ "MEDSCAN:urn:agi-protfc:actins": [
+  "FPLX:Actin"
+ ],
+ "MEDSCAN:urn:agi-protfc:AMPK": [
+  "FPLX:AMPK"
+ ],
+ "MEDSCAN:urn:agi-protfc:apolipoprotein": [
+  "FPLX:Apolipoprotein"
+ ],
+ "MEDSCAN:urn:agi-protfc:bone%20morphogenetic%20protein%20I%20receptor": [
+  "FPLX:BMP_receptor_type_I"
+ ],
+ "MEDSCAN:urn:agi-protfc:cadherin": [
+  "FPLX:Cadherin"
+ ],
+ "MEDSCAN:urn:agi-protfc:casein%20kinase%20I": [
+  "FPLX:CSNK1"
+ ],
+ "MEDSCAN:urn:agi-protfc:caveolin": [
+  "FPLX:CAV"
+ ],
+ "MEDSCAN:urn:agi-protfc:checkpoint%20kinase": [
+  "FPLX:CHEK"
+ ],
+ "MEDSCAN:urn:agi-protfc:chromatin%20remodeling%20complex": [
+  "FPLX:SWI_SNF"
+ ],
+ "MEDSCAN:urn:agi-protfc:class%20c%20orphan%20receptor": [
+  "FPLX:GPCR"
+ ],
+ "MEDSCAN:urn:agi-protfc:cullin": [
+  "FPLX:CUL"
+ ],
+ "MEDSCAN:urn:agi-protfc:cyclin": [
+  "FPLX:Cyclin"
+ ],
+ "MEDSCAN:urn:agi-protfc:cyclophilins": [
+  "FPLX:Cyclophilin"
+ ],
+ "MEDSCAN:urn:agi-protfc:cytosolic%20phospholipase%20a2": [
+  "FPLX:PLA2"
+ ],
+ "MEDSCAN:urn:agi-protfc:desmoglein": [
+  "FPLX:Desmoglein"
+ ],
+ "MEDSCAN:urn:agi-protfc:endothelin": [
+  "FPLX:EDN"
+ ],
+ "MEDSCAN:urn:agi-protfc:F-actin-binding%20protein": [
+  "FPLX:F_actin"
+ ],
+ "MEDSCAN:urn:agi-protfc:flotillin": [
+  "FPLX:FLOT"
+ ],
+ "MEDSCAN:urn:agi-protfc:hemoglobin": [
+  "FPLX:Hemoglobin"
+ ],
+ "MEDSCAN:urn:agi-protfc:histone%20H1": [
+  "FPLX:Histone_H1"
+ ],
+ "MEDSCAN:urn:agi-protfc:histone%20H2A": [
+  "FPLX:Histone_H2A"
+ ],
+ "MEDSCAN:urn:agi-protfc:histone%20H2B": [
+  "FPLX:Histone_H2B"
+ ],
+ "MEDSCAN:urn:agi-protfc:histone%20H3": [
+  "FPLX:Histone_H3"
+ ],
+ "MEDSCAN:urn:agi-protfc:histone%20H4": [
+  "FPLX:Histone_H4"
+ ],
+ "MEDSCAN:urn:agi-protfc:histone": [
+  "FPLX:Histone"
+ ],
+ "MEDSCAN:urn:agi-protfc:interferon": [
+  "FPLX:Interferon"
+ ],
+ "MEDSCAN:urn:agi-protfc:kallikrein": [
+  "FPLX:KLK"
+ ],
+ "MEDSCAN:urn:agi-protfc:mglur": [
+  "FPLX:GRM"
+ ],
+ "MEDSCAN:urn:agi-protfc:myosin%20heavy%20chain": [
+  "FPLX:MYH"
+ ],
+ "MEDSCAN:urn:agi-protfc:myosin%20light%20chain": [
+  "FPLX:MYL"
+ ],
+ "MEDSCAN:urn:agi-protfc:neuregulin%20family": [
+  "FPLX:NRG"
+ ],
+ "MEDSCAN:urn:agi-protfc:p2y%20receptor": [
+  "FPLX:P2RY"
+ ],
+ "MEDSCAN:urn:agi-protfc:p70rsk": [
+  "FPLX:P70S6K"
+ ],
+ "MEDSCAN:urn:agi-protfc:p90rsk": [
+  "FPLX:P90RSK"
+ ],
+ "MEDSCAN:urn:agi-protfc:PDE4%20subfamily": [
+  "FPLX:PDE4"
+ ],
+ "MEDSCAN:urn:agi-protfc:phosphodiesterase%20III": [
+  "FPLX:PDE3"
+ ],
+ "MEDSCAN:urn:agi-protfc:ppar": [
+  "FPLX:PPAR"
+ ],
+ "MEDSCAN:urn:agi-protfc:profilin": [
+  "FPLX:PFN"
+ ],
+ "MEDSCAN:urn:agi-protfc:rab": [
+  "FPLX:RAB"
+ ],
+ "MEDSCAN:urn:agi-protfc:sarcoplasmic%20reticulum%20calcium%20transporting%20adenosine%20triphosphatase": [
+  "FPLX:SERCA"
+ ],
+ "MEDSCAN:urn:agi-protfc:shc%20protein": [
+  "FPLX:SHC"
+ ],
+ "MEDSCAN:urn:agi-protfc:STAT5%20protein": [
+  "FPLX:STAT5"
+ ],
+ "MEDSCAN:urn:agi-protfc:sterol%20regulatory%20element%20binding%20protein": [
+  "FPLX:SREBF"
+ ],
+ "MEDSCAN:urn:agi-protfc:SWI%2fSNF%20family": [
+  "FPLX:SWI_SNF"
+ ],
+ "MEDSCAN:urn:agi-protfc:thioredoxin": [
+  "FPLX:TXN"
+ ],
+ "MEDSCAN:urn:agi-protfc:thrombospondins": [
+  "FPLX:THBS"
+ ],
+ "MEDSCAN:urn:agi-protfc:tubulin": [
+  "FPLX:Tubulin"
+ ],
+ "MEDSCAN:urn:agi-protfc:ubiquitin": [
+  "FPLX:Ubiquitin"
+ ],
+ "MESH:C072194": [
+  "FPLX:PDGF_BB"
+ ],
+ "MESH:D000199": [
+  "FPLX:Actin"
+ ],
+ "MESH:D018002": [
+  "FPLX:BDKR"
+ ],
+ "MESH:D002403": [
+  "FPLX:Cathepsin"
+ ],
+ "MESH:D003576": [
+  "FPLX:ETC_complex_IV"
+ ],
+ "MESH:D005337": [
+  "FPLX:Fibrin"
+ ],
+ "MESH:D006657": [
+  "FPLX:Histone"
+ ],
+ "MESH:D007987": [
+  "FPLX:GNRH"
+ ],
+ "MESH:D010749": [
+  "FPLX:Phosphatase"
+ ],
+ "MESH:D011493": [
+  "FPLX:PKC"
+ ],
+ "MESH:D011948": [
+  "FPLX:TCR"
+ ],
+ "MESH:D014450": [
+  "FPLX:ETC_complex_III"
+ ],
+ "MESH:D016695": [
+  "FPLX:Glycosyltransferase"
+ ],
+ "MESH:D017476": [
+  "FPLX:NPYR"
+ ],
+ "MESH:D018808": [
+  "FPLX:AP1"
+ ],
+ "MESH:D018844": [
+  "FPLX:CDK"
+ ],
+ "MESH:D020169": [
+  "FPLX:Caspase"
+ ],
+ "MESH:D025261": [
+  "FPLX:ETC_complex_V"
+ ],
+ "MESH:D042963": [
+  "FPLX:ETC_complex_II"
+ ],
+ "MESH:D042967": [
+  "FPLX:ETC_complex_I"
+ ],
+ "MESH:D046988": [
+  "FPLX:Proteasome"
+ ],
+ "MESH:D053759": [
+  "FPLX:IL23"
+ ],
+ "MESH:D000071756": [
+  "FPLX:SGC"
+ ],
+ "NCIT:C104194": [
+  "FPLX:Cyclin_D"
+ ],
+ "NCIT:C104197": [
+  "FPLX:Cyclin_E"
+ ],
+ "NCIT:C104199": [
+  "FPLX:IKK_family"
+ ],
+ "NCIT:C104676": [
+  "FPLX:TN"
+ ],
+ "NCIT:C105947": [
+  "FPLX:MAP2K"
+ ],
+ "NCIT:C105952": [
+  "FPLX:APOA"
+ ],
+ "NCIT:C107433": [
+  "FPLX:PDE4"
+ ],
+ "NCIT:C107559": [
+  "FPLX:CK2"
+ ],
+ "NCIT:C112049": [
+  "FPLX:ETC_complex_II"
+ ],
+ "NCIT:C112051": [
+  "FPLX:Carboxylesterase"
+ ],
+ "NCIT:C113839": [
+  "FPLX:HIF"
+ ],
+ "NCIT:C116019": [
+  "FPLX:AMPK_alpha"
+ ],
+ "NCIT:C118184": [
+  "FPLX:ETC_complex_I"
+ ],
+ "NCIT:C118481": [
+  "FPLX:ALDH"
+ ],
+ "NCIT:C118892": [
+  "FPLX:FOXO"
+ ],
+ "NCIT:C120030": [
+  "FPLX:Tryptase"
+ ],
+ "NCIT:C120493": [
+  "FPLX:Hedgehog"
+ ],
+ "NCIT:C124129": [
+  "FPLX:COL1"
+ ],
+ "NCIT:C126114": [
+  "FPLX:PLCG"
+ ],
+ "NCIT:C126122": [
+  "FPLX:GPIb_IX_V"
+ ],
+ "NCIT:C129655": [
+  "FPLX:TUBB"
+ ],
+ "NCIT:C147535": [
+  "FPLX:IL23"
+ ],
+ "NCIT:C16258": [
+  "FPLX:Actin"
+ ],
+ "NCIT:C16264": [
+  "FPLX:ADCY"
+ ],
+ "NCIT:C16272": [
+  "FPLX:ADH"
+ ],
+ "NCIT:C16373": [
+  "FPLX:Cadherin"
+ ],
+ "NCIT:C16375": [
+  "FPLX:CALM"
+ ],
+ "NCIT:C16376": [
+  "FPLX:MAPK",
+  "FPLX:ERK"
+ ],
+ "NCIT:C16377": [
+  "FPLX:CAPN"
+ ],
+ "NCIT:C16448": [
+  "FPLX:COL4"
+ ],
+ "NCIT:C16479": [
+  "FPLX:PKA"
+ ],
+ "NCIT:C16511": [
+  "FPLX:DNA_polymerase_delta"
+ ],
+ "NCIT:C16641": [
+  "FPLX:GST"
+ ],
+ "NCIT:C16650": [
+  "FPLX:GTPase"
+ ],
+ "NCIT:C16653": [
+  "FPLX:GUCY"
+ ],
+ "NCIT:C16676": [
+  "FPLX:Hemoglobin"
+ ],
+ "NCIT:C16682": [
+  "FPLX:HDAC"
+ ],
+ "NCIT:C16683": [
+  "FPLX:Histone_H1"
+ ],
+ "NCIT:C16684": [
+  "FPLX:Histone_H2A"
+ ],
+ "NCIT:C16685": [
+  "FPLX:Histone_H3"
+ ],
+ "NCIT:C16686": [
+  "FPLX:Histone_H4"
+ ],
+ "NCIT:C16687": [
+  "FPLX:Histone"
+ ],
+ "NCIT:C16692": [
+  "FPLX:HLA_DR"
+ ],
+ "NCIT:C16748": [
+  "FPLX:Integrins"
+ ],
+ "NCIT:C16965": [
+  "FPLX:Protease"
+ ],
+ "NCIT:C16979": [
+  "FPLX:PLA2"
+ ],
+ "NCIT:C16981": [
+  "FPLX:Phosphatase"
+ ],
+ "NCIT:C17017": [
+  "FPLX:PKC"
+ ],
+ "NCIT:C17061": [
+  "FPLX:RAS"
+ ],
+ "NCIT:C17062": [
+  "FPLX:ADRB"
+ ],
+ "NCIT:C17065": [
+  "FPLX:TCR"
+ ],
+ "NCIT:C17066": [
+  "FPLX:DRD"
+ ],
+ "NCIT:C17078": [
+  "FPLX:THR"
+ ],
+ "NCIT:C17219": [
+  "FPLX:Tubulin"
+ ],
+ "NCIT:C17227": [
+  "FPLX:Ubiquitin"
+ ],
+ "NCIT:C17270": [
+  "FPLX:PI3K"
+ ],
+ "NCIT:C17274": [
+  "FPLX:BMP"
+ ],
+ "NCIT:C17286": [
+  "FPLX:CREB"
+ ],
+ "NCIT:C17293": [
+  "FPLX:VEGFR"
+ ],
+ "NCIT:C17297": [
+  "FPLX:FGFR"
+ ],
+ "NCIT:C17298": [
+  "FPLX:GAP"
+ ],
+ "NCIT:C17322": [
+  "FPLX:PDGFR"
+ ],
+ "NCIT:C17343": [
+  "FPLX:Troponin_I"
+ ],
+ "NCIT:C17349": [
+  "FPLX:Cyclin"
+ ],
+ "NCIT:C17380": [
+  "FPLX:NFkappaB"
+ ],
+ "NCIT:C17450": [
+  "FPLX:AP1"
+ ],
+ "NCIT:C17458": [
+  "FPLX:G_protein"
+ ],
+ "NCIT:C17487": [
+  "FPLX:CD16"
+ ],
+ "NCIT:C17494": [
+  "FPLX:GEF"
+ ],
+ "NCIT:C17532": [
+  "FPLX:RAR"
+ ],
+ "NCIT:C17534": [
+  "FPLX:RXR"
+ ],
+ "NCIT:C17583": [
+  "FPLX:IKB"
+ ],
+ "NCIT:C17660": [
+  "FPLX:RTK"
+ ],
+ "NCIT:C17690": [
+  "FPLX:HIF1"
+ ],
+ "NCIT:C17763": [
+  "FPLX:ERBB"
+ ],
+ "NCIT:C17766": [
+  "FPLX:HSP90"
+ ],
+ "NCIT:C17767": [
+  "FPLX:CDK"
+ ],
+ "NCIT:C17903": [
+  "FPLX:NFAT"
+ ],
+ "NCIT:C18153": [
+  "FPLX:Caspase"
+ ],
+ "NCIT:C18162": [
+  "FPLX:EIF2B"
+ ],
+ "NCIT:C18164": [
+  "FPLX:MMP"
+ ],
+ "NCIT:C18239": [
+  "FPLX:GPCR"
+ ],
+ "NCIT:C18308": [
+  "FPLX:CD32"
+ ],
+ "NCIT:C18434": [
+  "FPLX:TOP2"
+ ],
+ "NCIT:C18492": [
+  "FPLX:CDKN"
+ ],
+ "NCIT:C18606": [
+  "FPLX:Ephrin_receptor"
+ ],
+ "NCIT:C19275": [
+  "FPLX:G_i_alpha"
+ ],
+ "NCIT:C19618": [
+  "FPLX:STAT"
+ ],
+ "NCIT:C19836": [
+  "FPLX:PLA2G4"
+ ],
+ "NCIT:C19866": [
+  "FPLX:PRC1_complex"
+ ],
+ "NCIT:C20448": [
+  "FPLX:PDGF"
+ ],
+ "NCIT:C129646": [
+  "FPLX:VEGF"
+ ],
+ "NCIT:C20456": [
+  "FPLX:Activin"
+ ],
+ "NCIT:C20466": [
+  "FPLX:Chemokine"
+ ],
+ "NCIT:C20493": [
+  "FPLX:Interferon"
+ ],
+ "NCIT:C20495": [
+  "FPLX:IFNB"
+ ],
+ "NCIT:C20506": [
+  "FPLX:IL1"
+ ],
+ "NCIT:C20514": [
+  "FPLX:IL12"
+ ],
+ "NCIT:C20591": [
+  "FPLX:SWI_SNF"
+ ],
+ "NCIT:C2270": [
+  "FPLX:GNRH"
+ ],
+ "NCIT:C2275": [
+  "FPLX:hCG"
+ ],
+ "NCIT:C2276": [
+  "FPLX:Inhibin"
+ ],
+ "NCIT:C2277": [
+  "FPLX:Inhibin_A"
+ ],
+ "NCIT:C2278": [
+  "FPLX:Inhibin_B"
+ ],
+ "NCIT:C25184": [
+  "FPLX:LDH"
+ ],
+ "NCIT:C25186": [
+  "FPLX:HDL"
+ ],
+ "NCIT:C26034": [
+  "FPLX:ETC_complex_IV"
+ ],
+ "NCIT:C26233": [
+  "FPLX:GRK"
+ ],
+ "NCIT:C26360": [
+  "FPLX:ERK"
+ ],
+ "NCIT:C28687": [
+  "FPLX:CRSP"
+ ],
+ "NCIT:C38041": [
+  "FPLX:Troponin_T"
+ ],
+ "NCIT:C38897": [
+  "FPLX:CD3"
+ ],
+ "NCIT:C41625": [
+  "FPLX:AKT"
+ ],
+ "NCIT:C736": [
+  "FPLX:Pertussis_toxin"
+ ],
+ "NCIT:C94701": [
+  "FPLX:AMPK"
+ ],
+ "NCIT:C95114": [
+  "FPLX:Gamma_secretase"
+ ],
+ "NCIT:C95947": [
+  "FPLX:RNApo_I"
+ ],
+ "NCIT:C95948": [
+  "FPLX:RNApo_II"
+ ],
+ "NCIT:C96314": [
+  "FPLX:mTORC1"
+ ],
+ "NCIT:C96315": [
+  "FPLX:mTORC2"
+ ],
+ "NXP:FA:00078": [
+  "FPLX:Actin"
+ ],
+ "NXP:FA:00093": [
+  "FPLX:ACAD"
+ ],
+ "NXP:FA:00209": [
+  "FPLX:TFAP2"
+ ],
+ "NXP:FA:00406": [
+  "FPLX:CEBP"
+ ],
+ "NXP:FA:00408": [
+  "FPLX:FOS_family"
+ ],
+ "NXP:FA:00421": [
+  "FPLX:PPP3R"
+ ],
+ "NXP:FA:00440": [
+  "FPLX:CALM"
+ ],
+ "NXP:FA:00489": [
+  "FPLX:CAV"
+ ],
+ "NXP:FA:00653": [
+  "FPLX:CNKSR"
+ ],
+ "NXP:FA:00787": [
+  "FPLX:CUL"
+ ],
+ "NXP:FA:00803": [
+  "FPLX:PDE3"
+ ],
+ "NXP:FA:00804": [
+  "FPLX:PDE4"
+ ],
+ "NXP:FA:00815": [
+  "FPLX:Cyclin"
+ ],
+ "NXP:FA:00818": [
+  "FPLX:Cyclin_D"
+ ],
+ "NXP:FA:00819": [
+  "FPLX:Cyclin_E"
+ ],
+ "NXP:FA:00921": [
+  "FPLX:EIF4A"
+ ],
+ "NXP:FA:01112": [
+  "FPLX:ENO"
+ ],
+ "NXP:FA:01121": [
+  "FPLX:EPN"
+ ],
+ "NXP:FA:01400": [
+  "FPLX:G_gamma"
+ ],
+ "NXP:FA:01553": [
+  "FPLX:GPX"
+ ],
+ "NXP:FA:01669": [
+  "FPLX:GST"
+ ],
+ "NXP:FA:01729": [
+  "FPLX:Hedgehog"
+ ],
+ "NXP:FA:01762": [
+  "FPLX:Histone_H2A"
+ ],
+ "NXP:FA:01764": [
+  "FPLX:Histone_H3"
+ ],
+ "NXP:FA:01765": [
+  "FPLX:Histone_H4"
+ ],
+ "NXP:FA:01820": [
+  "FPLX:IL1"
+ ],
+ "NXP:FA:02022": [
+  "FPLX:LDH"
+ ],
+ "NXP:FA:02159": [
+  "FPLX:SLC2A"
+ ],
+ "NXP:FA:02187": [
+  "FPLX:MCM"
+ ],
+ "NXP:FA:02504": [
+  "FPLX:NOS"
+ ],
+ "NXP:FA:02506": [
+  "FPLX:Notch"
+ ],
+ "NXP:FA:02630": [
+  "FPLX:P2RX"
+ ],
+ "NXP:FA:02632": [
+  "FPLX:p53_family"
+ ],
+ "NXP:FA:02660": [
+  "FPLX:PARV"
+ ],
+ "NXP:FA:02762": [
+  "FPLX:ELA"
+ ],
+ "NXP:FA:02767": [
+  "FPLX:Tryptase"
+ ],
+ "NXP:FA:02840": [
+  "FPLX:PLA2"
+ ],
+ "NXP:FA:03001": [
+  "FPLX:PPP1"
+ ],
+ "NXP:FA:03065": [
+  "FPLX:PKC"
+ ],
+ "NXP:FA:03066": [
+  "FPLX:RAC"
+ ],
+ "NXP:FA:03071": [
+  "FPLX:AMPK"
+ ],
+ "NXP:FA:03072": [
+  "FPLX:CAMK"
+ ],
+ "NXP:FA:03078": [
+  "FPLX:PIM"
+ ],
+ "NXP:FA:03083": [
+  "FPLX:CSNK1"
+ ],
+ "NXP:FA:03087": [
+  "FPLX:GSK3"
+ ],
+ "NXP:FA:03091": [
+  "FPLX:DYRK"
+ ],
+ "NXP:FA:03101": [
+  "FPLX:CK2"
+ ],
+ "NXP:FA:03104": [
+  "FPLX:IKK_family"
+ ],
+ "NXP:FA:03114": [
+  "FPLX:RAF"
+ ],
+ "NXP:FA:03124": [
+  "FPLX:Ephrin_receptor"
+ ],
+ "NXP:FA:03128": [
+  "FPLX:INSR"
+ ],
+ "NXP:FA:03129": [
+  "FPLX:JAK"
+ ],
+ "NXP:FA:03130": [
+  "FPLX:ROR"
+ ],
+ "NXP:FA:03131": [
+  "FPLX:SRC"
+ ],
+ "NXP:FA:03483": [
+  "FPLX:SAA"
+ ],
+ "NXP:FA:03579": [
+  "FPLX:SERPINB"
+ ],
+ "NXP:FA:03661": [
+  "FPLX:RAB"
+ ],
+ "NXP:FA:03663": [
+  "FPLX:RAS"
+ ],
+ "NXP:FA:03668": [
+  "FPLX:RHO"
+ ],
+ "NXP:FA:03672": [
+  "FPLX:SLRP"
+ ],
+ "NXP:FA:03673": [
+  "FPLX:SLRP_1"
+ ],
+ "NXP:FA:03674": [
+  "FPLX:SLRP_2"
+ ],
+ "NXP:FA:03675": [
+  "FPLX:SLRP_3"
+ ],
+ "NXP:FA:03676": [
+  "FPLX:SLRP_4"
+ ],
+ "NXP:FA:03677": [
+  "FPLX:SLRP_5"
+ ],
+ "NXP:FA:03686": [
+  "FPLX:SMC1"
+ ],
+ "NXP:FA:03943": [
+  "FPLX:TCF_LEF"
+ ],
+ "NXP:FA:03964": [
+  "FPLX:TN"
+ ],
+ "NXP:FA:03989": [
+  "FPLX:TGFB"
+ ],
+ "NXP:FA:04000": [
+  "FPLX:TXN"
+ ],
+ "NXP:FA:04014": [
+  "FPLX:TIAM"
+ ],
+ "NXP:FA:04239": [
+  "FPLX:Tubulin"
+ ],
+ "NXP:FA:04243": [
+  "FPLX:TNF"
+ ],
+ "NXP:FA:04276": [
+  "FPLX:Ubiquitin"
+ ],
+ "NXP:FA:04282": [
+  "FPLX:UBE2"
+ ],
+ "NXP:FA:04686": [
+  "FPLX:Wnt"
+ ],
+ "NXP:FA:04773": [
+  "FPLX:RAP1"
+ ],
+ "PF:PF00012": [
+  "FPLX:HSPA"
+ ],
+ "PF:PF00022": [
+  "FPLX:Actin"
+ ],
+ "PF:PF00028": [
+  "FPLX:Cadherin"
+ ],
+ "PF:PF00066": [
+  "FPLX:Notch"
+ ],
+ "PF:PF00071": [
+  "FPLX:RAS"
+ ],
+ "PF:PF00110": [
+  "FPLX:Wnt"
+ ],
+ "PF:PF00143": [
+  "FPLX:Interferon"
+ ],
+ "PF:PF00146": [
+  "FPLX:NADH_dehydrogenase"
+ ],
+ "PF:PF00167": [
+  "FPLX:FGF"
+ ],
+ "PF:PF00178": [
+  "FPLX:ETS"
+ ],
+ "PF:PF00183": [
+  "FPLX:HSP90"
+ ],
+ "PF:PF00219": [
+  "FPLX:IGFBP"
+ ],
+ "PF:PF00225": [
+  "FPLX:Kinesin"
+ ],
+ "PF:PF00229": [
+  "FPLX:TNF"
+ ],
+ "PF:PF00235": [
+  "FPLX:PFN"
+ ],
+ "PF:PF00244": [
+  "FPLX:p14_3_3"
+ ],
+ "PF:PF00255": [
+  "FPLX:GPX"
+ ],
+ "PF:PF00277": [
+  "FPLX:SAA"
+ ],
+ "PF:PF00320": [
+  "FPLX:GATA"
+ ],
+ "PF:PF00322": [
+  "FPLX:EDN"
+ ],
+ "PF:PF00340": [
+  "FPLX:IL1"
+ ],
+ "PF:PF00465": [
+  "FPLX:ADH"
+ ],
+ "PF:PF00493": [
+  "FPLX:MCM"
+ ],
+ "PF:PF00503": [
+  "FPLX:G_alpha"
+ ],
+ "PF:PF00616": [
+  "FPLX:RasGAP"
+ ],
+ "PF:PF00644": [
+  "FPLX:PARP"
+ ],
+ "PF:PF00656": [
+  "FPLX:Caspase"
+ ],
+ "PF:PF00864": [
+  "FPLX:P2RX"
+ ],
+ "PF:PF00870": [
+  "FPLX:p53_family"
+ ],
+ "PF:PF00888": [
+  "FPLX:CUL"
+ ],
+ "PF:PF00963": [
+  "FPLX:Cohesin"
+ ],
+ "PF:PF01146": [
+  "FPLX:CAV"
+ ],
+ "PF:PF01442": [
+  "FPLX:Apolipoprotein"
+ ],
+ "PF:PF01534": [
+  "FPLX:FZD"
+ ],
+ "PF:PF01756": [
+  "FPLX:ACOX"
+ ],
+ "PF:PF02046": [
+  "FPLX:COX6A"
+ ],
+ "PF:PF02158": [
+  "FPLX:NRG"
+ ],
+ "PF:PF02174": [
+  "FPLX:IRS"
+ ],
+ "PF:PF02234": [
+  "FPLX:CDKN"
+ ],
+ "PF:PF02238": [
+  "FPLX:COX7A"
+ ],
+ "PF:PF02285": [
+  "FPLX:COX8"
+ ],
+ "PF:PF02297": [
+  "FPLX:COX6B"
+ ],
+ "PF:PF02377": [
+  "FPLX:DVL"
+ ],
+ "PF:PF02460": [
+  "FPLX:Patched"
+ ],
+ "PF:PF02545": [
+  "FPLX:MAF"
+ ],
+ "PF:PF02608": [
+  "FPLX:BMP"
+ ],
+ "PF:PF02827": [
+  "FPLX:PKI"
+ ],
+ "PF:PF02854": [
+  "FPLX:EIF4G"
+ ],
+ "PF:PF02936": [
+  "FPLX:COX4"
+ ],
+ "PF:PF03039": [
+  "FPLX:IL12"
+ ],
+ "PF:PF03096": [
+  "FPLX:NDRG"
+ ],
+ "PF:PF05392": [
+  "FPLX:COX7B"
+ ],
+ "PF:PF08137": [
+  "FPLX:DVL"
+ ],
+ "PF:PF08562": [
+  "FPLX:CRISP"
+ ],
+ "PF:PF08841": [
+  "FPLX:DDR"
+ ],
+ "PF:PF11413": [
+  "FPLX:HIF1"
+ ],
+ "PF:PF12483": [
+  "FPLX:E3_Ub_ligase"
+ ],
+ "PF:PF15975": [
+  "FPLX:FLOT"
+ ],
+ "RE:R-HSA-1031694": [
+  "FPLX:CD64"
+ ],
+ "RE:R-HSA-109631": [
+  "FPLX:GTF2F"
+ ],
+ "RE:R-HSA-109633": [
+  "FPLX:GTF2E"
+ ],
+ "RE:R-HSA-109782": [
+  "FPLX:RAS"
+ ],
+ "RE:R-HSA-109783": [
+  "FPLX:RAS"
+ ],
+ "RE:R-HSA-109796": [
+  "FPLX:RAS"
+ ],
+ "RE:R-HSA-111854": [
+  "FPLX:PLCB"
+ ],
+ "RE:R-HSA-111864": [
+  "FPLX:G_i",
+  "FPLX:G_i_alpha"
+ ],
+ "RE:R-HSA-111921": [
+  "FPLX:PRKAR"
+ ],
+ "RE:R-HSA-111923": [
+  "FPLX:PRKAR"
+ ],
+ "RE:R-HSA-111952": [
+  "FPLX:PDE1"
+ ],
+ "RE:R-HSA-111953": [
+  "FPLX:PDE1"
+ ],
+ "RE:R-HSA-111960": [
+  "FPLX:PDE4"
+ ],
+ "RE:R-HSA-114525": [
+  "FPLX:G_12_alpha"
+ ],
+ "RE:R-HSA-114534": [
+  "FPLX:G_q",
+  "FPLX:G_q_alpha"
+ ],
+ "RE:R-HSA-114547": [
+  "FPLX:G_12"
+ ],
+ "RE:R-HSA-114556": [
+  "FPLX:G_q",
+  "FPLX:G_q_alpha"
+ ],
+ "RE:R-HSA-114617": [
+  "FPLX:Fibrinogen"
+ ],
+ "RE:R-HSA-114618": [
+  "FPLX:Fibrinogen"
+ ],
+ "RE:R-HSA-114657": [
+  "FPLX:TGFB"
+ ],
+ "RE:R-HSA-114668": [
+  "FPLX:GPIb_IX_V"
+ ],
+ "RE:R-HSA-1168365": [
+  "FPLX:PLCG"
+ ],
+ "RE:R-HSA-1168621": [
+  "FPLX:IKK_complex"
+ ],
+ "RE:R-HSA-1169086": [
+  "FPLX:PLCG"
+ ],
+ "RE:R-HSA-1169089": [
+  "FPLX:PLCG"
+ ],
+ "RE:R-HSA-1218829": [
+  "FPLX:HSP90AA"
+ ],
+ "RE:R-HSA-1221657": [
+  "FPLX:HSP90AA"
+ ],
+ "RE:R-HSA-1227956": [
+  "FPLX:NRG_1_2"
+ ],
+ "RE:R-HSA-1227957": [
+  "FPLX:NRG"
+ ],
+ "RE:R-HSA-1234130": [
+  "FPLX:HIF"
+ ],
+ "RE:R-HSA-1234147": [
+  "FPLX:HIF_alpha"
+ ],
+ "RE:R-HSA-1236898": [
+  "FPLX:CD64"
+ ],
+ "RE:R-HSA-1236905": [
+  "FPLX:CD64"
+ ],
+ "RE:R-HSA-1247495": [
+  "FPLX:NRG_1_2"
+ ],
+ "RE:R-HSA-1248743": [
+  "FPLX:NRG_1_2"
+ ],
+ "RE:R-HSA-1250100": [
+  "FPLX:p38"
+ ],
+ "RE:R-HSA-1250102": [
+  "FPLX:p38"
+ ],
+ "RE:R-HSA-1268261": [
+  "FPLX:ERK"
+ ],
+ "RE:R-HSA-1362227": [
+  "FPLX:TFDP"
+ ],
+ "RE:R-HSA-139848": [
+  "FPLX:P2RX"
+ ],
+ "RE:R-HSA-139933": [
+  "FPLX:Fibrinogen"
+ ],
+ "RE:R-HSA-139934": [
+  "FPLX:Fibrinogen"
+ ],
+ "RE:R-HSA-140586": [
+  "FPLX:Fibrinogen"
+ ],
+ "RE:R-HSA-140812": [
+  "FPLX:Thrombin_antithrombin"
+ ],
+ "RE:R-HSA-140871": [
+  "FPLX:Thrombin_antithrombin"
+ ],
+ "RE:R-HSA-140874": [
+  "FPLX:Thrombin_antithrombin"
+ ],
+ "RE:R-HSA-140919": [
+  "FPLX:Fibrinogen"
+ ],
+ "RE:R-HSA-1445138": [
+  "FPLX:p14_3_3"
+ ],
+ "RE:R-HSA-1449672": [
+  "FPLX:Activin_B"
+ ],
+ "RE:R-HSA-1449688": [
+  "FPLX:Inhibin"
+ ],
+ "RE:R-HSA-1449698": [
+  "FPLX:Activin_AB"
+ ],
+ "RE:R-HSA-1469978": [
+  "FPLX:STAT5"
+ ],
+ "RE:R-HSA-1504201": [
+  "FPLX:DVL"
+ ],
+ "RE:R-HSA-157462": [
+  "FPLX:Cyclin_E"
+ ],
+ "RE:R-HSA-162690": [
+  "FPLX:GPIT"
+ ],
+ "RE:R-HSA-163538": [
+  "FPLX:PPP1C"
+ ],
+ "RE:R-HSA-163679": [
+  "FPLX:AMPK_A2B2G2"
+ ],
+ "RE:R-HSA-163736": [
+  "FPLX:AMPK_A2B2G2"
+ ],
+ "RE:R-HSA-163747": [
+  "FPLX:AMPK_A2B2G2"
+ ],
+ "RE:R-HSA-165175": [
+  "FPLX:TSC"
+ ],
+ "RE:R-HSA-165180": [
+  "FPLX:TSC"
+ ],
+ "RE:R-HSA-1655720": [
+  "FPLX:SREBF"
+ ],
+ "RE:R-HSA-1655725": [
+  "FPLX:SREBF"
+ ],
+ "RE:R-HSA-1655726": [
+  "FPLX:SREBF"
+ ],
+ "RE:R-HSA-1655730": [
+  "FPLX:SREBF"
+ ],
+ "RE:R-HSA-1655732": [
+  "FPLX:SREBF"
+ ],
+ "RE:R-HSA-1655734": [
+  "FPLX:SREBF"
+ ],
+ "RE:R-HSA-165631": [
+  "FPLX:ETC_complex_II"
+ ],
+ "RE:R-HSA-165990": [
+  "FPLX:PPP2R_A"
+ ],
+ "RE:R-HSA-165997": [
+  "FPLX:PPP2R_A"
+ ],
+ "RE:R-HSA-167023": [
+  "FPLX:SHC"
+ ],
+ "RE:R-HSA-167204": [
+  "FPLX:RAS"
+ ],
+ "RE:R-HSA-167215": [
+  "FPLX:SOS"
+ ],
+ "RE:R-HSA-167409": [
+  "FPLX:G_beta"
+ ],
+ "RE:R-HSA-167410": [
+  "FPLX:G_i",
+  "FPLX:G_i_alpha"
+ ],
+ "RE:R-HSA-167413": [
+  "FPLX:G_i",
+  "FPLX:G_i_alpha"
+ ],
+ "RE:R-HSA-167438": [
+  "FPLX:G_i",
+  "FPLX:G_i_alpha"
+ ],
+ "RE:R-HSA-167442": [
+  "FPLX:G_gamma"
+ ],
+ "RE:R-HSA-1678828": [
+  "FPLX:EIF4G"
+ ],
+ "RE:R-HSA-168113": [
+  "FPLX:IKK_complex"
+ ],
+ "RE:R-HSA-169289": [
+  "FPLX:ERK"
+ ],
+ "RE:R-HSA-169291": [
+  "FPLX:ERK"
+ ],
+ "RE:R-HSA-170089": [
+  "FPLX:Cyclin_A"
+ ],
+ "RE:R-HSA-170108": [
+  "FPLX:CDC25"
+ ],
+ "RE:R-HSA-170994": [
+  "FPLX:RAL"
+ ],
+ "RE:R-HSA-170998": [
+  "FPLX:RAL"
+ ],
+ "RE:R-HSA-171016": [
+  "FPLX:p38"
+ ],
+ "RE:R-HSA-171172": [
+  "FPLX:SMAD2_3"
+ ],
+ "RE:R-HSA-171182": [
+  "FPLX:SMAD2_3"
+ ],
+ "RE:R-HSA-173584": [
+  "FPLX:C1"
+ ],
+ "RE:R-HSA-173615": [
+  "FPLX:C1"
+ ],
+ "RE:R-HSA-173617": [
+  "FPLX:C1"
+ ],
+ "RE:R-HSA-173728": [
+  "FPLX:MAC"
+ ],
+ "RE:R-HSA-174074": [
+  "FPLX:Cyclin_A"
+ ],
+ "RE:R-HSA-174454": [
+  "FPLX:RFC"
+ ],
+ "RE:R-HSA-177105": [
+  "FPLX:SMAD2_3"
+ ],
+ "RE:R-HSA-177656": [
+  "FPLX:NFkappaB_1"
+ ],
+ "RE:R-HSA-177662": [
+  "FPLX:NFkappaB_1"
+ ],
+ "RE:R-HSA-177663": [
+  "FPLX:IKK_complex"
+ ],
+ "RE:R-HSA-179508": [
+  "FPLX:ALDO"
+ ],
+ "RE:R-HSA-182582": [
+  "FPLX:Cyclin_D"
+ ],
+ "RE:R-HSA-182700": [
+  "FPLX:Cyclin_D"
+ ],
+ "RE:R-HSA-184196": [
+  "FPLX:PDGF_BB"
+ ],
+ "RE:R-HSA-184198": [
+  "FPLX:PDGF_BB"
+ ],
+ "RE:R-HSA-184203": [
+  "FPLX:PDGF_AA"
+ ],
+ "RE:R-HSA-184204": [
+  "FPLX:PDGF_BB"
+ ],
+ "RE:R-HSA-184206": [
+  "FPLX:PDGF_BB"
+ ],
+ "RE:R-HSA-186769": [
+  "FPLX:PDGFR_AB",
+  "FPLX:PDGFR"
+ ],
+ "RE:R-HSA-186770": [
+  "FPLX:PDGFR_AB",
+  "FPLX:PDGFR"
+ ],
+ "RE:R-HSA-186791": [
+  "FPLX:PDGFR_AB",
+  "FPLX:PDGFR"
+ ],
+ "RE:R-HSA-186792": [
+  "FPLX:PDGFR_AB",
+  "FPLX:PDGFR"
+ ],
+ "RE:R-HSA-186799": [
+  "FPLX:PDGFR_BB"
+ ],
+ "RE:R-HSA-186805": [
+  "FPLX:PDGFR_BB"
+ ],
+ "RE:R-HSA-186816": [
+  "FPLX:PDGFR_AA"
+ ],
+ "RE:R-HSA-186817": [
+  "FPLX:PDGFR_AA"
+ ],
+ "RE:R-HSA-186821": [
+  "FPLX:PDGFR_AB",
+  "FPLX:PDGFR"
+ ],
+ "RE:R-HSA-187493": [
+  "FPLX:Cyclin_E"
+ ],
+ "RE:R-HSA-189382": [
+  "FPLX:HMOX"
+ ],
+ "RE:R-HSA-189828": [
+  "FPLX:p38"
+ ],
+ "RE:R-HSA-1911410": [
+  "FPLX:ARRB"
+ ],
+ "RE:R-HSA-1911440": [
+  "FPLX:Notch"
+ ],
+ "RE:R-HSA-1911472": [
+  "FPLX:Notch"
+ ],
+ "RE:R-HSA-1911474": [
+  "FPLX:Notch"
+ ],
+ "RE:R-HSA-1911547": [
+  "FPLX:Notch"
+ ],
+ "RE:R-HSA-1911550": [
+  "FPLX:Notch"
+ ],
+ "RE:R-HSA-195361": [
+  "FPLX:VEGF"
+ ],
+ "RE:R-HSA-195376": [
+  "FPLX:VEGF"
+ ],
+ "RE:R-HSA-196206": [
+  "FPLX:PPP2"
+ ],
+ "RE:R-HSA-198358": [
+  "FPLX:GSK3"
+ ],
+ "RE:R-HSA-198373": [
+  "FPLX:GSK3"
+ ],
+ "RE:R-HSA-198701": [
+  "FPLX:ERK"
+ ],
+ "RE:R-HSA-198899": [
+  "FPLX:CD8"
+ ],
+ "RE:R-HSA-200408": [
+  "FPLX:AMPK_A2B2G2"
+ ],
+ "RE:R-HSA-200563": [
+  "FPLX:ACC"
+ ],
+ "RE:R-HSA-201465": [
+  "FPLX:BMP_receptor_type_II"
+ ],
+ "RE:R-HSA-201689": [
+  "FPLX:DVL"
+ ],
+ "RE:R-HSA-201711": [
+  "FPLX:CK2"
+ ],
+ "RE:R-HSA-201725": [
+  "FPLX:DVL"
+ ],
+ "RE:R-HSA-201779": [
+  "FPLX:PPP3C"
+ ],
+ "RE:R-HSA-201798": [
+  "FPLX:PPP3C"
+ ],
+ "RE:R-HSA-201804": [
+  "FPLX:BMP_receptor_type_II"
+ ],
+ "RE:R-HSA-202052": [
+  "FPLX:AKT"
+ ],
+ "RE:R-HSA-202072": [
+  "FPLX:AKT"
+ ],
+ "RE:R-HSA-202074": [
+  "FPLX:AKT"
+ ],
+ "RE:R-HSA-202088": [
+  "FPLX:AKT"
+ ],
+ "RE:R-HSA-202513": [
+  "FPLX:IKK_complex"
+ ],
+ "RE:R-HSA-202562": [
+  "FPLX:IKK_complex"
+ ],
+ "RE:R-HSA-202877": [
+  "FPLX:Caspase_3_7"
+ ],
+ "RE:R-HSA-2029095": [
+  "FPLX:PLCG"
+ ],
+ "RE:R-HSA-2029115": [
+  "FPLX:VAV"
+ ],
+ "RE:R-HSA-203947": [
+  "FPLX:PDK"
+ ],
+ "RE:R-HSA-206893": [
+  "FPLX:Activin_A"
+ ],
+ "RE:R-HSA-2089970": [
+  "FPLX:COL1"
+ ],
+ "RE:R-HSA-212420": [
+  "FPLX:Notch"
+ ],
+ "RE:R-HSA-2127310": [
+  "FPLX:COL5"
+ ],
+ "RE:R-HSA-2127389": [
+  "FPLX:COL4"
+ ],
+ "RE:R-HSA-2127422": [
+  "FPLX:COL5"
+ ],
+ "RE:R-HSA-2151208": [
+  "FPLX:AMPK_beta"
+ ],
+ "RE:R-HSA-2151212": [
+  "FPLX:AMPK_gamma"
+ ],
+ "RE:R-HSA-2151213": [
+  "FPLX:AMPK_alpha"
+ ],
+ "RE:R-HSA-215989": [
+  "FPLX:Laminin_111"
+ ],
+ "RE:R-HSA-216001": [
+  "FPLX:Laminin_332"
+ ],
+ "RE:R-HSA-2176482": [
+  "FPLX:SMAD2_3"
+ ],
+ "RE:R-HSA-2187329": [
+  "FPLX:SMAD2_3"
+ ],
+ "RE:R-HSA-2187387": [
+  "FPLX:SMAD2_3"
+ ],
+ "RE:R-HSA-2213185": [
+  "FPLX:DNM"
+ ],
+ "RE:R-HSA-2220790": [
+  "FPLX:Laminin_332"
+ ],
+ "RE:R-HSA-2316451": [
+  "FPLX:AMPK_gamma"
+ ],
+ "RE:R-HSA-2317310": [
+  "FPLX:AKT"
+ ],
+ "RE:R-HSA-2317317": [
+  "FPLX:AKT"
+ ],
+ "RE:R-HSA-2317329": [
+  "FPLX:AKT"
+ ],
+ "RE:R-HSA-2395330": [
+  "FPLX:TGFB"
+ ],
+ "RE:R-HSA-2396039": [
+  "FPLX:COL1"
+ ],
+ "RE:R-HSA-2396161": [
+  "FPLX:COL1"
+ ],
+ "RE:R-HSA-2396179": [
+  "FPLX:COL1"
+ ],
+ "RE:R-HSA-2396183": [
+  "FPLX:COL1"
+ ],
+ "RE:R-HSA-2396256": [
+  "FPLX:COL1"
+ ],
+ "RE:R-HSA-2396260": [
+  "FPLX:COL1"
+ ],
+ "RE:R-HSA-2396334": [
+  "FPLX:COL1"
+ ],
+ "RE:R-HSA-2396451": [
+  "FPLX:COL1"
+ ],
+ "RE:R-HSA-2396456": [
+  "FPLX:COL1"
+ ],
+ "RE:R-HSA-2396478": [
+  "FPLX:COL1"
+ ],
+ "RE:R-HSA-2399520": [
+  "FPLX:COL1"
+ ],
+ "RE:R-HSA-2399659": [
+  "FPLX:Laminin_332"
+ ],
+ "RE:R-HSA-2400006": [
+  "FPLX:AKT"
+ ],
+ "RE:R-HSA-2400013": [
+  "FPLX:AKT"
+ ],
+ "RE:R-HSA-2422450": [
+  "FPLX:ERK"
+ ],
+ "RE:R-HSA-2426131": [
+  "FPLX:NFY"
+ ],
+ "RE:R-HSA-2426276": [
+  "FPLX:PDGF_BB"
+ ],
+ "RE:R-HSA-2426371": [
+  "FPLX:Laminin_111"
+ ],
+ "RE:R-HSA-2428941": [
+  "FPLX:COL1"
+ ],
+ "RE:R-HSA-2445131": [
+  "FPLX:IRS"
+ ],
+ "RE:R-HSA-2445139": [
+  "FPLX:IRS"
+ ],
+ "RE:R-HSA-2457842": [
+  "FPLX:p14_3_3"
+ ],
+ "RE:R-HSA-2470478": [
+  "FPLX:Activin_AB",
+  "FPLX:Activin"
+ ],
+ "RE:R-HSA-2470491": [
+  "FPLX:Activin_AB",
+  "FPLX:Activin"
+ ],
+ "RE:R-HSA-2470494": [
+  "FPLX:Activin_AB",
+  "FPLX:Activin"
+ ],
+ "RE:R-HSA-2530496": [
+  "FPLX:FNT"
+ ],
+ "RE:R-HSA-2533911": [
+  "FPLX:Laminin_332"
+ ],
+ "RE:R-HSA-264974": [
+  "FPLX:EXOC"
+ ],
+ "RE:R-HSA-2672035": [
+  "FPLX:TN"
+ ],
+ "RE:R-HSA-2681744": [
+  "FPLX:TN"
+ ],
+ "RE:R-HSA-2685653": [
+  "FPLX:PLCG"
+ ],
+ "RE:R-HSA-2685656": [
+  "FPLX:RASGRP"
+ ],
+ "RE:R-HSA-2990868": [
+  "FPLX:Cholinesterase"
+ ],
+ "RE:R-HSA-2993807": [
+  "FPLX:Propionyl_CoA_carboxylase"
+ ],
+ "RE:R-HSA-2993809": [
+  "FPLX:Propionyl_CoA_carboxylase"
+ ],
+ "RE:R-HSA-3132719": [
+  "FPLX:ETS"
+ ],
+ "RE:R-HSA-3132724": [
+  "FPLX:ETS"
+ ],
+ "RE:R-HSA-3200029": [
+  "FPLX:ETS"
+ ],
+ "RE:R-HSA-3238268": [
+  "FPLX:Wnt"
+ ],
+ "RE:R-HSA-3238374": [
+  "FPLX:Wnt"
+ ],
+ "RE:R-HSA-3247790": [
+  "FPLX:Wnt"
+ ],
+ "RE:R-HSA-3247824": [
+  "FPLX:Wnt"
+ ],
+ "RE:R-HSA-3247835": [
+  "FPLX:Wnt"
+ ],
+ "RE:R-HSA-3299546": [
+  "FPLX:TCF_LEF"
+ ],
+ "RE:R-HSA-3323122": [
+  "FPLX:Propionyl_CoA_carboxylase"
+ ],
+ "RE:R-HSA-3323155": [
+  "FPLX:Propionyl_CoA_carboxylase"
+ ],
+ "RE:R-HSA-3371429": [
+  "FPLX:HSP90A"
+ ],
+ "RE:R-HSA-349716": [
+  "FPLX:NCOR"
+ ],
+ "RE:R-HSA-3640819": [
+  "FPLX:AXIN"
+ ],
+ "RE:R-HSA-3640837": [
+  "FPLX:Cholinesterase"
+ ],
+ "RE:R-HSA-3640863": [
+  "FPLX:AXIN"
+ ],
+ "RE:R-HSA-3656389": [
+  "FPLX:ERK"
+ ],
+ "RE:R-HSA-374848": [
+  "FPLX:G_q",
+  "FPLX:G_q_alpha"
+ ],
+ "RE:R-HSA-376002": [
+  "FPLX:ABL_family"
+ ],
+ "RE:R-HSA-3772407": [
+  "FPLX:DVL"
+ ],
+ "RE:R-HSA-3772502": [
+  "FPLX:AXIN"
+ ],
+ "RE:R-HSA-378941": [
+  "FPLX:hCG"
+ ],
+ "RE:R-HSA-378947": [
+  "FPLX:FSH"
+ ],
+ "RE:R-HSA-378969": [
+  "FPLX:LH"
+ ],
+ "RE:R-HSA-380748": [
+  "FPLX:PDGF_BB"
+ ],
+ "RE:R-HSA-380751": [
+  "FPLX:PDGF_BB"
+ ],
+ "RE:R-HSA-380759": [
+  "FPLX:PDGF_AB",
+  "FPLX:PDGF_BB"
+ ],
+ "RE:R-HSA-380931": [
+  "FPLX:AMPK"
+ ],
+ "RE:R-HSA-380934": [
+  "FPLX:AMPK"
+ ],
+ "RE:R-HSA-380961": [
+  "FPLX:AMPK"
+ ],
+ "RE:R-HSA-381204": [
+  "FPLX:NFY"
+ ],
+ "RE:R-HSA-381844": [
+  "FPLX:AMPK_alpha"
+ ],
+ "RE:R-HSA-381845": [
+  "FPLX:AMPK_alpha"
+ ],
+ "RE:R-HSA-381851": [
+  "FPLX:AMPK_gamma"
+ ],
+ "RE:R-HSA-381854": [
+  "FPLX:AMPK_beta"
+ ],
+ "RE:R-HSA-381855": [
+  "FPLX:TSC"
+ ],
+ "RE:R-HSA-381926": [
+  "FPLX:PDGF"
+ ],
+ "RE:R-HSA-381930": [
+  "FPLX:PDGF_DD"
+ ],
+ "RE:R-HSA-381935": [
+  "FPLX:PDGF_BB"
+ ],
+ "RE:R-HSA-381936": [
+  "FPLX:PDGF"
+ ],
+ "RE:R-HSA-381938": [
+  "FPLX:PDGF_BB"
+ ],
+ "RE:R-HSA-381941": [
+  "FPLX:PDGF_CC"
+ ],
+ "RE:R-HSA-3858467": [
+  "FPLX:DVL"
+ ],
+ "RE:R-HSA-3858479": [
+  "FPLX:DVL"
+ ],
+ "RE:R-HSA-387074": [
+  "FPLX:PDGF_BB"
+ ],
+ "RE:R-HSA-388544": [
+  "FPLX:EDN"
+ ],
+ "RE:R-HSA-390455": [
+  "FPLX:CCT_complex"
+ ],
+ "RE:R-HSA-390474": [
+  "FPLX:CCT_complex"
+ ],
+ "RE:R-HSA-390532": [
+  "FPLX:Troponin_C"
+ ],
+ "RE:R-HSA-390541": [
+  "FPLX:Troponin_I"
+ ],
+ "RE:R-HSA-390546": [
+  "FPLX:Troponin_T"
+ ],
+ "RE:R-HSA-390583": [
+  "FPLX:Troponin"
+ ],
+ "RE:R-HSA-390585": [
+  "FPLX:Troponin"
+ ],
+ "RE:R-HSA-390587": [
+  "FPLX:Troponin_C"
+ ],
+ "RE:R-HSA-390643": [
+  "FPLX:ADRB"
+ ],
+ "RE:R-HSA-390664": [
+  "FPLX:ADRA2"
+ ],
+ "RE:R-HSA-390670": [
+  "FPLX:ADRB"
+ ],
+ "RE:R-HSA-390700": [
+  "FPLX:ADRA2"
+ ],
+ "RE:R-HSA-392712": [
+  "FPLX:PDGF_BB"
+ ],
+ "RE:R-HSA-399713": [
+  "FPLX:GRIA"
+ ],
+ "RE:R-HSA-399987": [
+  "FPLX:G_q",
+  "FPLX:G_q_alpha"
+ ],
+ "RE:R-HSA-399992": [
+  "FPLX:G_q",
+  "FPLX:G_q_alpha"
+ ],
+ "RE:R-HSA-400000": [
+  "FPLX:G_q",
+  "FPLX:G_q_alpha"
+ ],
+ "RE:R-HSA-400008": [
+  "FPLX:G_q",
+  "FPLX:G_q_alpha"
+ ],
+ "RE:R-HSA-400062": [
+  "FPLX:G_gamma"
+ ],
+ "RE:R-HSA-400093": [
+  "FPLX:G_beta"
+ ],
+ "RE:R-HSA-416323": [
+  "FPLX:GRIA"
+ ],
+ "RE:R-HSA-417004": [
+  "FPLX:CAMK2_complex",
+  "FPLX:CAMK2_family"
+ ],
+ "RE:R-HSA-418312": [
+  "FPLX:SERCA"
+ ],
+ "RE:R-HSA-418379": [
+  "FPLX:PRKG"
+ ],
+ "RE:R-HSA-418540": [
+  "FPLX:PDE7"
+ ],
+ "RE:R-HSA-418541": [
+  "FPLX:PDE8"
+ ],
+ "RE:R-HSA-418570": [
+  "FPLX:G_12_alpha",
+  "FPLX:G_12"
+ ],
+ "RE:R-HSA-418572": [
+  "FPLX:G_12_alpha",
+  "FPLX:G_12"
+ ],
+ "RE:R-HSA-419057": [
+  "FPLX:ROCK"
+ ],
+ "RE:R-HSA-419160": [
+  "FPLX:RHO"
+ ],
+ "RE:R-HSA-419161": [
+  "FPLX:RHO"
+ ],
+ "RE:R-HSA-419164": [
+  "FPLX:RHO"
+ ],
+ "RE:R-HSA-419294": [
+  "FPLX:NOS"
+ ],
+ "RE:R-HSA-419346": [
+  "FPLX:S1PR"
+ ],
+ "RE:R-HSA-419401": [
+  "FPLX:S1PR"
+ ],
+ "RE:R-HSA-419619": [
+  "FPLX:HSP90A"
+ ],
+ "RE:R-HSA-420516": [
+  "FPLX:GRM"
+ ],
+ "RE:R-HSA-420519": [
+  "FPLX:GRM"
+ ],
+ "RE:R-HSA-420974": [
+  "FPLX:GRIA"
+ ],
+ "RE:R-HSA-421001": [
+  "FPLX:GRIA"
+ ],
+ "RE:R-HSA-426070": [
+  "FPLX:DGK"
+ ],
+ "RE:R-HSA-427905": [
+  "FPLX:SERCA"
+ ],
+ "RE:R-HSA-428110": [
+  "FPLX:PPAP2"
+ ],
+ "RE:R-HSA-428475": [
+  "FPLX:PAK"
+ ],
+ "RE:R-HSA-429842": [
+  "FPLX:EIF4A"
+ ],
+ "RE:R-HSA-430172": [
+  "FPLX:VAV"
+ ],
+ "RE:R-HSA-432792": [
+  "FPLX:CAMK2_complex",
+  "FPLX:CAMK2_family"
+ ],
+ "RE:R-HSA-434632": [
+  "FPLX:VAV"
+ ],
+ "RE:R-HSA-442272": [
+  "FPLX:VAV"
+ ],
+ "RE:R-HSA-442295": [
+  "FPLX:VAV"
+ ],
+ "RE:R-HSA-442734": [
+  "FPLX:RASGRF"
+ ],
+ "RE:R-HSA-444796": [
+  "FPLX:CAMK2_complex",
+  "FPLX:CAMK2_family"
+ ],
+ "RE:R-HSA-445134": [
+  "FPLX:Patched"
+ ],
+ "RE:R-HSA-445374": [
+  "FPLX:CAMK2_complex",
+  "FPLX:CAMK2_family"
+ ],
+ "RE:R-HSA-445744": [
+  "FPLX:IL1"
+ ],
+ "RE:R-HSA-446847": [
+  "FPLX:DNM"
+ ],
+ "RE:R-HSA-446849": [
+  "FPLX:P90RSK"
+ ],
+ "RE:R-HSA-447102": [
+  "FPLX:IL12"
+ ],
+ "RE:R-HSA-448866": [
+  "FPLX:MEF2"
+ ],
+ "RE:R-HSA-448868": [
+  "FPLX:MEF2"
+ ],
+ "RE:R-HSA-450226": [
+  "FPLX:JNK"
+ ],
+ "RE:R-HSA-450253": [
+  "FPLX:JNK"
+ ],
+ "RE:R-HSA-450289": [
+  "FPLX:JNK"
+ ],
+ "RE:R-HSA-451402": [
+  "FPLX:ACTN"
+ ],
+ "RE:R-HSA-452094": [
+  "FPLX:STAT5"
+ ],
+ "RE:R-HSA-4551456": [
+  "FPLX:PRKG"
+ ],
+ "RE:R-HSA-4551462": [
+  "FPLX:PRKG"
+ ],
+ "RE:R-HSA-4641132": [
+  "FPLX:AXIN"
+ ],
+ "RE:R-HSA-4652685": [
+  "FPLX:DVL"
+ ],
+ "RE:R-HSA-4687776": [
+  "FPLX:ROCK"
+ ],
+ "RE:R-HSA-507919": [
+  "FPLX:STAT5"
+ ],
+ "RE:R-HSA-507929": [
+  "FPLX:STAT5"
+ ],
+ "RE:R-HSA-508012": [
+  "FPLX:STAT5"
+ ],
+ "RE:R-HSA-5082395": [
+  "FPLX:HSP90A"
+ ],
+ "RE:R-HSA-5082406": [
+  "FPLX:HSP90AA"
+ ],
+ "RE:R-HSA-5083623": [
+  "FPLX:CSNK2"
+ ],
+ "RE:R-HSA-5083624": [
+  "FPLX:CSNK2"
+ ],
+ "RE:R-HSA-5138439": [
+  "FPLX:Clathrin"
+ ],
+ "RE:R-HSA-5138447": [
+  "FPLX:Clathrin"
+ ],
+ "RE:R-HSA-517388": [
+  "FPLX:FZD"
+ ],
+ "RE:R-HSA-5218789": [
+  "FPLX:VAV"
+ ],
+ "RE:R-HSA-5262981": [
+  "FPLX:IKK_complex"
+ ],
+ "RE:R-HSA-5323539": [
+  "FPLX:TCF_LEF"
+ ],
+ "RE:R-HSA-5333713": [
+  "FPLX:Clathrin"
+ ],
+ "RE:R-HSA-5336141": [
+  "FPLX:Annexin_II_heterotetramer"
+ ],
+ "RE:R-HSA-5340329": [
+  "FPLX:VAV"
+ ],
+ "RE:R-HSA-5358286": [
+  "FPLX:Hedgehog"
+ ],
+ "RE:R-HSA-5358318": [
+  "FPLX:Hedgehog"
+ ],
+ "RE:R-HSA-5358332": [
+  "FPLX:Hedgehog"
+ ],
+ "RE:R-HSA-5362382": [
+  "FPLX:Hedgehog"
+ ],
+ "RE:R-HSA-5362391": [
+  "FPLX:Hedgehog"
+ ],
+ "RE:R-HSA-5610566": [
+  "FPLX:PRKAR"
+ ],
+ "RE:R-HSA-5610568": [
+  "FPLX:PRKAR"
+ ],
+ "RE:R-HSA-5610577": [
+  "FPLX:ADCY"
+ ],
+ "RE:R-HSA-5610578": [
+  "FPLX:ADCY"
+ ],
+ "RE:R-HSA-5618088": [
+  "FPLX:HSP90A"
+ ],
+ "RE:R-HSA-5623453": [
+  "FPLX:EXOC"
+ ],
+ "RE:R-HSA-5656056": [
+  "FPLX:FLRT"
+ ],
+ "RE:R-HSA-5658216": [
+  "FPLX:RasGAP"
+ ],
+ "RE:R-HSA-5658219": [
+  "FPLX:SPRED"
+ ],
+ "RE:R-HSA-5672337": [
+  "FPLX:TSC"
+ ],
+ "RE:R-HSA-5672686": [
+  "FPLX:MEK"
+ ],
+ "RE:R-HSA-5672705": [
+  "FPLX:MEK"
+ ],
+ "RE:R-HSA-5672708": [
+  "FPLX:RAF"
+ ],
+ "RE:R-HSA-5672716": [
+  "FPLX:MEK"
+ ],
+ "RE:R-HSA-5672721": [
+  "FPLX:MEK"
+ ],
+ "RE:R-HSA-5672726": [
+  "FPLX:RAF"
+ ],
+ "RE:R-HSA-5674134": [
+  "FPLX:RAF"
+ ],
+ "RE:R-HSA-5674136": [
+  "FPLX:RAF"
+ ],
+ "RE:R-HSA-5674338": [
+  "FPLX:ERK"
+ ],
+ "RE:R-HSA-5674340": [
+  "FPLX:ERK"
+ ],
+ "RE:R-HSA-5674341": [
+  "FPLX:ERK"
+ ],
+ "RE:R-HSA-5674489": [
+  "FPLX:MEK"
+ ],
+ "RE:R-HSA-5675361": [
+  "FPLX:ERK"
+ ],
+ "RE:R-HSA-5675363": [
+  "FPLX:ERK"
+ ],
+ "RE:R-HSA-5682664": [
+  "FPLX:ATG4"
+ ],
+ "RE:R-HSA-5693120": [
+  "FPLX:BCKDC"
+ ],
+ "RE:R-HSA-5696998": [
+  "FPLX:Cyclin_A"
+ ],
+ "RE:R-HSA-6783051": [
+  "FPLX:Cyclin_A"
+ ],
+ "RE:R-HSA-6792583": [
+  "FPLX:BCKDC"
+ ],
+ "RE:R-HSA-6793931": [
+  "FPLX:LH"
+ ],
+ "RE:R-HSA-6793934": [
+  "FPLX:LH"
+ ],
+ "RE:R-HSA-6798076": [
+  "FPLX:p53_family"
+ ],
+ "RE:R-HSA-6798078": [
+  "FPLX:p53_family"
+ ],
+ "RE:R-HSA-6802607": [
+  "FPLX:RAS"
+ ],
+ "RE:R-HSA-6802608": [
+  "FPLX:RAS"
+ ],
+ "RE:R-HSA-6805064": [
+  "FPLX:CSNK2"
+ ],
+ "RE:R-HSA-6805066": [
+  "FPLX:CK2"
+ ],
+ "RE:R-HSA-6805073": [
+  "FPLX:CSNK2"
+ ],
+ "RE:R-HSA-6805467": [
+  "FPLX:AMPK"
+ ],
+ "RE:R-HSA-6813837": [
+  "FPLX:Cyclin_E"
+ ],
+ "RE:R-HSA-6814207": [
+  "FPLX:G_beta"
+ ],
+ "RE:R-HSA-6814413": [
+  "FPLX:G_beta"
+ ],
+ "RE:R-HSA-6814694": [
+  "FPLX:Desmoglein"
+ ],
+ "RE:R-HSA-68373": [
+  "FPLX:Cyclin_E"
+ ],
+ "RE:R-HSA-68436": [
+  "FPLX:RFC"
+ ],
+ "RE:R-HSA-68450": [
+  "FPLX:DNA_polymerase_delta"
+ ],
+ "RE:R-HSA-68462": [
+  "FPLX:RPA"
+ ],
+ "RE:R-HSA-69261": [
+  "FPLX:CDC25"
+ ],
+ "RE:R-HSA-70019": [
+  "FPLX:BCKDC"
+ ],
+ "RE:R-HSA-70990": [
+  "FPLX:ETC_complex_II"
+ ],
+ "RE:R-HSA-71025": [
+  "FPLX:Propionyl_CoA_carboxylase"
+ ],
+ "RE:R-HSA-71026": [
+  "FPLX:Propionyl_CoA_carboxylase"
+ ],
+ "RE:R-HSA-72526": [
+  "FPLX:EIF2B"
+ ],
+ "RE:R-HSA-727820": [
+  "FPLX:IKK_complex"
+ ],
+ "RE:R-HSA-74688": [
+  "FPLX:PI3K_p85"
+ ],
+ "RE:R-HSA-749499": [
+  "FPLX:G_q",
+  "FPLX:G_q_alpha"
+ ],
+ "RE:R-HSA-75202": [
+  "FPLX:Cyclin_A"
+ ],
+ "RE:R-HSA-8847714": [
+  "FPLX:Desmoglein"
+ ],
+ "RE:R-HSA-8848649": [
+  "FPLX:CAPN"
+ ],
+ "RE:R-HSA-8848668": [
+  "FPLX:CAPN"
+ ],
+ "RE:R-HSA-8849894": [
+  "FPLX:FLOT"
+ ],
+ "RE:R-HSA-8850524": [
+  "FPLX:G_beta"
+ ],
+ "RE:R-HSA-8852568": [
+  "FPLX:MAC"
+ ],
+ "RE:R-HSA-8855211": [
+  "FPLX:Augmin"
+ ],
+ "RE:R-HSA-8861873": [
+  "FPLX:P2RX"
+ ],
+ "RE:R-HSA-8864040": [
+  "FPLX:PDGFR_AB",
+  "FPLX:PDGFR"
+ ],
+ "RE:R-HSA-8864046": [
+  "FPLX:PDGFR_BB"
+ ],
+ "RE:R-HSA-8864283": [
+  "FPLX:TFAP2"
+ ],
+ "RE:R-HSA-8864286": [
+  "FPLX:TFAP2"
+ ],
+ "RE:R-HSA-8865622": [
+  "FPLX:STAT5"
+ ],
+ "RE:R-HSA-8866229": [
+  "FPLX:ADRBK"
+ ],
+ "RE:R-HSA-8868235": [
+  "FPLX:DNM"
+ ],
+ "RE:R-HSA-8868609": [
+  "FPLX:DNM"
+ ],
+ "RE:R-HSA-8870680": [
+  "FPLX:Fibrinogen"
+ ],
+ "RE:R-HSA-8936837": [
+  "FPLX:HIF_beta"
+ ],
+ "RE:R-HSA-8938866": [
+  "FPLX:Cyclin_D"
+ ],
+ "RE:R-HSA-8941923": [
+  "FPLX:CDKN1"
+ ],
+ "RE:R-HSA-8942604": [
+  "FPLX:CDKN1"
+ ],
+ "RE:R-HSA-8944354": [
+  "FPLX:TCF_LEF"
+ ],
+ "RE:R-HSA-8948131": [
+  "FPLX:CDKN1"
+ ],
+ "RE:R-HSA-8950122": [
+  "FPLX:IL12"
+ ],
+ "RE:R-HSA-8950228": [
+  "FPLX:IL12"
+ ],
+ "RE:R-HSA-8950694": [
+  "FPLX:IL12"
+ ],
+ "RE:R-HSA-8951427": [
+  "FPLX:TCF_LEF"
+ ],
+ "RE:R-HSA-909688": [
+  "FPLX:IFNA"
+ ],
+ "RE:R-HSA-936779": [
+  "FPLX:ATP1A"
+ ],
+ "RE:R-HSA-936820": [
+  "FPLX:ATP1B"
+ ],
+ "RE:R-HSA-976075": [
+  "FPLX:E3_Ub_ligase"
+ ],
+ "RE:R-HSA-996770": [
+  "FPLX:GATA"
+ ],
+ "SIGNOR:SIGNOR-PF1": [
+  "FPLX:ERK"
+ ],
+ "SIGNOR:SIGNOR-PF10": [
+  "FPLX:DVL"
+ ],
+ "SIGNOR:SIGNOR-PF11": [
+  "FPLX:FZD"
+ ],
+ "SIGNOR:SIGNOR-PF12": [
+  "FPLX:NFkappaB"
+ ],
+ "SIGNOR:SIGNOR-PF13": [
+  "FPLX:PAK"
+ ],
+ "SIGNOR:SIGNOR-PF14": [
+  "FPLX:ROBO"
+ ],
+ "SIGNOR:SIGNOR-PF15": [
+  "FPLX:JNK"
+ ],
+ "SIGNOR:SIGNOR-PF16": [
+  "FPLX:p38"
+ ],
+ "SIGNOR:SIGNOR-PF17": [
+  "FPLX:PRKAC"
+ ],
+ "SIGNOR:SIGNOR-PF18": [
+  "FPLX:PPP3C"
+ ],
+ "SIGNOR:SIGNOR-PF2": [
+  "FPLX:LPAR"
+ ],
+ "SIGNOR:SIGNOR-PF20": [
+  "FPLX:TLR"
+ ],
+ "SIGNOR:SIGNOR-PF21": [
+  "FPLX:TAOK"
+ ],
+ "SIGNOR:SIGNOR-PF22": [
+  "FPLX:TEAD"
+ ],
+ "SIGNOR:SIGNOR-PF23": [
+  "FPLX:FGFR"
+ ],
+ "SIGNOR:SIGNOR-PF24": [
+  "FPLX:AKT"
+ ],
+ "SIGNOR:SIGNOR-PF25": [
+  "FPLX:MEK"
+ ],
+ "SIGNOR:SIGNOR-PF26": [
+  "FPLX:P90RSK"
+ ],
+ "SIGNOR:SIGNOR-PF27": [
+  "FPLX:FOXO"
+ ],
+ "SIGNOR:SIGNOR-PF29": [
+  "FPLX:SMURF"
+ ],
+ "SIGNOR:SIGNOR-PF3": [
+  "FPLX:G_gamma"
+ ],
+ "SIGNOR:SIGNOR-PF30": [
+  "FPLX:Notch"
+ ],
+ "SIGNOR:SIGNOR-PF31": [
+  "FPLX:SLRP"
+ ],
+ "SIGNOR:SIGNOR-PF32": [
+  "FPLX:SRC"
+ ],
+ "SIGNOR:SIGNOR-PF33": [
+  "FPLX:GPCR"
+ ],
+ "SIGNOR:SIGNOR-PF34": [
+  "FPLX:PIM"
+ ],
+ "SIGNOR:SIGNOR-PF35": [
+  "FPLX:SMAD1_5_9"
+ ],
+ "SIGNOR:SIGNOR-PF4": [
+  "FPLX:G_beta"
+ ],
+ "SIGNOR:SIGNOR-PF5": [
+  "FPLX:TGFB"
+ ],
+ "SIGNOR:SIGNOR-PF6": [
+  "FPLX:AMPK_alpha"
+ ],
+ "SIGNOR:SIGNOR-PF7": [
+  "FPLX:p14_3_3"
+ ],
+ "SIGNOR:SIGNOR-PF8": [
+  "FPLX:FGF"
+ ],
+ "SIGNOR:SIGNOR-PF9": [
+  "FPLX:BMP_receptor"
+ ],
+ "UBERON:0000017": [
+  "MESH:D046790"
+ ],
+ "UBERON:0000059": [
+  "MESH:D007420"
+ ],
+ "UBERON:0000085": [
+  "MESH:D009028"
+ ],
+ "UBERON:0000088": [
+  "MESH:D014327"
+ ],
+ "UBERON:0000105": [
+  "MESH:D008018"
+ ],
+ "UBERON:0000120": [
+  "MESH:D001812"
+ ],
+ "UBERON:0000127": [
+  "MESH:D065828"
+ ],
+ "UBERON:0000159": [
+  "MESH:D001003"
+ ],
+ "UBERON:0000160": [
+  "MESH:D007422"
+ ],
+ "UBERON:0000175": [
+  "MESH:D010996"
+ ],
+ "UBERON:0000220": [
+  "MESH:D001269"
+ ],
+ "UBERON:0000305": [
+  "MESH:D000650"
+ ],
+ "UBERON:0000307": [
+  "MESH:D036703"
+ ],
+ "UBERON:0000349": [
+  "MESH:D008032"
+ ],
+ "UBERON:0000358": [
+  "MESH:D001755"
+ ],
+ "UBERON:0000369": [
+  "MESH:D003342"
+ ],
+ "UBERON:0000387": [
+  "MESH:D000072600"
+ ],
+ "UBERON:0000388": [
+  "MESH:D004825"
+ ],
+ "UBERON:0000411": [
+  "MESH:D014793"
+ ],
+ "UBERON:0000432": [
+  "MESH:D020392"
+ ],
+ "UBERON:0000451": [
+  "MESH:D017397"
+ ],
+ "UBERON:0000569": [
+  "MESH:D007080"
+ ],
+ "UBERON:0000911": [
+  "MESH:D002913"
+ ],
+ "UBERON:0000916": [
+  "MESH:D000005"
+ ],
+ "UBERON:0000923": [
+  "MESH:D005855"
+ ],
+ "UBERON:0000924": [
+  "MESH:D004475"
+ ],
+ "UBERON:0000925": [
+  "MESH:D004707"
+ ],
+ "UBERON:0000926": [
+  "MESH:D008648"
+ ],
+ "UBERON:0000939": [
+  "MESH:D060227"
+ ],
+ "UBERON:0000945": [
+  "MESH:D013270"
+ ],
+ "UBERON:0000956": [
+  "MESH:D002540"
+ ],
+ "UBERON:0000976": [
+  "MESH:D006811"
+ ],
+ "UBERON:0000979": [
+  "MESH:D013977"
+ ],
+ "UBERON:0000981": [
+  "MESH:D005269"
+ ],
+ "UBERON:0001040": [
+  "MESH:D015017"
+ ],
+ "UBERON:0001043": [
+  "MESH:D004947"
+ ],
+ "UBERON:0001049": [
+  "MESH:D054259"
+ ],
+ "UBERON:0001051": [
+  "MESH:D007013"
+ ],
+ "UBERON:0001052": [
+  "MESH:D012007"
+ ],
+ "UBERON:0001066": [
+  "MESH:D007403"
+ ],
+ "UBERON:0001152": [
+  "MESH:D003549"
+ ],
+ "UBERON:0001154": [
+  "MESH:D001065"
+ ],
+ "UBERON:0001155": [
+  "MESH:D003106"
+ ],
+ "UBERON:0001156": [
+  "MESH:D044682"
+ ],
+ "UBERON:0001157": [
+  "MESH:D044684"
+ ],
+ "UBERON:0001158": [
+  "MESH:D044683"
+ ],
+ "UBERON:0001159": [
+  "MESH:D012809"
+ ],
+ "UBERON:0001165": [
+  "MESH:D011706"
+ ],
+ "UBERON:0001166": [
+  "MESH:D011708"
+ ],
+ "UBERON:0001179": [
+  "MESH:D010529"
+ ],
+ "UBERON:0001242": [
+  "MESH:D007413"
+ ],
+ "UBERON:0001255": [
+  "MESH:D001743"
+ ],
+ "UBERON:0001273": [
+  "MESH:D007085"
+ ],
+ "UBERON:0001274": [
+  "MESH:D007512"
+ ],
+ "UBERON:0001275": [
+  "MESH:D011630"
+ ],
+ "UBERON:0001301": [
+  "MESH:D004822"
+ ],
+ "UBERON:0001347": [
+  "MESH:D052436"
+ ],
+ "UBERON:0001359": [
+  "MESH:D002555"
+ ],
+ "UBERON:0001393": [
+  "MESH:D001303"
+ ],
+ "UBERON:0001424": [
+  "MESH:D014457"
+ ],
+ "UBERON:0001435": [
+  "MESH:D002348"
+ ],
+ "UBERON:0001443": [
+  "MESH:D013909"
+ ],
+ "UBERON:0001446": [
+  "MESH:D005360"
+ ],
+ "UBERON:0001447": [
+  "MESH:D013639"
+ ],
+ "UBERON:0001448": [
+  "MESH:D008682"
+ ],
+ "UBERON:0001450": [
+  "MESH:D002111"
+ ],
+ "UBERON:0001473": [
+  "MESH:D042601"
+ ],
+ "UBERON:0001491": [
+  "MESH:D014955"
+ ],
+ "UBERON:0001629": [
+  "MESH:D002344"
+ ],
+ "UBERON:0001631": [
+  "MESH:D013897"
+ ],
+ "UBERON:0001642": [
+  "MESH:D054063"
+ ],
+ "UBERON:0001706": [
+  "MESH:D009300"
+ ],
+ "UBERON:0001715": [
+  "MESH:D065838"
+ ],
+ "UBERON:0001727": [
+  "MESH:D013650"
+ ],
+ "UBERON:0001728": [
+  "MESH:D009305"
+ ],
+ "UBERON:0001729": [
+  "MESH:D009960"
+ ],
+ "UBERON:0001732": [
+  "MESH:D000234"
+ ],
+ "UBERON:0001738": [
+  "MESH:D013957"
+ ],
+ "UBERON:0001739": [
+  "MESH:D007817"
+ ],
+ "UBERON:0001740": [
+  "MESH:D001193"
+ ],
+ "UBERON:0001751": [
+  "MESH:D003804"
+ ],
+ "UBERON:0001752": [
+  "MESH:D003743"
+ ],
+ "UBERON:0001753": [
+  "MESH:D003739"
+ ],
+ "UBERON:0001754": [
+  "MESH:D003782"
+ ],
+ "UBERON:0001758": [
+  "MESH:D010519"
+ ],
+ "UBERON:0001798": [
+  "MESH:D014822"
+ ],
+ "UBERON:0001806": [
+  "MESH:D005728"
+ ],
+ "UBERON:0001808": [
+  "MESH:D005726"
+ ],
+ "UBERON:0001811": [
+  "MESH:D003228"
+ ],
+ "UBERON:0001823": [
+  "MESH:D055171"
+ ],
+ "UBERON:0001828": [
+  "MESH:D005881"
+ ],
+ "UBERON:0001845": [
+  "MESH:D010498"
+ ],
+ "UBERON:0001852": [
+  "MESH:D004710"
+ ],
+ "UBERON:0001856": [
+  "MESH:D054776"
+ ],
+ "UBERON:0001862": [
+  "MESH:D014722"
+ ],
+ "UBERON:0001863": [
+  "MESH:D054738"
+ ],
+ "UBERON:0001871": [
+  "MESH:D013702"
+ ],
+ "UBERON:0001872": [
+  "MESH:D010296"
+ ],
+ "UBERON:0001873": [
+  "MESH:D002421"
+ ],
+ "UBERON:0001874": [
+  "MESH:D011699"
+ ],
+ "UBERON:0001875": [
+  "MESH:D005917"
+ ],
+ "UBERON:0001876": [
+  "MESH:D000679"
+ ],
+ "UBERON:0001882": [
+  "MESH:D009714"
+ ],
+ "UBERON:0001883": [
+  "MESH:D066208"
+ ],
+ "UBERON:0001894": [
+  "MESH:D004027"
+ ],
+ "UBERON:0001898": [
+  "MESH:D007031"
+ ],
+ "UBERON:0001899": [
+  "MESH:D019261"
+ ],
+ "UBERON:0001904": [
+  "MESH:D019262"
+ ],
+ "UBERON:0001906": [
+  "MESH:D020531"
+ ],
+ "UBERON:0001907": [
+  "MESH:D065820"
+ ],
+ "UBERON:0001913": [
+  "MESH:D008892"
+ ],
+ "UBERON:0001928": [
+  "MESH:D011301"
+ ],
+ "UBERON:0001929": [
+  "MESH:D013495"
+ ],
+ "UBERON:0001932": [
+  "MESH:D001111"
+ ],
+ "UBERON:0001944": [
+  "MESH:D066250"
+ ],
+ "UBERON:0001945": [
+  "MESH:D013477"
+ ],
+ "UBERON:0001946": [
+  "MESH:D007245"
+ ],
+ "UBERON:0001947": [
+  "MESH:D012012"
+ ],
+ "UBERON:0001950": [
+  "MESH:D019579"
+ ],
+ "UBERON:0001954": [
+  "MESH:D006624"
+ ],
+ "UBERON:0001977": [
+  "MESH:D044967"
+ ],
+ "UBERON:0001979": [
+  "MESH:D014699"
+ ],
+ "UBERON:0001982": [
+  "MESH:D002196"
+ ],
+ "UBERON:0001987": [
+  "MESH:D010920"
+ ],
+ "UBERON:0001995": [
+  "MESH:D051445"
+ ],
+ "UBERON:0002020": [
+  "MESH:D066128"
+ ],
+ "UBERON:0002021": [
+  "MESH:D009778"
+ ],
+ "UBERON:0002034": [
+  "MESH:D013493"
+ ],
+ "UBERON:0002038": [
+  "MESH:D013378"
+ ],
+ "UBERON:0002043": [
+  "MESH:D065847"
+ ],
+ "UBERON:0002062": [
+  "MESH:D054089"
+ ],
+ "UBERON:0002068": [
+  "MESH:D014497"
+ ],
+ "UBERON:0002095": [
+  "MESH:D008643"
+ ],
+ "UBERON:0002106": [
+  "MESH:D013154"
+ ],
+ "UBERON:0002108": [
+  "MESH:D007421"
+ ],
+ "UBERON:0002114": [
+  "MESH:D004386"
+ ],
+ "UBERON:0002115": [
+  "MESH:D007583"
+ ],
+ "UBERON:0002116": [
+  "MESH:D007082"
+ ],
+ "UBERON:0002120": [
+  "MESH:D060910"
+ ],
+ "UBERON:0002128": [
+  "MESH:D065832"
+ ],
+ "UBERON:0002139": [
+  "MESH:D013351"
+ ],
+ "UBERON:0002145": [
+  "MESH:D066268"
+ ],
+ "UBERON:0002152": [
+  "MESH:D065837"
+ ],
+ "UBERON:0002156": [
+  "MESH:D065846"
+ ],
+ "UBERON:0002157": [
+  "MESH:D065848"
+ ],
+ "UBERON:0002181": [
+  "MESH:D013376"
+ ],
+ "UBERON:0002186": [
+  "MESH:D055745"
+ ],
+ "UBERON:0002196": [
+  "MESH:D010903"
+ ],
+ "UBERON:0002198": [
+  "MESH:D010904"
+ ],
+ "UBERON:0002206": [
+  "MESH:D008326"
+ ],
+ "UBERON:0002219": [
+  "MESH:D013356"
+ ],
+ "UBERON:0002224": [
+  "MESH:D035423"
+ ],
+ "UBERON:0002236": [
+  "MESH:D066186"
+ ],
+ "UBERON:0002242": [
+  "MESH:D000070614"
+ ],
+ "UBERON:0002255": [
+  "MESH:D019147"
+ ],
+ "UBERON:0002264": [
+  "MESH:D009830"
+ ],
+ "UBERON:0002316": [
+  "MESH:D066127"
+ ],
+ "UBERON:0002320": [
+  "MESH:D005920"
+ ],
+ "UBERON:0002328": [
+  "MESH:D009672"
+ ],
+ "UBERON:0002329": [
+  "MESH:D019170"
+ ],
+ "UBERON:0002331": [
+  "MESH:D014470"
+ ],
+ "UBERON:0002336": [
+  "MESH:D003337"
+ ],
+ "UBERON:0002342": [
+  "MESH:D009432"
+ ],
+ "UBERON:0002358": [
+  "MESH:D010537"
+ ],
+ "UBERON:0002364": [
+  "MESH:D014432"
+ ],
+ "UBERON:0002370": [
+  "MESH:D013950"
+ ],
+ "UBERON:0002372": [
+  "MESH:D014066"
+ ],
+ "UBERON:0002373": [
+  "MESH:D014066"
+ ],
+ "UBERON:0002375": [
+  "MESH:D003413"
+ ],
+ "UBERON:0002391": [
+  "MESH:D008196"
+ ],
+ "UBERON:0002395": [
+  "MESH:D013628"
+ ],
+ "UBERON:0002396": [
+  "MESH:D055172"
+ ],
+ "UBERON:0002402": [
+  "MESH:D035422"
+ ],
+ "UBERON:0002409": [
+  "MESH:D000069236"
+ ],
+ "UBERON:0002430": [
+  "MESH:D007026"
+ ],
+ "UBERON:0002446": [
+  "MESH:D010329"
+ ],
+ "UBERON:0002469": [
+  "MESH:D000071041"
+ ],
+ "UBERON:0002493": [
+  "MESH:D055988"
+ ],
+ "UBERON:0002540": [
+  "MESH:D053403"
+ ],
+ "UBERON:0002548": [
+  "MESH:D007814"
+ ],
+ "UBERON:0002555": [
+  "MESH:D007033"
+ ],
+ "UBERON:0002600": [
+  "MESH:D065726"
+ ],
+ "UBERON:0002620": [
+  "MESH:D014371"
+ ],
+ "UBERON:0002623": [
+  "MESH:D065850"
+ ],
+ "UBERON:0002631": [
+  "MESH:D065843"
+ ],
+ "UBERON:0002639": [
+  "MESH:D066265"
+ ],
+ "UBERON:0002663": [
+  "MESH:D012686"
+ ],
+ "UBERON:0002682": [
+  "MESH:D065827"
+ ],
+ "UBERON:0002684": [
+  "MESH:D065849"
+ ],
+ "UBERON:0002691": [
+  "MESH:D017557"
+ ],
+ "UBERON:0002728": [
+  "MESH:D018728"
+ ],
+ "UBERON:0002733": [
+  "MESH:D020646"
+ ],
+ "UBERON:0002743": [
+  "MESH:D066187"
+ ],
+ "UBERON:0002770": [
+  "MESH:D007034"
+ ],
+ "UBERON:0002788": [
+  "MESH:D020643"
+ ],
+ "UBERON:0002883": [
+  "MESH:D066274"
+ ],
+ "UBERON:0002894": [
+  "MESH:D066194"
+ ],
+ "UBERON:0002932": [
+  "MESH:D065833"
+ ],
+ "UBERON:0002973": [
+  "MESH:D020534"
+ ],
+ "UBERON:0002981": [
+  "MESH:D020649"
+ ],
+ "UBERON:0003017": [
+  "MESH:D013377"
+ ],
+ "UBERON:0003023": [
+  "MESH:D065821"
+ ],
+ "UBERON:0003040": [
+  "MESH:D010487"
+ ],
+ "UBERON:0003044": [
+  "MESH:D000083382"
+ ],
+ "UBERON:0003074": [
+  "MESH:D014928"
+ ],
+ "UBERON:0003075": [
+  "MESH:D054258"
+ ],
+ "UBERON:0003125": [
+  "MESH:D014817"
+ ],
+ "UBERON:0003143": [
+  "MESH:D011679"
+ ],
+ "UBERON:0003209": [
+  "MESH:D049428"
+ ],
+ "UBERON:0003460": [
+  "MESH:D050280"
+ ],
+ "UBERON:0003462": [
+  "MESH:D005147"
+ ],
+ "UBERON:0003483": [
+  "MESH:D013950"
+ ],
+ "UBERON:0003672": [
+  "MESH:D003817"
+ ],
+ "UBERON:0003674": [
+  "MESH:D003481"
+ ],
+ "UBERON:0003675": [
+  "MESH:D019228"
+ ],
+ "UBERON:0003677": [
+  "MESH:D014092"
+ ],
+ "UBERON:0003678": [
+  "MESH:D019227"
+ ],
+ "UBERON:0003684": [
+  "MESH:D034841"
+ ],
+ "UBERON:0003688": [
+  "MESH:D009852"
+ ],
+ "UBERON:0003693": [
+  "MESH:D012187"
+ ],
+ "UBERON:0003695": [
+  "MESH:D008662"
+ ],
+ "UBERON:0003697": [
+  "MESH:D034861"
+ ],
+ "UBERON:0003702": [
+  "MESH:D007264"
+ ],
+ "UBERON:0003705": [
+  "MESH:D008467"
+ ],
+ "UBERON:0003718": [
+  "MESH:D009470"
+ ],
+ "UBERON:0003728": [
+  "MESH:D008482"
+ ],
+ "UBERON:0003881": [
+  "MESH:D056547"
+ ],
+ "UBERON:0003882": [
+  "MESH:D056651"
+ ],
+ "UBERON:0003883": [
+  "MESH:D056654"
+ ],
+ "UBERON:0003890": [
+  "MESH:D009095"
+ ],
+ "UBERON:0004340": [
+  "MESH:D000482"
+ ],
+ "UBERON:0004341": [
+  "MESH:D054240"
+ ],
+ "UBERON:0004347": [
+  "MESH:D018878"
+ ],
+ "UBERON:0004676": [
+  "MESH:D066152"
+ ],
+ "UBERON:0004684": [
+  "MESH:D011903"
+ ],
+ "UBERON:0004720": [
+  "MESH:D065814"
+ ],
+ "UBERON:0004725": [
+  "MESH:D066195"
+ ],
+ "UBERON:0004734": [
+  "MESH:D005775"
+ ],
+ "UBERON:0004749": [
+  "MESH:D054239"
+ ],
+ "UBERON:0004750": [
+  "MESH:D001756"
+ ],
+ "UBERON:0004913": [
+  "MESH:D014670"
+ ],
+ "UBERON:0005290": [
+  "MESH:D054024"
+ ],
+ "UBERON:0005335": [
+  "MESH:D049033"
+ ],
+ "UBERON:0005403": [
+  "MESH:D066328"
+ ],
+ "UBERON:0005408": [
+  "MESH:D066280"
+ ],
+ "UBERON:0005438": [
+  "MESH:D054326"
+ ],
+ "UBERON:0005456": [
+  "MESH:D000080869"
+ ],
+ "UBERON:0005631": [
+  "MESH:D005321"
+ ],
+ "UBERON:0005742": [
+  "MESH:D063194"
+ ],
+ "UBERON:0005777": [
+  "MESH:D050533"
+ ],
+ "UBERON:0005893": [
+  "MESH:D007867"
+ ],
+ "UBERON:0006083": [
+  "MESH:D000071039"
+ ],
+ "UBERON:0006108": [
+  "MESH:D066276"
+ ],
+ "UBERON:0006135": [
+  "MESH:D009413"
+ ],
+ "UBERON:0006136": [
+  "MESH:D036421"
+ ],
+ "UBERON:0006444": [
+  "MESH:D000070616"
+ ],
+ "UBERON:0006562": [
+  "MESH:D010614"
+ ],
+ "UBERON:0006588": [
+  "MESH:D000069592"
+ ],
+ "UBERON:0006589": [
+  "MESH:D012404"
+ ],
+ "UBERON:0006614": [
+  "MESH:D000070606"
+ ],
+ "UBERON:0006675": [
+  "MESH:D055422"
+ ],
+ "UBERON:0006812": [
+  "MESH:D000080383"
+ ],
+ "UBERON:0007105": [
+  "MESH:D014816"
+ ],
+ "UBERON:0007106": [
+  "MESH:D002824"
+ ],
+ "UBERON:0007109": [
+  "MESH:D008470"
+ ],
+ "UBERON:0007111": [
+  "MESH:D004312"
+ ],
+ "UBERON:0007115": [
+  "MESH:D014094"
+ ],
+ "UBERON:0007116": [
+  "MESH:D014094"
+ ],
+ "UBERON:0007118": [
+  "MESH:D014472"
+ ],
+ "UBERON:0007132": [
+  "MESH:D060226"
+ ],
+ "UBERON:0007268": [
+  "MESH:D049631"
+ ],
+ "UBERON:0007329": [
+  "MESH:D010183"
+ ],
+ "UBERON:0007378": [
+  "MESH:D004530"
+ ],
+ "UBERON:0007412": [
+  "MESH:D066267"
+ ],
+ "UBERON:0007632": [
+  "MESH:D065835"
+ ],
+ "UBERON:0007634": [
+  "MESH:D065823"
+ ],
+ "UBERON:0007650": [
+  "MESH:D004943"
+ ],
+ "UBERON:0007703": [
+  "MESH:D013133"
+ ],
+ "UBERON:0007774": [
+  "MESH:D019229"
+ ],
+ "UBERON:0007776": [
+  "MESH:D014097"
+ ],
+ "UBERON:0007799": [
+  "MESH:D003818"
+ ],
+ "UBERON:0008266": [
+  "MESH:D010513"
+ ],
+ "UBERON:0008269": [
+  "MESH:D060734"
+ ],
+ "UBERON:0008826": [
+  "MESH:D011663"
+ ],
+ "UBERON:0008930": [
+  "MESH:D013003"
+ ],
+ "UBERON:0008974": [
+  "MESH:D001050"
+ ],
+ "UBERON:0009755": [
+  "MESH:C009301"
+ ],
+ "UBERON:0009757": [
+  "MESH:D018648"
+ ],
+ "UBERON:0009976": [
+  "MESH:D007030"
+ ],
+ "UBERON:0009977": [
+  "MESH:D009306"
+ ],
+ "UBERON:0010264": [
+  "MESH:D043143"
+ ],
+ "UBERON:0010361": [
+  "MESH:D013580"
+ ],
+ "UBERON:0010725": [
+  "MESH:C536002"
+ ],
+ "UBERON:0011119": [
+  "MESH:D052737"
+ ],
+ "UBERON:0011166": [
+  "MESH:D057071"
+ ],
+ "UBERON:0011390": [
+  "MESH:D060525"
+ ],
+ "UBERON:0011924": [
+  "MESH:D001338"
+ ],
+ "UBERON:0011925": [
+  "MESH:D001339"
+ ],
+ "UBERON:0011926": [
+  "MESH:D017779"
+ ],
+ "UBERON:0011929": [
+  "MESH:D017777"
+ ],
+ "UBERON:0012111": [
+  "MESH:D003970"
+ ],
+ "UBERON:0012245": [
+  "MESH:D047011"
+ ],
+ "UBERON:0012449": [
+  "MESH:D008465"
+ ],
+ "UBERON:0012451": [
+  "MESH:D011984"
+ ],
+ "UBERON:0013201": [
+  "MESH:D009833"
+ ],
+ "UBERON:0013422": [
+  "MESH:D000080884"
+ ],
+ "UBERON:0014374": [
+  "MESH:D058732"
+ ],
+ "UBERON:0014398": [
+  "MESH:D012132"
+ ],
+ "UBERON:0014537": [
+  "MESH:D066277"
+ ],
+ "UBERON:0015488": [
+  "MESH:D013497"
+ ],
+ "UBERON:0016403": [
+  "MESH:D035441"
+ ],
+ "UBERON:0016482": [
+  "MESH:D003773"
+ ],
+ "UBERON:0016525": [
+  "MESH:D005625"
+ ],
+ "UBERON:0016884": [
+  "MESH:D012785"
+ ],
+ "UBERON:0018144": [
+  "MESH:D057070"
+ ],
+ "UBERON:0018229": [
+  "MESH:D012084"
+ ],
+ "UBERON:0018388": [
+  "MESH:D058487"
+ ],
+ "UBERON:0034971": [
+  "MESH:D001016"
+ ],
+ "UBERON:0035017": [
+  "MESH:D009619"
+ ],
+ "UBERON:0035018": [
+  "MESH:D013823"
+ ],
+ "UBERON:0035032": [
+  "MESH:D000071596"
+ ],
+ "UBERON:0035618": [
+  "MESH:D000080886"
+ ],
+ "UBERON:0035642": [
+  "MESH:D007823"
+ ],
+ "UBERON:0035652": [
+  "MESH:D010543"
+ ],
+ "UBERON:0035803": [
+  "MESH:D005116"
+ ],
+ "UBERON:0036016": [
+  "MESH:D006722"
+ ],
+ "UBERON:0036145": [
+  "MESH:D000077502"
+ ],
+ "UBERON:1000010": [
+  "MESH:D009506"
+ ],
+ "UBERON:2001553": [
+  "MESH:D008371"
+ ],
+ "UBERON:4000104": [
+  "MESH:C067951"
+ ],
+ "UBERON:4200215": [
+  "MESH:D013537"
+ ]
+}


### PR DESCRIPTION
This PR adds more cross-reference equivalences for the BioID benchmark (between UBERON/CL and MESH), adds the used equivalences to version control, and also generalizes the FamPlex benchmarks to be able to be run without disambiguation models.