### PR TITLE
Use legacy UniProt service to generate terms

### DIFF
--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.10.1'
+__version__ = '0.10.2'
 
 import logging
 

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -339,7 +339,7 @@ def generate_uniprot_terms(download=False, organisms=None):
     path = os.path.join(resource_dir, 'up_synonyms.tsv')
     org_filter_str = ' OR '.join(organisms)
     if not os.path.exists(path) or download:
-        url = (f'https://www.uniprot.org/uniprot/?format=tab&columns=id,'
+        url = (f'https://legacy.uniprot.org/uniprot/?format=tab&columns=id,'
                f'genes(PREFERRED),genes(ALTERNATIVE),protein%20names,organism-id&sort=score&'
                f'query=reviewed:yes&fil=organism:{org_filter_str}')
         logger.info('Downloading UniProt resource file')

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -311,6 +311,8 @@ class Grounder(object):
             The list of entity texts for which a disambiguation model is
             available.
         """
+        if self.gilda_disambiguators is None:
+            self.gilda_disambiguators = load_gilda_models()
         return sorted(list(self.gilda_disambiguators.keys()))
 
     def get_names(self, db, id, status=None, source=None):


### PR DESCRIPTION
This is a short term fix to adapt resource generation to breaking changes in the UniProt web service. Using the new UniProt web service will require more complicated changes to the resource generation code.