### PR TITLE
Lazy loading for disambiguation models

### DIFF
--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.0'
+__version__ = '0.10.0'
 
 import logging
 

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -1,7 +1,6 @@
 import csv
 import json
 import gzip
-import pickle
 import logging
 import itertools
 from pathlib import Path
@@ -582,8 +581,8 @@ def load_adeft_models():
 
 
 def load_gilda_models(cutoff=0.7):
-    with gzip.open(get_gilda_models(), 'rb') as fh:
-        models_raw = pickle.load(fh)
-    models = {k: load_model_info(v['cl']) for k, v in models_raw.items()}
-    models = {k: v for k, v in models.items() if v.stats['f1']['mean'] > cutoff}
+    with gzip.open(get_gilda_models(), 'rt') as fh:
+        models = {k: load_model_info(v)
+                  for k, v in json.loads(fh.read()).items()
+                  if v['stats']['f1']['mean'] > cutoff}
     return models

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -73,7 +73,7 @@ class Grounder(object):
                             'nor a normalized entry name to term dictionary')
 
         self.adeft_disambiguators = find_adeft_models()
-        self.gilda_disambiguators = load_gilda_models()
+        self.gilda_disambiguators = None
 
     def lookup(self, raw_str: str) -> List[Term]:
         """Return matching Terms for a given raw string.
@@ -201,6 +201,10 @@ class Grounder(object):
         return unique_scores
 
     def disambiguate(self, raw_str, scored_matches, context):
+        # This is only called if context was passed in so we do lazy
+        # loading here
+        if self.gilda_disambiguators is None:
+            self.gilda_disambiguators = load_gilda_models()
         # If we don't have a disambiguator for this string, we return with
         # the original scores intact. Otherwise, we attempt to disambiguate.
         if raw_str in self.adeft_disambiguators:

--- a/gilda/resources/__init__.py
+++ b/gilda/resources/__init__.py
@@ -80,7 +80,7 @@ def get_grounding_terms():
 
 
 def get_gilda_models():
-    base_name = 'gilda_models.pkl.gz'
+    base_name = 'gilda_models.json.gz'
     full_path = os.path.join(resource_dir, base_name)
     if not os.path.exists(full_path):
         logger.info('Downloading disambiguation models from S3.')


### PR DESCRIPTION
This PR makes the loading of Gilda and Adeft disambiguation models lazy. If no context is used for grounding, no disambiguation models are loaded at any point. If context is used and there is an appropriate Adeft model for the input string, only that specific model is loaded when needed. Gilda models are loaded in bulk if needed (these are faster to load and have a lower memory footprint to begin with, and are packaged in a way that separating them would require more disruptive changes). This reduces overall baseline memory usage from ~2.3GB to ~1.6GB, startup time also decreases from 14s to 8s. This is relevant for #95.