### PR TITLE
Improve filtering of duplicates

### DIFF
--- a/gilda/term.py
+++ b/gilda/term.py
@@ -162,13 +162,17 @@ def _priority_key(term: Term) -> Tuple[int, int]:
     based on status, and if the status is the same, give priority
     to the ones that are from primary resources
     """
-    return statuses[term.status], 0 if term.db.casefold() == term.source.casefold() else 1
+    return (
+        statuses[term.status],
+        0 if term.db.casefold() == term.source.casefold() else 1
+    )
 
 
 def filter_out_duplicates(terms):
     logger.info('Filtering %d terms for uniqueness...' % len(terms))
     new_terms = []
-    for _, terms in itertools.groupby(sorted(terms, key=_term_key), key=_term_key):
+    for _, terms in itertools.groupby(sorted(terms, key=_term_key),
+                                      key=_term_key):
         terms = sorted(terms, key=_priority_key)
         new_terms.append(terms[0])
     # Re-sort the terms

--- a/gilda/tests/test_generate_terms.py
+++ b/gilda/tests/test_generate_terms.py
@@ -75,6 +75,21 @@ def test_filter_priority():
     assert term.status == 'synonym'
 
 
+def test_filter_priority_by_source():
+    term1 = Term('mekk2', 'MEKK2', 'HGNC', '6854', 'MAP3K2',
+                 'synonym', 'hgnc', '9606')
+    term2 = Term('mekk2', 'MEKK2', 'HGNC', '6854', 'MAP3K2',
+                 'synonym', 'up', '9606')
+    terms = filter_out_duplicates([term1, term2])
+    assert len(terms) == 1
+    assert terms[0] == term1
+
+    # now test the other way, to make sure order doesn't matter
+    terms = filter_out_duplicates([term2, term1])
+    assert len(terms) == 1
+    assert terms[0] == term1
+
+
 def test_get_terms_simple():
     row = {'Entry': 'P15056',
            'Gene names  (primary )': 'BRAF',


### PR DESCRIPTION
This improves the function `filter_out_duplicates` by not only considering the "status" of the term, but now additionally if the `source` of the term matches the `db` (meaning it's a first party data). This is useful for me while working on combining multiple resources via xrefs.

It also externalizes the key functions for better readability.