### PR TITLE
Optimize sqlite database size and speed

### DIFF
--- a/gilda/__init__.py
+++ b/gilda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.5.0'
+__version__ = '1.6.0'
 
 import logging
 

--- a/gilda/resources/sqlite_adapter.py
+++ b/gilda/resources/sqlite_adapter.py
@@ -1,11 +1,18 @@
 """This module implements an optional SQLite database back-end for Gilda
-as an alternative to loading Terms directly into memory."""
+as an alternative to loading Terms directly into memory.
+
+It uses a flat relational table with one row per Term and one column per
+Term attribute. The set of columns is derived from
+the ``Term``constructor signature so that the schema follows the Term
+model.
+"""
 
 import os
-import json
 import sys
+import inspect
 import logging
 import sqlite3
+import itertools
 import threading
 from gilda.term import Term
 from . import resource_dir
@@ -28,6 +35,7 @@ class SqliteEntries:
     def __init__(self, db):
         self.db = db
         self._local = threading.local()
+        self._columns = None
 
     @property
     def conn(self):
@@ -41,18 +49,34 @@ class SqliteEntries:
             self._local.conn = sqlite3.connect(self.db)
         return self._local.conn
 
+    @property
+    def columns(self):
+        """The Term columns present in the database, in definition order."""
+        if self._columns is None:
+            res = self.get_connection().execute("PRAGMA table_info(terms)")
+            self._columns = [row[1] for row in res.fetchall()]
+        return self._columns
+
+    def _make_terms(self, rows):
+        """Reconstruct Term objects from raw database rows."""
+        cols = self.columns
+        return [Term(**dict(zip(cols, row))) for row in rows]
+
     def get(self, key, default=None):
-        res = self.get_connection().execute(
-            "SELECT terms FROM terms WHERE norm_text=?", (key,))
-        result = res.fetchone()
-        if not result:
+        cols = self.columns
+        q = "SELECT %s FROM terms WHERE norm_text=?" % ', '.join(cols)
+        rows = self.get_connection().execute(q, (key,)).fetchall()
+        if not rows:
             return default
-        return [Term(**j) for j in json.loads(result[0])]
+        return self._make_terms(rows)
 
     def values(self):
-        res = self.get_connection().execute("SELECT terms FROM terms")
-        for result in res.fetchall():
-            yield [Term(**j) for j in json.loads(result[0])]
+        cols = self.columns
+        nt_idx = cols.index('norm_text')
+        q = "SELECT %s FROM terms ORDER BY norm_text" % ', '.join(cols)
+        res = self.get_connection().execute(q)
+        for _, group in itertools.groupby(res, key=lambda row: row[nt_idx]):
+            yield self._make_terms(list(group))
 
     def __getitem__(self, item):
         res = self.get(item)
@@ -61,11 +85,13 @@ class SqliteEntries:
         return res
 
     def __len__(self):
-        res = self.get_connection().execute("SELECT COUNT(norm_text) FROM terms")
+        res = self.get_connection().execute(
+            "SELECT COUNT(DISTINCT norm_text) FROM terms")
         return res.fetchone()[0]
 
     def __iter__(self):
-        res = self.get_connection().execute("SELECT norm_text FROM terms")
+        res = self.get_connection().execute(
+            "SELECT DISTINCT norm_text FROM terms")
         for norm_text, in res.fetchall():
             yield norm_text
 
@@ -87,23 +113,37 @@ def build(grounding_entries, path=None):
     conn = sqlite3.connect(path)
     cur = conn.cursor()
 
-    # Create the table
-    logger.info('Creating the table')
-    q = "CREATE TABLE terms (norm_text text not null primary key, terms text)"
-    cur.execute(q)
+    # Derive the schema from the Term model rather than hard-coding it
+    cols = _term_columns()
 
-    # Insert terms
+    # Create the table with one column per Term attribute
+    logger.info('Creating the table with columns: %s' % ', '.join(cols))
+    col_defs = ', '.join('%s text' % col for col in cols)
+    cur.execute("CREATE TABLE terms (%s)" % col_defs)
+
+    # Insert one row per Term
     logger.info('Inserting terms')
-    q = "INSERT INTO terms (norm_text, terms) VALUES (?, ?)"
-    for norm_text, terms in grounding_entries.items():
-        cur.execute(q, (norm_text, json.dumps([t.to_json() for t in terms])))
+    placeholders = ', '.join(['?'] * len(cols))
+    q = "INSERT INTO terms (%s) VALUES (%s)" % (', '.join(cols), placeholders)
+
+    def row_generator():
+        for norm_text, terms in grounding_entries.items():
+            for term in terms:
+                yield tuple(getattr(term, col) for col in cols)
+
+    cur.executemany(q, row_generator())
 
     # Build index
     logger.info('Making index')
-    q = "CREATE INDEX norm_index ON terms (norm_text);"
-    cur.execute(q)
+    cur.execute("CREATE INDEX norm_index ON terms (norm_text);")
     conn.commit()
     conn.close()
+
+
+def _term_columns():
+    """Return the Term attribute names derived from its constructor."""
+    params = inspect.signature(Term.__init__).parameters
+    return [name for name in params if name != 'self']
 
 
 if __name__ == '__main__':

--- a/gilda/resources/sqlite_adapter.py
+++ b/gilda/resources/sqlite_adapter.py
@@ -36,16 +36,17 @@ class SqliteEntries:
         self.db = db
         self._local = threading.local()
         self._columns = None
+        self._cols_clause = None
 
     @property
     def conn(self):
         return self.get_connection()
 
     def get_connection(self):
-        # Use hasattr rather than checking for None because each thread has its own
-        # local instance of threading.local, which may or may not have the conn
-        # attribute set
-        if not hasattr(self._local,'conn'):
+        # Use hasattr rather than checking for None because each thread has its
+        # own local instance of threading.local, which may or may not have the
+        # conn attribute set
+        if not hasattr(self._local, 'conn'):
             self._local.conn = sqlite3.connect(self.db)
         return self._local.conn
 
@@ -57,26 +58,26 @@ class SqliteEntries:
             self._columns = [row[1] for row in res.fetchall()]
         return self._columns
 
-    def _make_terms(self, rows):
-        """Reconstruct Term objects from raw database rows."""
-        cols = self.columns
-        return [Term(**dict(zip(cols, row))) for row in rows]
+    @property
+    def _column_clause(self):
+        """The comma-separated column list for SELECTs, computed once."""
+        if self._cols_clause is None:
+            self._cols_clause = ', '.join(self.columns)
+        return self._cols_clause
 
     def get(self, key, default=None):
-        cols = self.columns
-        q = "SELECT %s FROM terms WHERE norm_text=?" % ', '.join(cols)
+        q = "SELECT %s FROM terms WHERE norm_text=?" % self._column_clause
         rows = self.get_connection().execute(q, (key,)).fetchall()
         if not rows:
             return default
-        return self._make_terms(rows)
+        return [Term(*row) for row in rows]
 
     def values(self):
-        cols = self.columns
-        nt_idx = cols.index('norm_text')
-        q = "SELECT %s FROM terms ORDER BY norm_text" % ', '.join(cols)
+        nt_idx = self.columns.index('norm_text')
+        q = "SELECT %s FROM terms ORDER BY norm_text" % self._column_clause
         res = self.get_connection().execute(q)
         for _, group in itertools.groupby(res, key=lambda row: row[nt_idx]):
-            yield self._make_terms(list(group))
+            yield [Term(*row) for row in group]
 
     def __getitem__(self, item):
         res = self.get(item)


### PR DESCRIPTION
This PR makes optimizations to the sqlite-based back-end for Gilda. The previous approach represented each `norm_text` as one row with a list of corresponding JSON-serialized Terms as a single value in another column. This is convenient and maps intuitively to the `Dict[str, List[Term]]` data structure the sqlite adapter stands in for. But all the JSON keys being stored redundantly are taking up a large amount of space.

In this PR, the sqlite schema is changed such that we have one row per Term and each Term attribute has its own column. This significantly cuts down on db size (old: 655MB, new: 331MB) and the net speed of retrieval (i.e., norm_text -> list of deserialized Term objects) is also slightly improved.