### PR TITLE
Move `filter_out_duplicates` function

### DIFF
--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -9,7 +9,6 @@ import gzip
 import json
 import logging
 import requests
-import itertools
 import indra
 from indra.databases import hgnc_client, uniprot_client, chebi_client, \
     go_client, mesh_client, doid_client

--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -14,7 +14,7 @@ import indra
 from indra.databases import hgnc_client, uniprot_client, chebi_client, \
     go_client, mesh_client, doid_client
 from indra.statements.resources import amino_acids
-from .term import Term
+from .term import Term, filter_out_duplicates
 from .process import normalize
 from .resources import resource_dir, popular_organisms
 
@@ -657,21 +657,6 @@ def _make_mesh_mappings():
 
 
 mesh_mappings, mesh_mappings_reverse = _make_mesh_mappings()
-
-
-def filter_out_duplicates(terms):
-    logger.info('Filtering %d terms for uniqueness...' % len(terms))
-    term_key = lambda term: (term.db, term.id, term.text)
-    statuses = {'curated': 1, 'name': 2, 'synonym': 3, 'former_name': 4}
-    new_terms = []
-    for _, terms in itertools.groupby(sorted(terms, key=lambda x: term_key(x)),
-                                      key=lambda x: term_key(x)):
-        terms = sorted(terms, key=lambda x: statuses[x.status])
-        new_terms.append(terms[0])
-    # Re-sort the terms
-    new_terms = sorted(new_terms, key=lambda x: (x.text, x.db, x.id))
-    logger.info('Got %d unique terms...' % len(new_terms))
-    return new_terms
 
 
 def terms_from_obo_url(url, prefix, ignore_mappings=False, map_to_ns=None):

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -9,7 +9,7 @@ __all__ = [
     "filter_out_duplicates",
 ]
 
-logger = logging.getLogger("gilda.term")
+logger = logging.getLogger(__name__)
 
 
 class Term(object):

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -4,6 +4,7 @@ __all__ = [
     "Term",
     "get_identifiers_curie",
     "get_identifiers_url",
+    "filter_out_duplicates",
 ]
 
 
@@ -39,6 +40,7 @@ class Term(object):
         from a given source, this attribute provides the original ID value
         before mapping.
     """
+
     def __init__(self, norm_text, text, db, id, entry_name, status, source,
                  organism=None, source_db=None, source_id=None):
         if not text:
@@ -141,3 +143,18 @@ def get_identifiers_url(db, id):
     curie = get_identifiers_curie(db, id)
     if curie is not None:
         return f'https://identifiers.org/{curie}'
+
+
+def filter_out_duplicates(terms):
+    logger.info('Filtering %d terms for uniqueness...' % len(terms))
+    term_key = lambda term: (term.db, term.id, term.text)
+    statuses = {'curated': 1, 'name': 2, 'synonym': 3, 'former_name': 4}
+    new_terms = []
+    for _, terms in itertools.groupby(sorted(terms, key=lambda x: term_key(x)),
+                                      key=lambda x: term_key(x)):
+        terms = sorted(terms, key=lambda x: statuses[x.status])
+        new_terms.append(terms[0])
+    # Re-sort the terms
+    new_terms = sorted(new_terms, key=lambda x: (x.text, x.db, x.id))
+    logger.info('Got %d unique terms...' % len(new_terms))
+    return new_terms

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -1,3 +1,5 @@
+import itertools
+import logging
 from typing import Optional, Set, Tuple
 
 __all__ = [
@@ -6,6 +8,8 @@ __all__ = [
     "get_identifiers_url",
     "filter_out_duplicates",
 ]
+
+logger = logging.getLogger("gilda.term")
 
 
 class Term(object):


### PR DESCRIPTION
This PR moves the `filter_out_duplicates()` frunction from the `gilda.generate_terms` module to `gilda.term` module.

This makes it possible for `biomappings` to import this function without installing `indra`.

Since `filter_out_duplicates` is still imported by `gilda.generated_terms`, it is still available in the namespace and therefore no downstream code needs to be modified.