### PR TITLE
Move dump_terms()

### DIFF
--- a/gilda/generate_terms.py
+++ b/gilda/generate_terms.py
@@ -5,7 +5,6 @@ to be available locally."""
 import re
 import os
 import csv
-import gzip
 import json
 import logging
 import requests
@@ -13,7 +12,7 @@ import indra
 from indra.databases import hgnc_client, uniprot_client, chebi_client, \
     go_client, mesh_client, doid_client
 from indra.statements.resources import amino_acids
-from .term import Term, filter_out_duplicates
+from .term import Term, dump_terms, filter_out_duplicates
 from .process import normalize
 from .resources import resource_dir, popular_organisms
 
@@ -702,17 +701,6 @@ def get_all_terms():
 
     terms = filter_out_duplicates(terms)
     return terms
-
-
-def dump_terms(terms, fname):
-    """Dump a list of terms to a tsv.gz file."""
-    logger.info('Dumping into %s' % fname)
-    header = ['norm_text', 'text', 'db', 'id', 'entry_name', 'status',
-              'source', 'organism', 'source_db', 'source_id']
-    with gzip.open(fname, 'wt', encoding='utf-8') as fh:
-        writer = csv.writer(fh, delimiter='\t')
-        writer.writerow(header)
-        writer.writerows(t.to_list() for t in terms)
 
 
 def main():

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -1,12 +1,15 @@
+import csv
+import gzip
 import itertools
 import logging
-from typing import Optional, Set, Tuple
+from typing import List, Optional, Set, Tuple
 
 __all__ = [
     "Term",
     "get_identifiers_curie",
     "get_identifiers_url",
     "filter_out_duplicates",
+    "dump_terms",
 ]
 
 logger = logging.getLogger(__name__)
@@ -179,3 +182,16 @@ def filter_out_duplicates(terms):
     new_terms = sorted(new_terms, key=lambda x: (x.text, x.db, x.id))
     logger.info('Got %d unique terms...' % len(new_terms))
     return new_terms
+
+
+TERMS_HEADER = ['norm_text', 'text', 'db', 'id', 'entry_name', 'status',
+                'source', 'organism', 'source_db', 'source_id']
+
+
+def dump_terms(terms: List[Term], fname) -> None:
+    """Dump a list of terms to a tsv.gz file."""
+    logger.info('Dumping into %s', fname)
+    with gzip.open(fname, 'wt', encoding='utf-8') as fh:
+        writer = csv.writer(fh, delimiter='\t')
+        writer.writerow(TERMS_HEADER)
+        writer.writerows(t.to_list() for t in terms)

--- a/gilda/term.py
+++ b/gilda/term.py
@@ -2,7 +2,7 @@ import csv
 import gzip
 import itertools
 import logging
-from typing import List, Optional, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple
 
 __all__ = [
     "Term",
@@ -188,7 +188,7 @@ TERMS_HEADER = ['norm_text', 'text', 'db', 'id', 'entry_name', 'status',
                 'source', 'organism', 'source_db', 'source_id']
 
 
-def dump_terms(terms: List[Term], fname) -> None:
+def dump_terms(terms: Iterable[Term], fname) -> None:
     """Dump a list of terms to a tsv.gz file."""
     logger.info('Dumping into %s', fname)
     with gzip.open(fname, 'wt', encoding='utf-8') as fh:


### PR DESCRIPTION
Because this function is in generate_terms.py, it means you need to have indra installed to reuse this function. This PR moves dump_terms() into term.py, which is always available. Since it's still imported into generate_terms.py, this should have no backwards compatibility issues, even if someone is doing from `gilda.generate_terms import dump_terms`