### PR TITLE
Implement optional SQLite back-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ approrpiate for a narrow use case.
 3. Gilda also offers an optional sqlite back-end which significantly decreases
 memory usage and results in minor drop in the number of strings grounder per
 unit time. The sqlite back-end database can be built as follows with an
-optional `[db_path]` argument, which if used, should use the .db extension.
+optional `[db_path]` argument, which if used, should use the .db extension. If
+not specified, the .db file is generated in Gilda's default resource folder.
 
 ```bash
 python -m gilda.resources.sqlite_adapter [db_path]
@@ -100,7 +101,7 @@ A Grounder instance can then be instantiated as follows:
 ```python
 from gilda.grounder import Grounder
 gr = Grounder(db_path)
-matches = gr.ground(...)
+matches = gr.ground('kras')
 ```
 
 ## Run web service with Docker

--- a/README.md
+++ b/README.md
@@ -76,6 +76,33 @@ import requests
 requests.post('http://grounding.indra.bio/ground', json={'text': 'kras'})
 ```
 
+## Resource usage
+Gilda loads grounding terms into memory when first used. If memory usage
+is an issue, the following options are recommended.
+
+1. Run a single instance of Gilda as a local web service that one or more
+other processes send requests to.
+
+2. Create a custom Grounder instance that only loads a subset of terms
+approrpiate for a narrow use case.
+
+3. Gilda also offers an optional sqlite back-end which significantly decreases
+memory usage and results in minor drop in the number of strings grounder per
+unit time. The sqlite back-end database can be built as follows with an
+optional `[db_path]` argument, which if used, should use the .db extension.
+
+```bash
+python -m gilda.resources.sqlite_adapter [db_path]
+```
+
+A Grounder instance can then be instantiated as follows:
+
+```python
+from gilda.grounder import Grounder
+gr = Grounder(db_path)
+matches = gr.ground(...)
+```
+
 ## Run web service with Docker
 
 After cloning the repository locally, you can build and run a Docker image

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -60,7 +60,11 @@ class Grounder(object):
             terms = get_grounding_terms()
 
         if isinstance(terms, (str, Path)):
-            self.entries = load_terms_file(terms)
+            if terms.endswith('shelve'):
+                import shelve
+                self.entries = shelve.open(terms, 'r')
+            else:
+                self.entries = load_terms_file(terms)
         elif isinstance(terms, list):
             self.entries = defaultdict(list)
             for term in terms:

--- a/gilda/resources/sqlite_adapter.py
+++ b/gilda/resources/sqlite_adapter.py
@@ -1,5 +1,6 @@
 import os
 import json
+import sys
 import logging
 import sqlite3
 from gilda.term import Term
@@ -43,9 +44,9 @@ class SqliteEntries:
         return res.fetchone()[0]
 
 
-def build(grounding_entries):
-    db = os.path.join(resource_dir, 'grounding_terms.db')
-    conn = sqlite3.connect(db)
+def build(grounding_entries, path=None):
+    path = path if path else os.path.join(resource_dir, 'grounding_terms.db')
+    conn = sqlite3.connect(path)
     cur = conn.cursor()
 
     # Create the table
@@ -65,3 +66,12 @@ def build(grounding_entries):
     cur.execute(q)
     conn.commit()
     conn.close()
+
+
+if __name__ == '__main__':
+    from gilda.grounder import Grounder
+
+    path = sys.argv[1] if len(sys.argv) > 1 else None
+    logger.info('Loading default grounder')
+    gr = Grounder()
+    build(gr.entries, path=path)

--- a/gilda/resources/sqlite_adapter.py
+++ b/gilda/resources/sqlite_adapter.py
@@ -46,6 +46,7 @@ class SqliteEntries:
 
 def build(grounding_entries, path=None):
     path = path if path else os.path.join(resource_dir, 'grounding_terms.db')
+    logger.info('Starting SQLite database at %s' % path)
     conn = sqlite3.connect(path)
     cur = conn.cursor()
 

