### PR TITLE
Improve depluralization

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.10"]
+        python-version: ["3.7", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -123,8 +123,8 @@ class Grounder(object):
         roman_arabic = normalize(replace_roman_arabic(raw_str))
         lookups.add(roman_arabic)
         # Finally, we attempt to depluralize the word
-        depluralized = normalize(depluralize(raw_str)[0])
-        lookups.add(depluralized)
+        for singular, rule in depluralize(raw_str):
+            lookups.add(normalize(singular))
 
         logger.debug('Looking up the following strings: %s' %
                      ', '.join(lookups))

--- a/gilda/tests/test_process.py
+++ b/gilda/tests/test_process.py
@@ -3,13 +3,18 @@ from gilda.process import depluralize, replace_greek_spelled_out, \
 
 
 def test_depluralize():
-    assert depluralize('BRAF') == ('BRAF', 'non_plural')
-    assert depluralize('apoptosis') == ('apoptosis', 'non_plural')
-    assert depluralize('mosquitoes') == ('mosquito', 'plural_oes')
-    assert depluralize('antibodies') == ('antibody', 'plural_ies')
-    assert depluralize('branches') == ('branch', 'plural_es')
-    assert depluralize('CDs') == ('CD', 'plural_caps_s')
-    assert depluralize('receptors') == ('receptor', 'plural_s')
+    assert depluralize('BRAF') == [('BRAF', 'non_plural')]
+    assert depluralize('apoptosis') == [('apoptosis', 'non_plural')]
+    assert depluralize('mosquitoes') == [('mosquito', 'plural_oes'),
+                                         ('mosquitoe', 'plural_s')]
+    assert depluralize('antibodies') == [('antibody', 'plural_ies'),
+                                         ('antibodie', 'plural_s')]
+    assert depluralize('branches') == [('branch', 'plural_es'),
+                                       ('branche', 'plural_s')]
+    assert depluralize('CDs') == [('CD', 'plural_caps_s')]
+    assert depluralize('receptors') == [('receptor', 'plural_s')]
+    assert depluralize('kinases') == [('kinas', 'plural_es'),
+                                      ('kinase', 'plural_s')]
 
 
 def test_greek():


### PR DESCRIPTION
This PR slightly improves depluralization by allowing for cases where e.g., both -ses -> -s and -ses -> -se singular forms are possible. This sometimes produces benign non-existent singular forms but is important for correctly depluralizing some words like "kinases" or "inflammatory responses". The benchmarks are unchanged.