### PR TITLE
Strip whitespaces for input

### DIFF
--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -163,6 +163,11 @@ class Grounder(object):
         """
         if not organisms:
             organisms = ['9606']
+        # Stripping whitespaces is done up front directly on the raw string
+        # so that all lookups and comparisons are done with respect to the
+        # stripped string
+        raw_str = raw_str.strip()
+        # Initial lookup of all possible matches
         entries = self.lookup(raw_str)
         logger.debug('Filtering %d entries by organism' % len(entries))
         entries = filter_for_organism(entries, organisms)

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -222,3 +222,8 @@ def test_sqlite():
     assert len(matches) == len(matchessql)
 
     assert grsql.ground('kras') == []
+
+
+def test_strip_whitespace():
+    matches = gr.ground(' inflammatory response ')
+    assert matches


### PR DESCRIPTION
This PR adds whitespace stripping for input strings to the `ground` function.