--- a/gilda/resources/sqlite_adapter.py
+++ b/gilda/resources/sqlite_adapter.py
@@ -1,0 +1,67 @@
+import os
+import json
+import logging
+import sqlite3
+from gilda.term import Term
+from . import resource_dir
+
+logger = logging.getLogger('gilda.resources.sqlite_adapter')
+
+
+class SqliteEntries:
+    def __init__(self, db):
+        self.db = db
+        self.conn = None
+
+    def get_connection(self):
+        if self.conn:
+            return self.conn
+        self.conn = sqlite3.connect(self.db)
+        return self.conn
+
+    def get(self, key, default=None):
+        res = self.get_connection().execute(
+            "SELECT terms FROM terms WHERE norm_text=?", (key,))
+        result = res.fetchone()
+        if not result:
+            return default
+        return [Term(**j) for j in json.loads(result[0])]
+
+    def values(self):
+        res = self.get_connection().execute("SELECT terms FROM terms")
+        for result in res.fetchall():
+            yield [Term(**j) for j in json.loads(result[0])]
+
+    def __getitem__(self, item):
+        res = self.get(item)
+        if res is None:
+            raise KeyError(item)
+        return res
+
+    def __len__(self):
+        res = self.get_connection().execute("SELECT COUNT(norm_text) FROM terms")
+        return res.fetchone()[0]
+
+
+def build(grounding_entries):
+    db = os.path.join(resource_dir, 'grounding_terms.db')
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+
+    # Create the table
+    logger.info('Creating the table')
+    q = "CREATE TABLE terms (norm_text text not null primary key, terms text)"
+    cur.execute(q)
+
+    # Insert terms
+    logger.info('Inserting terms')
+    q = "INSERT INTO terms (norm_text, terms) VALUES (?, ?)"
+    for norm_text, terms in grounding_entries.items():
+        cur.execute(q, (norm_text, json.dumps([t.to_json() for t in terms])))
+
+    # Build index
+    logger.info('Making index')
+    q = "CREATE INDEX norm_index ON terms (norm_text);"
+    cur.execute(q)
+    conn.commit()
+    conn.close()

--- a/gilda/resources/sqlite_adapter.py
+++ b/gilda/resources/sqlite_adapter.py
@@ -1,3 +1,6 @@
+"""This module implements an optional SQLite database back-end for Gilda
+as an alternative to loading Terms directly into memory."""
+
 import os
 import json
 import sys
@@ -10,6 +13,17 @@ logger = logging.getLogger('gilda.resources.sqlite_adapter')
 
 
 class SqliteEntries:
+    """A class exposing lists of Terms similar to a string-keyed dict.
+
+    From the perspective of a Grounder instance, instances of this class
+    have an interface similar to a dict ot lists of Terms and can therefore
+    be used seamlessly as a Grounder instance's entries attribute.
+
+    Parameters
+    ----------
+    db : str
+        A path to a SQLite database file.
+    """
     def __init__(self, db):
         self.db = db
         self.conn = None
@@ -45,6 +59,17 @@ class SqliteEntries:
 
 
 def build(grounding_entries, path=None):
+    """Build a SQLite database file from a set of grounding entries.
+
+    Parameters
+    ----------
+    grounding_entries : dict[str, list[Term]]
+        A grounding entries data structure from which the DB is generated.
+    path : Optional[str, Path]
+        Optional path to the output file which should use the .db extension.
+        If not given, the .db file is generated in Gilda's default resources
+        folder.
+    """
     path = path if path else os.path.join(resource_dir, 'grounding_terms.db')
     logger.info('Starting SQLite database at %s' % path)
     conn = sqlite3.connect(path)

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -213,7 +213,6 @@ def test_namespaces():
 
 def test_sqlite():
     from gilda.resources.sqlite_adapter import build
-    gr = Grounder()
     matches = gr.ground('braf')
     entries = {'braf': gr.entries['braf']}
     build(entries, 'test.db')

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -209,3 +209,17 @@ def test_namespaces():
     assert not matches
     matches = gr.ground('KRAS', namespaces=['HGNC'])
     assert matches
+
+
+def test_sqlite():
+    from gilda.resources.sqlite_adapter import build
+    gr = Grounder()
+    matches = gr.ground('braf')
+    entries = {'braf': gr.entries['braf']}
+    build(entries, 'test.db')
+
+    grsql = Grounder('test.db')
+    matchessql = grsql.ground('braf')
+    assert len(matches) == len(matchessql)
+
+    assert grsql.ground('kras') == []


### PR DESCRIPTION
This PR implements an optional SQLite back-end for grounding terms. The SQLite database can be generated from the default tsv.gz grounding entries and then used to instantiate a Grounder instance (instructions are added to the README). This optional mode results in close to instant startup time, and - assuming no context-dependent disambiguation is used - minimal memory usage.

Resolves #95.