### PR TITLE
Add batched grounding endpoint to web service

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ import requests
 requests.post('http://grounding.indra.bio/ground', json={'text': 'kras'})
 ```
 
+The web service also supports multiple inputs in a single request on the
+`ground_multi` endpoint, for instance
+
+```python
+import requests
+requests.post('http://grounding.indra.bio/ground_multi',
+              json=[
+                  {'text': 'braf'},
+                  {'text': 'ER', 'context': 'endoplasmic reticulum (ER) is a cellular component'}
+              ]
+          )
+```
+
 ## Resource usage
 Gilda loads grounding terms into memory when first used. If memory usage
 is an issue, the following options are recommended.


### PR DESCRIPTION
This PR adds a new endpoint called `ground_multi` to the web service. This allows providing a list of inputs in a single request and returns a list of results. This allows overcoming some of the overhead associated with network requests. In terms of the responsiveness benchmark, grounding batches of 100 with the local web service results in a 13x speedup without disambiguation and a 3x speedup with disambiguation (when passing in large batches of text as context with each request).