### PR TITLE
Make term prefix prioritization configurable

### DIFF
--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -15,7 +15,7 @@ from .term import Term, get_identifiers_curie, get_identifiers_url
 from .process import normalize, replace_dashes, replace_greek_uni, \
     replace_greek_latin, replace_greek_spelled_out, depluralize, \
     replace_roman_arabic
-from .scorer import Match, generate_match, score, score_namespace
+from .scorer import Match, generate_match, score
 from .resources import get_gilda_models, get_grounding_terms
 
 __all__ = [
@@ -157,7 +157,7 @@ class Grounder(object):
                      ', '.join(lookups))
         return lookups
 
-    def score_namespace(self, term) -> int:
+    def _score_namespace(self, term) -> int:
         """Apply a priority to the term based on its namespace.
 
         .. note::
@@ -238,7 +238,7 @@ class Grounder(object):
             unique_scores = self.disambiguate(raw_str, unique_scores, context)
 
         # Then sort by decreasing score
-        rank_fun = lambda x: (x.score, self.score_namespace(x.term))
+        rank_fun = lambda x: (x.score, self._score_namespace(x.term))
         unique_scores = sorted(unique_scores, key=rank_fun, reverse=True)
 
         # If we have a namespace constraint, we filter to the given

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -62,11 +62,12 @@ class Grounder(object):
         Specifies a term namespace priority order. For example, if multiple
         terms are matched with the same score, will use this list to decide
         which are given by which namespace appears further towards the front
-        of the list. By default, :data:`DEFAULT_ORDER` is used, which, for
-        example, prioritizes famplex entities over HGNC ones.
+        of the list. By default, :data:`DEFAULT_NAMESPACE_PRIORITY` is used,
+        which, for example, prioritizes famplex entities over HGNC ones.
     """
 
     entries: Mapping[str, List[Term]]
+    namespace_priority: List[str]
 
     def __init__(
         self,

--- a/gilda/grounder.py
+++ b/gilda/grounder.py
@@ -34,8 +34,10 @@ logger = logging.getLogger(__name__)
 
 GrounderInput = Union[str, Path, List[Term], Mapping[str, List[Term]]]
 
-#: The default prefix priority order
-DEFAULT_ORDER = ['FPLX', 'HGNC', 'UP', 'CHEBI', 'GO', 'MESH', 'DOID', 'HP', 'EFO']
+#: The default namespace priority order
+DEFAULT_NAMESPACE_PRIORITY = [
+    'FPLX', 'HGNC', 'UP', 'CHEBI', 'GO', 'MESH', 'DOID', 'HP', 'EFO'
+]
 
 
 class Grounder(object):
@@ -56,7 +58,7 @@ class Grounder(object):
         - If :class:`dict`, it is assumed to be a grounding terms dict with
           normalized entity strings as keys and :class:`gilda.term.Term`
           instances as values.
-    order :
+    namespace_priority :
         Specifies a term namespace priority order. For example, if multiple
         terms are matched with the same score, will use this list to decide
         which are given by which namespace appears further towards the front
@@ -70,7 +72,7 @@ class Grounder(object):
         self,
         terms: Optional[GrounderInput] = None,
         *,
-        order: Optional[List[str]] = None,
+        namespace_priority: Optional[List[str]] = None,
     ):
         if terms is None:
             terms = get_grounding_terms()
@@ -99,7 +101,11 @@ class Grounder(object):
         self.adeft_disambiguators = find_adeft_models()
         self.gilda_disambiguators = None
 
-        self.order = DEFAULT_ORDER if order is None else order
+        self.namespace_priority = (
+            DEFAULT_NAMESPACE_PRIORITY
+            if namespace_priority is None else
+            namespace_priority
+        )
 
     def _build_prefix_index(self):
         prefix_index = defaultdict(set)
@@ -166,7 +172,7 @@ class Grounder(object):
             It is just used to rank identically scored entries.
         """
         try:
-            return len(self.order) - self.order.index(term.db)
+            return len(self.namespace_priority) - self.namespace_priority.index(term.db)
         except ValueError:
             return 0
 

--- a/gilda/scorer.py
+++ b/gilda/scorer.py
@@ -246,16 +246,6 @@ def score_status(term):
     return scores[term.status]
 
 
-def score_namespace(term):
-    """Note: this is currently not included as an explicit score term.
-    It is just used to rank identically scored entries."""
-    order = ['FPLX', 'HGNC', 'UP', 'CHEBI', 'GO', 'MESH', 'DOID', 'HP', 'EFO']
-    try:
-        return len(order) - order.index(term.db)
-    except ValueError:
-        return 0
-
-
 def score(match, term):
     string_match_score = score_string_match(match)
     status_score = score_status(term)

--- a/gilda/scorer.py
+++ b/gilda/scorer.py
@@ -7,7 +7,6 @@ __all__ = [
     "generate_match",
     "score_string_match",
     "score_status",
-    "score_namespace",
     "score",
 ]
 

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -79,6 +79,16 @@ def test_disambiguate_gilda():
 def test_rank_namespace():
     matches = gr.ground('interferon-gamma')
     assert matches[0].term.db == 'HGNC'
+    assert matches[1].term.db == 'EFO'
+
+
+def test_rank_namespace_custom_order():
+    """Test when applying a custom order.
+    See also the above test ``test_rank_namespace``."""
+    custom_grounder = Grounder(order=["EFO", "HGNC"])
+    matches = custom_grounder.ground('interferon-gamma')
+    assert matches[0].term.db == 'EFO'
+    assert matches[1].term.db == 'HGNC'
 
 
 def test_aa_synonym():

--- a/gilda/tests/test_grounder.py
+++ b/gilda/tests/test_grounder.py
@@ -85,7 +85,7 @@ def test_rank_namespace():
 def test_rank_namespace_custom_order():
     """Test when applying a custom order.
     See also the above test ``test_rank_namespace``."""
-    custom_grounder = Grounder(order=["EFO", "HGNC"])
+    custom_grounder = Grounder(namespace_priority=["EFO", "HGNC"])
     matches = custom_grounder.ground('interferon-gamma')
     assert matches[0].term.db == 'EFO'
     assert matches[1].term.db == 'HGNC'


### PR DESCRIPTION
This PR does the following:

1. puts the `score_namespace` function used to sort scored matches as a function within the Grounder class itself
2. makes the `order` used by that function an instance variable for the Grounder class
3. makes it possible to pass a custom `order` on instantiation.
4. adds a test to make sure this works properly

Why: this is to support the custom gilda instance in RAPTER, where I am realizing we are getting suboptimal results since the namespaces don't exactly match the default Gilda index (e.g., using lowercased prefixes) and we have additional things that should be prioritized (e.g., NCBITaxon should be prioritized over ITO)
