### PR TITLE
Add function to yield Terms from file

### DIFF
--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -694,9 +694,8 @@ def get_all_terms():
     return terms
 
 
-def main():
-    terms = get_all_terms()
-    from .resources import GROUNDING_TERMS_PATH as fname
+def dump_terms(terms, fname):
+    """Dump a list of terms to a tsv.gz file."""
     logger.info('Dumping into %s' % fname)
     header = ['norm_text', 'text', 'db', 'id', 'entry_name', 'status',
               'source', 'organism', 'source_db', 'source_id']
@@ -704,6 +703,12 @@ def main():
         writer = csv.writer(fh, delimiter='\t')
         writer.writerow(header)
         writer.writerows(t.to_list() for t in terms)
+
+
+def main():
+    from .resources import GROUNDING_TERMS_PATH as fname
+    terms = get_all_terms()
+    dump_terms(terms, fname)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a convenience function to allow yielding individual Terms from a grounding resource file. This is useful if e.g., the default Gilda terms need to be loaded, then deduplicated and combined with terms from other sources to create a custom grounder.